### PR TITLE
feat(rhelGraphCard): partial data and empty array domain

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2,7 +2,7 @@
   "curiosity-graph": {
     "heading": "Daily CPU socket usage",
     "dropdownDefault": "Last 30 Days",
-    "activeLabel": "sockets active",
-    "previousLabel": "from previous day"
+    "tooltipLabel": "sockets on",
+    "tooltipPreviousLabel": "from previous day"
   }
 }

--- a/src/common/__tests__/__snapshots__/graphHelpers.test.js.snap
+++ b/src/common/__tests__/__snapshots__/graphHelpers.test.js.snap
@@ -1,86 +1,155 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`GraphHelpers should convert graph data and generate tooltips when usage is populated: usage populated 1`] = `
-Array [
-  Object {
-    "label": "5 sockets on Jun 1",
-    "x": "Jun 1",
-    "y": 5,
-  },
-  Object {
-    "label": "7 sockets on Jun 2
+Object {
+  "chartData": Array [
+    Object {
+      "label": "5 sockets on Jun 1",
+      "x": "Jun 1",
+      "y": 5,
+    },
+    Object {
+      "label": "7 sockets on Jun 2
  +2 from previous day",
-    "x": "Jun 2",
-    "y": 7,
-  },
-  Object {
-    "label": "3 sockets on Jun 3
+      "x": "Jun 2",
+      "y": 7,
+    },
+    Object {
+      "label": "3 sockets on Jun 3
  -4 from previous day",
-    "x": "Jun 3",
-    "y": 3,
-  },
-  Object {
-    "label": "0 sockets on Jun 4
+      "x": "Jun 3",
+      "y": 3,
+    },
+    Object {
+      "label": "0 sockets on Jun 4
  -3 from previous day",
-    "x": "Jun 4",
-    "y": 0,
+      "x": "Jun 4",
+      "y": 0,
+    },
+    Object {
+      "label": "0 sockets on Jun 5",
+      "x": "Jun 5",
+      "y": 0,
+    },
+  ],
+  "chartDomain": Object {
+    "x": Array [
+      0,
+      31,
+    ],
   },
-  Object {
-    "label": "0 sockets on Jun 5",
-    "x": "Jun 5",
-    "y": 0,
+}
+`;
+
+exports[`GraphHelpers should convert graph data and return zeroed usage array if error: error is true 1`] = `
+Object {
+  "chartData": Array [
+    Object {
+      "x": "Jun 1",
+      "y": 0,
+    },
+    Object {
+      "x": "Jun 2",
+      "y": 0,
+    },
+    Object {
+      "x": "Jun 3",
+      "y": 0,
+    },
+    Object {
+      "x": "Jun 4",
+      "y": 0,
+    },
+    Object {
+      "x": "Jun 5",
+      "y": 0,
+    },
+  ],
+  "chartDomain": Object {
+    "x": Array [
+      0,
+      31,
+    ],
+    "y": Array [
+      0,
+      100,
+    ],
   },
-]
+}
 `;
 
 exports[`GraphHelpers should convert graph data and return zeroed usage array if usage is empty: zeroed array 1`] = `
-Array [
-  Object {
-    "x": "Jun 1",
-    "y": "0",
+Object {
+  "chartData": Array [
+    Object {
+      "x": "Jun 1",
+      "y": 0,
+    },
+    Object {
+      "x": "Jun 2",
+      "y": 0,
+    },
+    Object {
+      "x": "Jun 3",
+      "y": 0,
+    },
+    Object {
+      "x": "Jun 4",
+      "y": 0,
+    },
+    Object {
+      "x": "Jun 5",
+      "y": 0,
+    },
+  ],
+  "chartDomain": Object {
+    "x": Array [
+      0,
+      31,
+    ],
+    "y": Array [
+      0,
+      100,
+    ],
   },
-  Object {
-    "x": "Jun 2",
-    "y": "0",
-  },
-  Object {
-    "x": "Jun 3",
-    "y": "0",
-  },
-  Object {
-    "x": "Jun 4",
-    "y": "0",
-  },
-  Object {
-    "x": "Jun 5",
-    "y": "0",
-  },
-]
+}
 `;
 
 exports[`GraphHelpers should convert graph data and returned zeroed array when usage throws error: throws error 1`] = `
-Array [
-  Object {
-    "x": "Jun 1",
-    "y": "0",
+Object {
+  "chartData": Array [
+    Object {
+      "x": "Jun 1",
+      "y": 0,
+    },
+    Object {
+      "x": "Jun 2",
+      "y": 0,
+    },
+    Object {
+      "x": "Jun 3",
+      "y": 0,
+    },
+    Object {
+      "x": "Jun 4",
+      "y": 0,
+    },
+    Object {
+      "x": "Jun 5",
+      "y": 0,
+    },
+  ],
+  "chartDomain": Object {
+    "x": Array [
+      0,
+      31,
+    ],
+    "y": Array [
+      0,
+      100,
+    ],
   },
-  Object {
-    "x": "Jun 2",
-    "y": "0",
-  },
-  Object {
-    "x": "Jun 3",
-    "y": "0",
-  },
-  Object {
-    "x": "Jun 4",
-    "y": "0",
-  },
-  Object {
-    "x": "Jun 5",
-    "y": "0",
-  },
-]
+}
 `;
 
 exports[`GraphHelpers should have specific functions: graphHelpers 1`] = `

--- a/src/common/__tests__/graphHelpers.test.js
+++ b/src/common/__tests__/graphHelpers.test.js
@@ -13,6 +13,16 @@ describe('GraphHelpers', () => {
     expect(graphHelpers).toMatchSnapshot('graphHelpers');
   });
 
+  it('should convert graph data and return zeroed usage array if error', () => {
+    const props = {
+      startDate: new Date('2019-06-01T00:00:00Z'),
+      endDate: new Date('2019-06-05T23:59:59Z'),
+      error: true
+    };
+
+    expect(convertGraphUsageData(props)).toMatchSnapshot('error is true');
+  });
+
   it('should convert graph data and return zeroed usage array if usage is empty', () => {
     const props = {
       startDate: new Date('2019-06-01T00:00:00Z'),

--- a/src/components/rhelGraphCard/__tests__/__snapshots__/rhelGraphCard.test.js.snap
+++ b/src/components/rhelGraphCard/__tests__/__snapshots__/rhelGraphCard.test.js.snap
@@ -247,124 +247,159 @@ exports[`RhelGraphCard Component should render multiple states: error shows zero
 Object {
   "chartBarData": Array [
     Object {
+      "label": "5 sockets on Jun 1",
       "x": "Jun 1",
-      "y": "0",
+      "y": 5,
     },
     Object {
+      "label": "0 sockets on Jun 2
+ -5 from previous day",
       "x": "Jun 2",
-      "y": "0",
+      "y": 0,
     },
     Object {
+      "label": "0 sockets on Jun 3",
       "x": "Jun 3",
-      "y": "0",
+      "y": 0,
     },
     Object {
+      "label": "0 sockets on Jun 4",
       "x": "Jun 4",
-      "y": "0",
+      "y": 0,
     },
     Object {
+      "label": "0 sockets on Jun 5",
       "x": "Jun 5",
-      "y": "0",
+      "y": 0,
     },
     Object {
+      "label": "0 sockets on Jun 6",
       "x": "Jun 6",
-      "y": "0",
+      "y": 0,
     },
     Object {
+      "label": "0 sockets on Jun 7",
       "x": "Jun 7",
-      "y": "0",
+      "y": 0,
     },
     Object {
+      "label": "7 sockets on Jun 8
+ +7 from previous day",
       "x": "Jun 8",
-      "y": "0",
+      "y": 7,
     },
     Object {
+      "label": "0 sockets on Jun 9
+ -7 from previous day",
       "x": "Jun 9",
-      "y": "0",
+      "y": 0,
     },
     Object {
+      "label": "0 sockets on Jun 10",
       "x": "Jun 10",
-      "y": "0",
+      "y": 0,
     },
     Object {
+      "label": "0 sockets on Jun 11",
       "x": "Jun 11",
-      "y": "0",
+      "y": 0,
     },
     Object {
+      "label": "0 sockets on Jun 12",
       "x": "Jun 12",
-      "y": "0",
+      "y": 0,
     },
     Object {
+      "label": "0 sockets on Jun 13",
       "x": "Jun 13",
-      "y": "0",
+      "y": 0,
     },
     Object {
+      "label": "0 sockets on Jun 14",
       "x": "Jun 14",
-      "y": "0",
+      "y": 0,
     },
     Object {
+      "label": "0 sockets on Jun 15",
       "x": "Jun 15",
-      "y": "0",
+      "y": 0,
     },
     Object {
+      "label": "0 sockets on Jun 16",
       "x": "Jun 16",
-      "y": "0",
+      "y": 0,
     },
     Object {
+      "label": "0 sockets on Jun 17",
       "x": "Jun 17",
-      "y": "0",
+      "y": 0,
     },
     Object {
+      "label": "0 sockets on Jun 18",
       "x": "Jun 18",
-      "y": "0",
+      "y": 0,
     },
     Object {
+      "label": "0 sockets on Jun 19",
       "x": "Jun 19",
-      "y": "0",
+      "y": 0,
     },
     Object {
+      "label": "0 sockets on Jun 20",
       "x": "Jun 20",
-      "y": "0",
+      "y": 0,
     },
     Object {
+      "label": "0 sockets on Jun 21",
       "x": "Jun 21",
-      "y": "0",
+      "y": 0,
     },
     Object {
+      "label": "0 sockets on Jun 22",
       "x": "Jun 22",
-      "y": "0",
+      "y": 0,
     },
     Object {
+      "label": "0 sockets on Jun 23",
       "x": "Jun 23",
-      "y": "0",
+      "y": 0,
     },
     Object {
+      "label": "0 sockets on Jun 24",
       "x": "Jun 24",
-      "y": "0",
+      "y": 0,
     },
     Object {
+      "label": "3 sockets on Jun 25
+ +3 from previous day",
       "x": "Jun 25",
-      "y": "0",
+      "y": 3,
     },
     Object {
+      "label": "0 sockets on Jun 26
+ -3 from previous day",
       "x": "Jun 26",
-      "y": "0",
+      "y": 0,
     },
     Object {
+      "label": "0 sockets on Jun 27",
       "x": "Jun 27",
-      "y": "0",
+      "y": 0,
     },
     Object {
+      "label": "0 sockets on Jun 28",
       "x": "Jun 28",
-      "y": "0",
+      "y": 0,
     },
     Object {
+      "label": "0 sockets on Jun 29",
       "x": "Jun 29",
-      "y": "0",
+      "y": 0,
     },
     Object {
+      "label": "0 sockets on Jun 30",
       "x": "Jun 30",
-      "y": "0",
+      "y": 0,
     },
   ],
 }
