### PR TITLE
fix(chart): set y domain appropriately

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -43,11 +43,12 @@
         "ignoreUrls": true
       }
     ],
+    "no-case-declarations": 0,
     "no-console": 0,
     "no-debugger": 1,
     "no-lonely-if": 1,
     "no-plusplus": 0,
-    "no-case-declarations": 0,
+    "no-restricted-properties": [0, {"object": "Math", "property": "pow"}],
     "prettier/prettier": [
       "error",
       {

--- a/src/common/__tests__/__snapshots__/graphHelpers.test.js.snap
+++ b/src/common/__tests__/__snapshots__/graphHelpers.test.js.snap
@@ -1,5 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`GraphHelpers getChartDomain should return expected y domain for given inputs 1`] = `
+Object {
+  "empty array": Array [
+    0,
+    10,
+  ],
+  "maxY = 0": Array [
+    0,
+    10,
+  ],
+  "maxY = 100": Array [
+    0,
+    1000,
+  ],
+  "maxY = 1000": Array [
+    0,
+    10000,
+  ],
+  "maxY = 49": Array [
+    0,
+    50,
+  ],
+  "maxY = 50": Array [
+    0,
+    100,
+  ],
+  "maxY = 9": Array [
+    0,
+    10,
+  ],
+}
+`;
+
 exports[`GraphHelpers should convert graph data and generate tooltips when usage is populated: usage populated 1`] = `
 Object {
   "chartData": Array [
@@ -37,6 +70,10 @@ Object {
       0,
       31,
     ],
+    "y": Array [
+      0,
+      10,
+    ],
   },
 }
 `;
@@ -72,7 +109,7 @@ Object {
     ],
     "y": Array [
       0,
-      100,
+      10,
     ],
   },
 }
@@ -109,7 +146,7 @@ Object {
     ],
     "y": Array [
       0,
-      100,
+      10,
     ],
   },
 }
@@ -146,7 +183,7 @@ Object {
     ],
     "y": Array [
       0,
-      100,
+      10,
     ],
   },
 }
@@ -156,6 +193,7 @@ exports[`GraphHelpers should have specific functions: graphHelpers 1`] = `
 Object {
   "chartDateFormat": "MMM D",
   "convertGraphUsageData": [Function],
+  "getChartDomain": [Function],
   "getGraphHeight": [Function],
   "getTooltipDimensions": [Function],
   "getTooltipFontSize": [Function],

--- a/src/common/__tests__/graphHelpers.test.js
+++ b/src/common/__tests__/graphHelpers.test.js
@@ -1,6 +1,7 @@
 import {
   graphHelpers,
   convertGraphUsageData,
+  getChartDomain,
   getGraphHeight,
   getTooltipDimensions,
   getTooltipFontSize
@@ -92,6 +93,18 @@ describe('GraphHelpers', () => {
         ...props
       })
     ).toMatchSnapshot('throws error');
+  });
+
+  it('getChartDomain should return expected y domain for given inputs', () => {
+    expect({
+      'empty array': getChartDomain({ empty: true }).y,
+      'maxY = 0': getChartDomain({ maxY: 0 }).y,
+      'maxY = 9': getChartDomain({ maxY: 9 }).y,
+      'maxY = 49': getChartDomain({ maxY: 49 }).y,
+      'maxY = 50': getChartDomain({ maxY: 50 }).y,
+      'maxY = 100': getChartDomain({ maxY: 100 }).y,
+      'maxY = 1000': getChartDomain({ maxY: 1000 }).y
+    }).toMatchSnapshot();
   });
 
   it('should match graph heights at all breakpoints', () => {

--- a/src/components/rhelGraphCard/__tests__/__snapshots__/rhelGraphCard.test.js.snap
+++ b/src/components/rhelGraphCard/__tests__/__snapshots__/rhelGraphCard.test.js.snap
@@ -301,6 +301,10 @@ exports[`RhelGraphCard Component should render multiple states: fulfilled 1`] = 
               0,
               31,
             ],
+            "y": Array [
+              0,
+              10,
+            ],
           }
         }
         domainPadding={


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->

Set the y-domain according the max y value in the input data...

Related Victory issues:
FormidableLabs/victory#883
https://github.com/FormidableLabs/victory-docs/pull/559/files

<!-- ### Notes -->
<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
Targets a current edge case where all y values are the same causing the issue noted in Victory charts.

Example data which found this edge case:
```
{
   "data":[
      {
         "date":"2019-07-25T18:00:09.56Z",
         "instance_count":0,
         "cores":0,
         "sockets":0
      },
      {
         "date":"2019-07-26T00:00:00.696Z",
         "instance_count":0,
         "cores":0,
         "sockets":0
      }
   ],
   "links":{
      "first":"/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=daily&beginning=2019-06-26T00:00:00.000Z&ending=2019-07-26T23:59:59.999Z&offset=0",
      "last":"/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=daily&beginning=2019-06-26T00:00:00.000Z&ending=2019-07-26T23:59:59.999Z&offset=0"
   },
   "meta":{
      "count":2,
      "product":"RHEL",
      "granularity":"daily"
   }
}
```

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
1. `$ yarn test:dev`

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Closes #60 