### PR TITLE
fix(graphHelpers,chartArea): quarters granularity display

### DIFF
--- a/src/common/__tests__/__snapshots__/graphHelpers.test.js.snap
+++ b/src/common/__tests__/__snapshots__/graphHelpers.test.js.snap
@@ -165,23 +165,30 @@ Object {
       "y": 5,
     },
     Object {
-      "tooltip": "7 t('curiosity-graph.tooltipLabel') Aug
- +2 t('curiosity-graph.tooltipPreviousLabelQuarterly')",
+      "tooltip": "0 t('curiosity-graph.tooltipLabel') Jul
+ -5 t('curiosity-graph.tooltipPreviousLabelQuarterly')",
       "x": 1,
-      "xAxisLabel": "Aug",
-      "y": 7,
+      "xAxisLabel": "Jul",
+      "y": 0,
     },
     Object {
-      "tooltip": "7 t('curiosity-graph.tooltipLabel') Dec",
+      "tooltip": "0 t('curiosity-graph.tooltipLabel') Oct",
       "x": 2,
-      "xAxisLabel": "Dec",
-      "y": 7,
+      "xAxisLabel": "Oct",
+      "y": 0,
     },
     Object {
-      "tooltip": "7 t('curiosity-graph.tooltipLabel') Apr 2019",
+      "tooltip": "0 t('curiosity-graph.tooltipLabel') Jan 2019",
       "x": 3,
-      "xAxisLabel": "Apr
+      "xAxisLabel": "Jan
 2019",
+      "y": 0,
+    },
+    Object {
+      "tooltip": "7 t('curiosity-graph.tooltipLabel') Apr
+ +7 t('curiosity-graph.tooltipPreviousLabelQuarterly')",
+      "x": 4,
+      "xAxisLabel": "Apr",
       "y": 7,
     },
   ],