@@ -441,21 +476,159 @@ exports[`RhelGraphCard Component should render multiple states: fulfilled 1`] = 
             data={
               Array [
                 Object {
-                  "label": "5 sockets active Jun 1",
+                  "label": "5 sockets on Jun 1",
                   "x": "Jun 1",
                   "y": 5,
                 },
                 Object {
-                  "label": "7 sockets active Jun 8
- +2 from previous day",
+                  "label": "0 sockets on Jun 2
+ -5 from previous day",
+                  "x": "Jun 2",
+                  "y": 0,
+                },
+                Object {
+                  "label": "0 sockets on Jun 3",
+                  "x": "Jun 3",
+                  "y": 0,
+                },
+                Object {
+                  "label": "0 sockets on Jun 4",
+                  "x": "Jun 4",
+                  "y": 0,
+                },
+                Object {
+                  "label": "0 sockets on Jun 5",
+                  "x": "Jun 5",
+                  "y": 0,
+                },
+                Object {
+                  "label": "0 sockets on Jun 6",
+                  "x": "Jun 6",
+                  "y": 0,
+                },
+                Object {
+                  "label": "0 sockets on Jun 7",
+                  "x": "Jun 7",
+                  "y": 0,
+                },
+                Object {
+                  "label": "7 sockets on Jun 8
+ +7 from previous day",
                   "x": "Jun 8",
                   "y": 7,
                 },
                 Object {
-                  "label": "3 sockets active Jun 25
- -4 from previous day",
+                  "label": "0 sockets on Jun 9
+ -7 from previous day",
+                  "x": "Jun 9",
+                  "y": 0,
+                },
+                Object {
+                  "label": "0 sockets on Jun 10",
+                  "x": "Jun 10",
+                  "y": 0,
+                },
+                Object {
+                  "label": "0 sockets on Jun 11",
+                  "x": "Jun 11",
+                  "y": 0,
+                },
+                Object {
+                  "label": "0 sockets on Jun 12",
+                  "x": "Jun 12",
+                  "y": 0,
+                },
+                Object {
+                  "label": "0 sockets on Jun 13",
+                  "x": "Jun 13",
+                  "y": 0,
+                },
+                Object {
+                  "label": "0 sockets on Jun 14",
+                  "x": "Jun 14",
+                  "y": 0,
+                },
+                Object {
+                  "label": "0 sockets on Jun 15",
+                  "x": "Jun 15",
+                  "y": 0,
+                },
+                Object {
+                  "label": "0 sockets on Jun 16",
+                  "x": "Jun 16",
+                  "y": 0,
+                },
+                Object {
+                  "label": "0 sockets on Jun 17",
+                  "x": "Jun 17",
+                  "y": 0,
+                },
+                Object {
+                  "label": "0 sockets on Jun 18",
+                  "x": "Jun 18",
+                  "y": 0,
+                },
+                Object {
+                  "label": "0 sockets on Jun 19",
+                  "x": "Jun 19",
+                  "y": 0,
+                },
+                Object {
+                  "label": "0 sockets on Jun 20",
+                  "x": "Jun 20",
+                  "y": 0,
+                },
+                Object {
+                  "label": "0 sockets on Jun 21",
+                  "x": "Jun 21",
+                  "y": 0,
+                },
+                Object {
+                  "label": "0 sockets on Jun 22",
+                  "x": "Jun 22",
+                  "y": 0,
+                },
+                Object {
+                  "label": "0 sockets on Jun 23",
+                  "x": "Jun 23",
+                  "y": 0,
+                },
+                Object {
+                  "label": "0 sockets on Jun 24",
+                  "x": "Jun 24",
+                  "y": 0,
+                },
+                Object {
+                  "label": "3 sockets on Jun 25
+ +3 from previous day",
                   "x": "Jun 25",
                   "y": 3,
+                },
+                Object {
+                  "label": "0 sockets on Jun 26
+ -3 from previous day",
+                  "x": "Jun 26",
+                  "y": 0,
+                },
+                Object {
+                  "label": "0 sockets on Jun 27",
+                  "x": "Jun 27",
+                  "y": 0,
+                },
+                Object {
+                  "label": "0 sockets on Jun 28",
+                  "x": "Jun 28",
+                  "y": 0,
+                },
+                Object {
+                  "label": "0 sockets on Jun 29",
+                  "x": "Jun 29",
+                  "y": 0,
+                },
+                Object {
+                  "label": "0 sockets on Jun 30",
+                  "x": "Jun 30",
+                  "y": 0,
                 },
               ]
             }

