### PR TITLE
fix(chartArea): issues/79 streamline on multiple data facets

### DIFF
--- a/src/components/chartArea/__tests__/chartArea.test.js
+++ b/src/components/chartArea/__tests__/chartArea.test.js
@@ -30,7 +30,8 @@ describe('ChartArea Component', () => {
               yAxisLabel: '2 y axis label'
             }
           ],
-          dataLegendLabel: 'Arma virumque cano'
+          legendLabel: 'Arma virumque cano',
+          isStacked: true
         }
       ]
     };
@@ -58,8 +59,13 @@ describe('ChartArea Component', () => {
               xAxisLabel: '2 x axis label'
             }
           ],
-          dataLegendLabel: 'Arma virumque cano',
-          thresholdLegendLabel: 'Arma virumque cano'
+          legendLabel: 'Arma virumque cano',
+          isStacked: true
+        },
+        {
+          data: [],
+          legendLabel: 'Arma virumque cano',
+          isThreshold: true
         }
       ]
     };
@@ -93,8 +99,8 @@ describe('ChartArea Component', () => {
               xAxisLabel: '2 x axis label'
             }
           ],
-          dataLegendLabel: 'Arma virumque cano',
-          thresholdLegendLabel: 'Arma virumque cano'
+          legendLabel: 'Arma virumque cano',
+          isStacked: true
         }
       ]
     };
@@ -125,7 +131,11 @@ describe('ChartArea Component', () => {
               xAxisLabel: '2 x axis label'
             }
           ],
-          threshold: [
+          legendLabel: 'Arma virumque cano',
+          isStacked: true
+        },
+        {
+          data: [
             {
               x: 1,
               y: 10,
@@ -139,8 +149,8 @@ describe('ChartArea Component', () => {
               xAxisLabel: '2 x axis label'
             }
           ],
-          dataLegendLabel: 'Arma virumque cano',
-          thresholdLegendLabel: 'Arma virumque cano'
+          legendLabel: 'Arma virumque cano',
+          isThreshold: true
         }
       ]
     };
@@ -161,7 +171,12 @@ describe('ChartArea Component', () => {
               xAxisLabel: '1 x axis label'
             }
           ],
-          threshold: [
+          interpolation: 'natural',
+          legendLabel: 'Arma virumque cano',
+          isStacked: true
+        },
+        {
+          data: [
             {
               x: 1,
               y: 10,
@@ -169,9 +184,8 @@ describe('ChartArea Component', () => {
               xAxisLabel: '1 x axis label'
             }
           ],
-          dataInterpolation: 'natural',
-          dataLegendLabel: 'Arma virumque cano',
-          thresholdLegendLabel: 'Arma virumque cano'
+          legendLabel: 'Arma virumque cano',
+          isThreshold: true
         }
       ]
     };
@@ -232,7 +246,7 @@ describe('ChartArea Component', () => {
             yAxisLabel: '1 hello world y-axis label'
           }
         ],
-        legendData: { name: 'Hello world' },
+        legendLabel: 'Hello world',
         xAxisLabelUseDataSet: true,
         yAxisLabelUseDataSet: true
       }

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -16,7 +16,7 @@ msgstr \\"\\"
 msgid \\"curiosity-graph.legendSocketsLabel\\"
 msgstr \\"\\"
 
-#: src/components/rhelGraphCard/rhelGraphCard.js:87
+#: src/components/rhelGraphCard/rhelGraphCard.js:90
 msgid \\"curiosity-graph.legendSocketsThresholdLabel\\"
 msgstr \\"\\"
 
@@ -48,7 +48,7 @@ msgstr \\"\\"
 msgid \\"curiosity-graph.tooltipSocketsThreshold\\"
 msgstr \\"\\"
 
-#: src/components/rhelGraphCard/rhelGraphCard.js:102
+#: src/components/rhelGraphCard/rhelGraphCard.js:106
 msgctxt \\"CPU socket usage\\"
 msgid \\"curiosity-graph.heading\\"
 msgstr \\"\\"
@@ -68,8 +68,8 @@ msgctxt \\"Quarterly\\"
 msgid \\"curiosity-graph.dropdownQuarterly\\"
 msgstr \\"\\"
 
-#: src/components/rhelGraphCard/rhelGraphCard.js:105
 #: src/components/rhelGraphCard/rhelGraphCard.js:109
+#: src/components/rhelGraphCard/rhelGraphCard.js:113
 msgctxt \\"Select date range\\"
 msgid \\"curiosity-graph.dropdownPlaceholder\\"
 msgstr \\"\\"

--- a/src/components/rhelGraphCard/__tests__/__snapshots__/rhelGraphCard.test.js.snap
+++ b/src/components/rhelGraphCard/__tests__/__snapshots__/rhelGraphCard.test.js.snap
@@ -51,6 +51,12 @@ exports[`RhelGraphCard Component should render a non-connected component: non-co
         dataSets={
           Array [
             Object {
+              "animate": Object {
+                "duration": 250,
+                "onLoad": Object {
+                  "duration": 250,
+                },
+              },
               "data": Array [
                 Object {
                   "tooltip": "t('curiosity-graph.tooltipSocketsNoData')",
@@ -239,22 +245,20 @@ exports[`RhelGraphCard Component should render a non-connected component: non-co
                   "y": 0,
                 },
               ],