@@ -255,7 +262,7 @@ exports[`GraphHelpers should return a date type based on granularity: granularit
 Object {
   "daily": "days",
   "monthly": "months",
-  "quarterly": "months",
+  "quarterly": "quarters",
   "weekly": "weeks",
 }
 `;

--- a/src/common/graphHelpers.js
+++ b/src/common/graphHelpers.js
@@ -13,6 +13,9 @@ const chartDateDayFormat = 'MMM D YYYY';
 const chartDateMonthFormatShort = 'MMM';
 const chartDateMonthFormat = 'MMM YYYY';
 
+const chartDateQuarterFormatShort = 'MMM';
+const chartDateQuarterFormat = 'MMM YYYY';
+
 /**
  * Returns x axis ticks/intervals array for the xAxisTickInterval
  *
@@ -70,14 +73,15 @@ const getGraphLabels = granularity => {
  */
 const getGranularityDateType = granularity => {
   switch (granularity) {
-    case GRANULARITY_TYPES.DAILY:
-      return 'days';
     case GRANULARITY_TYPES.WEEKLY:
       return 'weeks';
     case GRANULARITY_TYPES.MONTHLY:
-    case GRANULARITY_TYPES.QUARTERLY:
-    default:
       return 'months';
+    case GRANULARITY_TYPES.QUARTERLY:
+      return 'quarters';
+    case GRANULARITY_TYPES.DAILY:
+    default:
+      return 'days';
   }
 };
 
@@ -122,11 +126,10 @@ const fillFormatChartData = ({ data, endDate, granularity, startDate }) => {
   let previousYear = null;
 
   for (let i = 0; i <= endDateStartDateDiff; i++) {
-    if (GRANULARITY_TYPES.QUARTERLY === granularity && i % 4 !== 0) {
-      continue;
-    }
-
-    const momentDate = moment.utc(startDate).add(i, granularityType);
+    const momentDate = moment
+      .utc(startDate)
+      .add(i, granularityType)
+      .startOf(granularityType);
     const stringDate = momentDate.toISOString();
     const year = parseInt(momentDate.year(), 10);
 
@@ -134,7 +137,11 @@ const fillFormatChartData = ({ data, endDate, granularity, startDate }) => {
     const isNewYear = i !== 0 && checkTick && year !== previousYear;
     let formattedDate;
 
-    if (granularityType === 'months') {
+    if (granularityType === 'quarters') {
+      formattedDate = isNewYear
+        ? momentDate.format(chartDateQuarterFormat)
+        : momentDate.format(chartDateQuarterFormatShort);
+    } else if (granularityType === 'months') {
       formattedDate = isNewYear
         ? momentDate.format(chartDateMonthFormat)
         : momentDate.format(chartDateMonthFormatShort);
@@ -155,7 +162,10 @@ const fillFormatChartData = ({ data, endDate, granularity, startDate }) => {
       x: chartData.length,
       y: yAxis,
       tooltip: getLabel(labelData),
-      xAxisLabel: granularityType === 'months' ? formattedDate.replace(/\s/, '\n') : formattedDate
+      xAxisLabel:
+        granularityType === 'months' || granularityType === 'quarters'
+          ? formattedDate.replace(/\s/, '\n')
+          : formattedDate
     });
 
     previousData = yAxis;

--- a/src/components/chartArea/__tests__/__snapshots__/chartArea.test.js.snap
+++ b/src/components/chartArea/__tests__/__snapshots__/chartArea.test.js.snap
@@ -342,9 +342,12 @@ exports[`ChartArea Component should render a basic component: basic 1`] = `
     }
     width={0}
   >
-    <ChartAxis />
+    <ChartAxis
+      fixLabelOverlap={false}
+    />
     <ChartAxis
       dependentAxis={true}
+      fixLabelOverlap={false}
       showGrid={true}
     />
     <ChartStack />

--- a/src/components/chartArea/chartArea.js
+++ b/src/components/chartArea/chartArea.js
@@ -124,18 +124,20 @@ class ChartArea extends React.Component {
 
   render() {
     const { chartWidth } = this.state;
-    const { dataSetOne } = this.props;
+    const { dataSetOne, xAxisFixLabelOverlap, yAxisFixLabelOverlap } = this.props;
 
     const { xAxisTickValues, xAxisTickFormat, yAxisTickValues, yAxisTickFormat } = this.getChartTicks();
-    const updatedXAxisProps = {};
+    const updatedXAxisProps = {
+      fixLabelOverlap: xAxisFixLabelOverlap
+    };
     const updatedYAxisProps = {
       dependentAxis: true,
-      showGrid: true
+      showGrid: true,
+      fixLabelOverlap: yAxisFixLabelOverlap
     };
 
     if (xAxisTickValues) {
       updatedXAxisProps.tickValues = xAxisTickValues;
-      updatedXAxisProps.fixLabelOverlap = false;
     }
 
     if (xAxisTickFormat) {
@@ -144,7 +146,6 @@ class ChartArea extends React.Component {
 
     if (yAxisTickValues) {
       updatedYAxisProps.tickValues = yAxisTickValues;
-      updatedYAxisProps.fixLabelOverlap = false;
     }
 
     if (yAxisTickFormat) {
@@ -193,9 +194,11 @@ ChartArea.propTypes = {
     right: PropTypes.number,
     top: PropTypes.number
   }),
+  xAxisFixLabelOverlap: PropTypes.bool,
   xAxisLabelIncrement: PropTypes.number,
   xAxisLabelUseDataSet: PropTypes.oneOf(['one']),
   xAxisTickFormat: PropTypes.func,
+  yAxisFixLabelOverlap: PropTypes.bool,
   yAxisLabelIncrement: PropTypes.number,
   yAxisLabelUseDataSet: PropTypes.oneOf(['one']),
   yAxisTickFormat: PropTypes.func
@@ -207,13 +210,15 @@ ChartArea.defaultProps = {
   height: 275,
   padding: {
     bottom: 50,
-    left: 85,
-    right: 85,
+    left: 50,
+    right: 50,
     top: 50
   },
+  xAxisFixLabelOverlap: false,
   xAxisLabelIncrement: 1,
   xAxisLabelUseDataSet: 'one',
   xAxisTickFormat: null,
+  yAxisFixLabelOverlap: false,
   yAxisLabelIncrement: 1,
   yAxisLabelUseDataSet: 'one',
   yAxisTickFormat: null

--- a/src/components/rhelGraphCard/__tests__/__snapshots__/rhelGraphCard.test.js.snap
+++ b/src/components/rhelGraphCard/__tests__/__snapshots__/rhelGraphCard.test.js.snap
@@ -655,14 +655,16 @@ exports[`RhelGraphCard Component should render multiple states: fulfilled 1`] = 
         padding={
           Object {
             "bottom": 50,
-            "left": 85,
-            "right": 85,
+            "left": 50,
+            "right": 50,
             "top": 50,
           }
         }
+        xAxisFixLabelOverlap={true}
         xAxisLabelIncrement={5}
         xAxisLabelUseDataSet="one"
         xAxisTickFormat={null}
+        yAxisFixLabelOverlap={false}
         yAxisLabelIncrement={1}
         yAxisLabelUseDataSet="one"
         yAxisTickFormat={[Function]}

--- a/src/components/rhelGraphCard/rhelGraphCard.js
+++ b/src/components/rhelGraphCard/rhelGraphCard.js
@@ -60,6 +60,7 @@ class RhelGraphCard extends React.Component {
 
     return (
       <ChartArea
+        xAxisFixLabelOverlap
         xAxisLabelIncrement={chartXAxisLabelIncrement}
         yAxisTickFormat={({ tick }) => numeral(tick).format('0a')}
         dataSetOne={chartData}

--- a/src/styles/_app.scss
+++ b/src/styles/_app.scss
@@ -1,0 +1,3 @@
+.curiosity {
+  min-width: 320px;
+}

--- a/src/styles/_common.scss
+++ b/src/styles/_common.scss
@@ -1,7 +1,9 @@
-.fadein {
-  opacity:0;
-  animation:fadein .25s ease-in forwards;
-  animation-delay:.25s;
-}
+.curiosity {
+  .fadein {
+    opacity:0;
+    animation:fadein .25s ease-in forwards;
+    animation-delay:.25s;
+  }
 
-@keyframes fadein { 0%{opacity:0} 100%{opacity:1} }
+  @keyframes fadein { 0%{opacity:0} 100%{opacity:1} }
+}

--- a/src/styles/_usage-graph.scss
+++ b/src/styles/_usage-graph.scss
@@ -1,17 +1,19 @@
-.curiosity-usage-graph {
-  .pf-c-card__head {
-    border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
-  }
+.curiosity {
+  .curiosity-usage-graph {
+    .pf-c-card__head {
+      border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
+    }
 
-  .curiosity-skeleton-container {
-    padding-top: var(--pf-c-card--child--PaddingBottom);
-  }
+    .curiosity-skeleton-container {
+      padding-top: var(--pf-c-card--child--PaddingBottom);
+    }
 
-  .curiosity-skeleton-container .ins-c-skeleton {
-    margin-bottom: 20px;
+    .curiosity-skeleton-container .ins-c-skeleton {
+      margin-bottom: 20px;
 
-    &:last-child {
-      margin-bottom: 0;
+      &:last-child {
+        margin-bottom: 0;
+      }
     }
   }
 }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -4,8 +4,6 @@
 @import '~@patternfly/patternfly/sass-utilities/all';
 
 // App
-.curiosity {
-  @import 'app';
-  @import 'common';
-  @import 'usage-graph';
-}
+@import 'app';
+@import 'common';
+@import 'usage-graph';

--- a/tests/__snapshots__/i18n.test.js.snap
+++ b/tests/__snapshots__/i18n.test.js.snap
@@ -5,23 +5,23 @@ exports[`i18n locale should generate a predictable pot output snapshot: pot outp
 msgstr \\"\\"
 \\"Content-Type: text/plain; charset=UTF-8\\\\n\\"
 
-#: src/common/graphHelpers.js:43
+#: src/common/graphHelpers.js:46
 msgid \\"curiosity-graph.tooltipLabel\\"
 msgstr \\"\\"
 
-#: src/common/graphHelpers.js:58
+#: src/common/graphHelpers.js:61
 msgid \\"curiosity-graph.tooltipPreviousLabelDaily\\"
 msgstr \\"\\"
 
-#: src/common/graphHelpers.js:51
+#: src/common/graphHelpers.js:54
 msgid \\"curiosity-graph.tooltipPreviousLabelMonthly\\"
 msgstr \\"\\"
 
-#: src/common/graphHelpers.js:54
+#: src/common/graphHelpers.js:57
 msgid \\"curiosity-graph.tooltipPreviousLabelQuarterly\\"
 msgstr \\"\\"
 
-#: src/common/graphHelpers.js:48
+#: src/common/graphHelpers.js:51
 msgid \\"curiosity-graph.tooltipPreviousLabelWeekly\\"
 msgstr \\"\\"
 
@@ -30,7 +30,7 @@ msgctxt \\"Daily\\"
 msgid \\"curiosity-graph.dropdownDaily\\"
 msgstr \\"\\"
 
-#: src/components/rhelGraphCard/rhelGraphCard.js:78
+#: src/components/rhelGraphCard/rhelGraphCard.js:79
 msgctxt \\"Daily CPU socket usage\\"
 msgid \\"curiosity-graph.heading\\"
 msgstr \\"\\"
@@ -45,8 +45,8 @@ msgctxt \\"Quarterly\\"
 msgid \\"curiosity-graph.dropdownQuarterly\\"
 msgstr \\"\\"
 
-#: src/components/rhelGraphCard/rhelGraphCard.js:81
-#: src/components/rhelGraphCard/rhelGraphCard.js:85
+#: src/components/rhelGraphCard/rhelGraphCard.js:82
+#: src/components/rhelGraphCard/rhelGraphCard.js:86
 msgctxt \\"Select date range\\"
 msgid \\"curiosity-graph.dropdownPlaceholder\\"
 msgstr \\"\\"


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(graphHelpers,chartArea): quarters granularity display
  * graphHelpers, quarters granularity in moment
  * chartArea, added label overlap
  * rhelGraphCard, label overlap
  * styling, min-width for main view around graph displays

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- after the "thirdlies" incident, actually show quarters =)

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. select the "quarters" granularity selection from the GUI dropdown, it should render like the below examples


<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screen Shot 2019-08-23 at 3 18 03 PM](https://user-images.githubusercontent.com/3761375/63618147-565bf700-c5b9-11e9-8bdd-35bcb064534e.png)

  
![Screen Shot 2019-08-23 at 3 17 54 PM](https://user-images.githubusercontent.com/3761375/63618149-5bb94180-c5b9-11e9-8d8e-e3fc0ce2dcd4.png)


![Screen Shot 2019-08-23 at 3 18 17 PM](https://user-images.githubusercontent.com/3761375/63618159-61168c00-c5b9-11e9-8fec-7e7583539a48.png)



## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
fixes #6 and #88 