--- a/src/components/rhelGraphCard/rhelGraphCard.js
+++ b/src/components/rhelGraphCard/rhelGraphCard.js
@@ -41,42 +41,21 @@ class RhelGraphCard extends React.Component {
     }));
   };
 
-  render() {
-    const { error, fulfilled, graphData, pending, t, breakpoints, currentBreakpoint, startDate, endDate } = this.props;
-    const { dropdownIsOpen } = this.state;
+  renderChart() {
+    const { graphData, t, breakpoints, currentBreakpoint, startDate, endDate } = this.props;
 
     const graphHeight = graphHelpers.getGraphHeight(breakpoints, currentBreakpoint);
     const tooltipDimensions = graphHelpers.getTooltipDimensions(breakpoints, currentBreakpoint);
 
-    // todo: evaluate the granularity here: "daily" "weekly" etc. this may need to move towards the helpers
-    const chartDomain = { x: [0, 31] };
-
-    let chartData;
-
-    if (error) {
-      // todo: evaluate show error toast
-      // todo: this only fires on error, not in the event an array with a valid zero length.
-      // todo: we may need to combine error and fulfilled checks and handle the x and y axis defaults in the helpers
-      // note: specify a y range if we are showing the zeroed view
-      chartDomain.y = [0, 100];
-      chartData = graphHelpers.zeroedUsageData(startDate, endDate);
-    }
-
-    if (fulfilled) {
-      chartData = graphHelpers.convertGraphUsageData({
-        data: graphData.usage,
-        startDate,
-        endDate,
-        label: t('curiosity-graph.activeLabel', 'sockets active'),
-        previousLabel: t('curiosity-graph.previousLabel', 'from previous day')
-      });
-    }
-
-    const dropdownToggle = (
-      <DropdownToggle isDisabled onToggle={this.onToggle}>
-        {t('curiosity-graph.dropdownDefault', 'Last 30 Days')}
-      </DropdownToggle>
-    );
+    // todo: evaluate show error toast
+    // todo: evaluate the granularity here: "daily" "weekly" etc. and pass startDate/endDate
+    const { chartData, chartDomain } = graphHelpers.convertGraphUsageData({
+      data: graphData.usage,
+      startDate,
+      endDate,
+      label: t('curiosity-graph.tooltipLabel', 'sockets on'),
+      previousLabel: t('curiosity-graph.tooltipPreviousLabel', 'from previous day')
+    });
 
     const tooltipTheme = {
       ...ChartBaseTheme,
@@ -99,6 +78,29 @@ class RhelGraphCard extends React.Component {
         theme={tooltipTheme}
         labelComponent={<ChartLabel dy={-1} className="curiosity-usage-graph-tooltip-text" />}
       />
+    );
+
+    return (
+      <CardBody>
+        <div className="stack-chart-container">
+          <Chart height={graphHeight} domainPadding={{ x: [10, 2], y: [1, 1] }} domain={chartDomain}>
+            <ChartStack>
+              <ChartBar data={chartData} labelComponent={chartTooltip} />
+            </ChartStack>
+          </Chart>
+        </div>
+      </CardBody>
+    );
+  }
+
+  render() {
+    const { error, fulfilled, pending, t } = this.props;
+    const { dropdownIsOpen } = this.state;
+
+    const dropdownToggle = (
+      <DropdownToggle isDisabled onToggle={this.onToggle}>
+        {t('curiosity-graph.dropdownDefault', 'Last 30 Days')}
+      </DropdownToggle>
     );
 
     return (
@@ -125,17 +127,7 @@ class RhelGraphCard extends React.Component {
             </div>
           </CardBody>
         )}
-        {(fulfilled || error) && (
-          <CardBody>
-            <div className="stack-chart-container">
-              <Chart height={graphHeight} domainPadding={{ x: [10, 2], y: [1, 1] }} domain={chartDomain}>
-                <ChartStack>
-                  <ChartBar data={chartData} labelComponent={chartTooltip} />
-                </ChartStack>
-              </Chart>
-            </div>
-          </CardBody>
-        )}
+        {(fulfilled || error) && this.renderChart()}
       </Card>
     );
   }

--- a/tests/__snapshots__/i18n.test.js.snap
+++ b/tests/__snapshots__/i18n.test.js.snap
@@ -5,24 +5,24 @@ exports[`i18n locale should generate a predictable pot output snapshot: pot outp
 msgstr \\"\\"
 \\"Content-Type: text/plain; charset=UTF-8\\\\n\\"
 
-#: src/components/rhelGraphCard/rhelGraphCard.js:107
+#: src/components/rhelGraphCard/rhelGraphCard.js:109
 msgctxt \\"Daily CPU socket usage\\"
 msgid \\"curiosity-graph.heading\\"
 msgstr \\"\\"
 
-#: src/components/rhelGraphCard/rhelGraphCard.js:71
+#: src/components/rhelGraphCard/rhelGraphCard.js:57
 msgctxt \\"from previous day\\"
-msgid \\"curiosity-graph.previousLabel\\"
+msgid \\"curiosity-graph.tooltipPreviousLabel\\"
 msgstr \\"\\"
 
-#: src/components/rhelGraphCard/rhelGraphCard.js:77
+#: src/components/rhelGraphCard/rhelGraphCard.js:102
 msgctxt \\"Last 30 Days\\"
 msgid \\"curiosity-graph.dropdownDefault\\"
 msgstr \\"\\"
 
-#: src/components/rhelGraphCard/rhelGraphCard.js:70
-msgctxt \\"sockets active\\"
-msgid \\"curiosity-graph.activeLabel\\"
+#: src/components/rhelGraphCard/rhelGraphCard.js:56
+msgctxt \\"sockets on\\"
+msgid \\"curiosity-graph.tooltipLabel\\"
 msgstr \\"\\"
 "
 `;


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->

* provide a custom y domain if the data array is missing
* fill missing or partial data arrays with zero values
* refactor convertGraphUsageData to return chartDomain
* update tests accordingly

Related Victory issues for y-domain problem:
https://github.com/FormidableLabs/victory/issues/883
https://github.com/FormidableLabs/victory-docs/pull/559/files

Open question and potential edge case - what should the y-domain max be set to if all y values are the same? This poses the problem noted in Victory above. We currently set the y max value to 100 if we are in the error state and passing a zeroed array, however the same exact display issue can happen if all y values are the same (ex. : { x: 'Jun 1' y: 0 } , { x: 'Jun 2' y: 0 } , { x: 'Jun 3' y: 0 }, ... } )

<!-- ### Notes -->
<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->

Zeroed array (and no data) will now show the same empty chart w/ y-max set to 100...

<img width="1549" alt="Screen Shot 2019-07-18 at 11 43 03 AM" src="https://user-images.githubusercontent.com/4237045/61674692-eb21bb00-acc2-11e9-82cd-a9b3680339ed.png">


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
#19 