-              "dataAnimate": Object {
-                "duration": 250,
-                "onLoad": Object {
-                  "duration": 250,
-                },
-              },
-              "dataLegendLabel": "t('curiosity-graph.legendSocketsLabel')",
-              "threshold": Array [],
-              "thresholdAnimate": Object {
+              "isStacked": true,
+              "legendLabel": "t('curiosity-graph.legendSocketsLabel')",
+            },
+            Object {
+              "animate": Object {
                 "duration": 100,
                 "onLoad": Object {
                   "duration": 100,
                 },
               },
-              "thresholdColor": "green",
-              "thresholdLegendLabel": "t('curiosity-graph.legendSocketsThresholdLabel')",
+              "color": "green",
+              "data": Array [],
+              "isThreshold": true,
+              "legendLabel": "t('curiosity-graph.legendSocketsThresholdLabel')",
             },
           ]
         }
@@ -284,6 +288,12 @@ exports[`RhelGraphCard Component should render multiple states: error shows zero
 Object {
   "chartBarData": Array [
     Object {
+      "animate": Object {
+        "duration": 250,
+        "onLoad": Object {
+          "duration": 250,
+        },
+      },
       "data": Array [
         Object {
           "tooltip": "10 t('curiosity-graph.tooltipSockets') June 1",
@@ -466,22 +476,20 @@ Object {
           "y": 0,
         },
       ],
-      "dataAnimate": Object {
-        "duration": 250,
-        "onLoad": Object {
-          "duration": 250,
-        },
-      },
-      "dataLegendLabel": "t('curiosity-graph.legendSocketsLabel')",
-      "threshold": Array [],
-      "thresholdAnimate": Object {
+      "isStacked": true,
+      "legendLabel": "t('curiosity-graph.legendSocketsLabel')",
+    },
+    Object {
+      "animate": Object {
         "duration": 100,
         "onLoad": Object {
           "duration": 100,
         },
       },
-      "thresholdColor": "green",
-      "thresholdLegendLabel": "t('curiosity-graph.legendSocketsThresholdLabel')",
+      "color": "green",
+      "data": Array [],
+      "isThreshold": true,
+      "legendLabel": "t('curiosity-graph.legendSocketsThresholdLabel')",
     },
   ],
 }
@@ -538,6 +546,12 @@ exports[`RhelGraphCard Component should render multiple states: fulfilled 1`] = 
         dataSets={
           Array [
             Object {
+              "animate": Object {
+                "duration": 250,
+                "onLoad": Object {
+                  "duration": 250,
+                },
+              },
               "data": Array [
                 Object {
                   "tooltip": "10 t('curiosity-graph.tooltipSockets') June 1",
@@ -720,22 +734,20 @@ exports[`RhelGraphCard Component should render multiple states: fulfilled 1`] = 
                   "y": 0,
                 },
               ],
-              "dataAnimate": Object {
-                "duration": 250,
-                "onLoad": Object {
-                  "duration": 250,
-                },
-              },
-              "dataLegendLabel": "t('curiosity-graph.legendSocketsLabel')",
-              "threshold": Array [],
-              "thresholdAnimate": Object {
+              "isStacked": true,
+              "legendLabel": "t('curiosity-graph.legendSocketsLabel')",
+            },
+            Object {
+              "animate": Object {
                 "duration": 100,
                 "onLoad": Object {
                   "duration": 100,
                 },
               },
-              "thresholdColor": "green",
-              "thresholdLegendLabel": "t('curiosity-graph.legendSocketsThresholdLabel')",
+              "color": "green",
+              "data": Array [],
+              "isThreshold": true,
+              "legendLabel": "t('curiosity-graph.legendSocketsThresholdLabel')",
             },
           ]
         }

--- a/src/components/rhelGraphCard/rhelGraphCard.js
+++ b/src/components/rhelGraphCard/rhelGraphCard.js
@@ -73,18 +73,22 @@ class RhelGraphCard extends React.Component {
         dataSets={[
           {
             data: chartData,
-            dataAnimate: {
+            animate: {
               duration: 250,
               onLoad: { duration: 250 }
             },
-            dataLegendLabel: t('curiosity-graph.legendSocketsLabel'),
-            threshold: chartDataThresholds,
-            thresholdAnimate: {
+            legendLabel: t('curiosity-graph.legendSocketsLabel'),
+            isStacked: true
+          },
+          {
+            data: chartDataThresholds,
+            animate: {
               duration: 100,
               onLoad: { duration: 100 }
             },
-            thresholdColor: ChartThemeColor.green,
-            thresholdLegendLabel: t('curiosity-graph.legendSocketsThresholdLabel')
+            color: ChartThemeColor.green,
+            legendLabel: t('curiosity-graph.legendSocketsThresholdLabel'),
+            isThreshold: true
           }
         ]}
       />


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(chartArea): issues/79 streamline on multiple data facets
   * chartArea, allow multiple data facets as prep for hypervisor
   * rhelGraphCard, update towards chartArea props update
   * tests, chartArea, i18n and rhelGraphCard tweak

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- This is a incremental update while the GUI is converted towards displaying the Hypervisor aspect of the RHSM API properties.

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. No visual changes should be detectable. And no console errors should be present

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. No visual changes should be detectable. And no console errors should be present

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Updates #79 