### PR TITLE
feat(build): issues/52 default date time override

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,14 @@ can be found in [.codecov.yml](./.codecov.yml).
 
 ### Debugging and Testing
 
+#### Debugging the Graph Display
+You can apply a date override during local development by adding a `.env.local` (dotenv) file with the following line, in the repository root directory
+   ```
+   REACT_APP_DEBUG_DEFAULT_DATETIME=20190630
+   ```
+
+*Any changes you make to the `.env.local` file should be ignored with `.gitignore`.*
+
 #### Debugging Redux
 This project makes use of React & Redux. To enable Redux console logging, within the repository root directory, add a `.env.local` (dotenv) file with the follow line
   ```

--- a/src/common/dateHelpers.js
+++ b/src/common/dateHelpers.js
@@ -1,27 +1,21 @@
 import moment from 'moment/moment';
 import { helpers } from './helpers';
 
-const defaultDateTime = (helpers.TEST_MODE && {
+const defaultDateTime = ((
+  date = (helpers.TEST_MODE && '20190720') ||
+    (helpers.DEV_MODE && process.env.REACT_APP_DEBUG_DEFAULT_DATETIME) ||
+    new Date()
+) => ({
   start: moment
-    .utc('20190720')
+    .utc(date)
     .startOf('day')
     .subtract(30, 'days')
     .toDate(),
   end: moment
-    .utc('20190720')
+    .utc(date)
     .endOf('day')
     .toDate()
-}) || {
-  start: moment
-    .utc()
-    .startOf('day')
-    .subtract(30, 'days')
-    .toDate(),
-  end: moment
-    .utc()
-    .endOf('day')
-    .toDate()
-};
+}))();
 
 const dateHelpers = {
   defaultDateTime


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- feat(build): issues/52 default date time override
  * build, dotenv default date time override

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- this is a convenience debugging update related to design and demo

## How to test
<!-- Are there directions to test/review? -->
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
### Create an override on local run
1. create a `.env.local` file in the root of the project, place this line in there, or whatever date you want
   ```
    REACT_APP_DEBUG_DEFAULT_DATETIME=20190625
   ```
2. run `$ yarn start`, the date should override the default starting date display for the graph
3. stop everything, now run `$ yarn test`, no unit test snapshots should require updating, unit tests are hardcoded to use the date `20190720`.
4. after running the tests check the proxy run `$ yarn start:proxy`. the default date should be the current date and the graph should display accordingly

<!-- ## Example -->
<!-- Append a demo/screenshot/animated gif of the solution -->


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Updates #52 
