### PR TITLE
fix(graphCardSelectors): confirm granularity loaded correctly

### DIFF
--- a/src/components/rhelGraphCard/rhelGraphCard.js
+++ b/src/components/rhelGraphCard/rhelGraphCard.js
@@ -217,7 +217,6 @@ const makeMapStateToProps = () => {
   const getRhelGraphCard = reduxSelectors.graphCard.makeRhelGraphCard();
 
   return (state, props) => ({
-    ...state.rhelGraph.component,
     ...getRhelGraphCard(state, props)
   });
 };

--- a/src/redux/selectors/__tests__/__snapshots__/graphCardSelectors.test.js.snap
+++ b/src/redux/selectors/__tests__/__snapshots__/graphCardSelectors.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GraphCardSelectors Should error on a RHEL product ID without granularity provided: rhelGraphCard: no granularity error 1`] = `
+exports[`GraphCardSelectors should error on a RHEL product ID without granularity provided: rhelGraphCard: no granularity error 1`] = `
 Object {
   "error": true,
   "fulfilled": false,
@@ -14,7 +14,21 @@ Object {
 }
 `;
 
-exports[`GraphCardSelectors Should handle pending state on a RHEL product ID: rhelGraphCard: pending 1`] = `
+exports[`GraphCardSelectors should error on missing a reducer response: rhelGraphCard: missing reducer error 1`] = `
+Object {
+  "error": true,
+  "fulfilled": false,
+  "graphData": Object {
+    "hypervisor": Array [],
+    "sockets": Array [],
+    "threshold": Array [],
+  },
+  "initialLoad": true,
+  "pending": false,
+}
+`;
+
+exports[`GraphCardSelectors should handle pending state on a RHEL product ID: rhelGraphCard: pending 1`] = `
 Object {
   "error": false,
   "fulfilled": false,
@@ -28,8 +42,9 @@ Object {
 }
 `;
 
-exports[`GraphCardSelectors Should map a fulfilled RHEL product ID response to an aggregated output: rhelGraphCard: fulfilled granularity 1`] = `
+exports[`GraphCardSelectors should map a fulfilled RHEL product ID response to an aggregated output: rhelGraphCard: fulfilled granularity 1`] = `
 Object {
+  "endDate": 2019-07-20T00:00:00.000Z,
   "error": false,
   "fulfilled": true,
   "graphData": Object {
@@ -85,22 +100,91 @@ Object {
       },
     ],
   },
+  "graphGranularity": "daily",
   "initialLoad": false,
   "pending": false,
+  "startDate": 2019-06-20T00:00:00.000Z,
 }
 `;
 
-exports[`GraphCardSelectors Should pass data through on a RHEL product ID when granularity provided mismatches between aggregated responses: rhelGraphCard: granularity mismatch fulfilled 1`] = `
+exports[`GraphCardSelectors should pass data through on a RHEL product ID when granularity provided mismatches between aggregated responses: rhelGraphCard: granularity mismatch fulfilled 1`] = `
 Object {
-  "error": false,
-  "fulfilled": true,
+  "error": true,
+  "fulfilled": false,
   "graphData": Object {
     "hypervisor": Array [],
     "sockets": Array [],
     "threshold": Array [],
   },
+  "initialLoad": true,
+  "pending": false,
+}
+`;
+
+exports[`GraphCardSelectors should pass data through on a RHEL product ID when granularity provided mismatches between aggregated responses: rhelGraphCard: granularity mismatch on component 1`] = `
+Object {
+  "error": false,
+  "fulfilled": true,
+  "graphData": Object {
+    "hypervisor": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 1,
+      },
+    ],
+    "sockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 1,
+      },
+    ],
+    "threshold": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 100,
+      },
+    ],
+  },
   "initialLoad": false,
   "pending": false,
+}
+`;
+
+exports[`GraphCardSelectors should populate data on a RHEL product ID when api response provided mismatches index or date: rhelGraphCard: data populated on mismatch fulfilled 1`] = `
+Object {
+  "endDate": 2019-07-20T00:00:00.000Z,
+  "error": false,
+  "fulfilled": true,
+  "graphData": Object {
+    "hypervisor": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 1,
+      },
+    ],
+    "sockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 1,
+      },
+    ],
+    "threshold": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+  },
+  "graphGranularity": "daily",
+  "initialLoad": false,
+  "pending": false,
+  "startDate": 2019-06-20T00:00:00.000Z,
 }
 `;
 

--- a/src/redux/selectors/__tests__/graphCardSelectors.test.js
+++ b/src/redux/selectors/__tests__/graphCardSelectors.test.js
@@ -1,14 +1,21 @@
 import graphCardSelectors from '../graphCardSelectors';
 import { rhelApiTypes } from '../../../types/rhelApiTypes';
+import { dateHelpers } from '../../../common/dateHelpers';
 
 describe('GraphCardSelectors', () => {
   it('should return specific selectors', () => {
     expect(graphCardSelectors).toMatchSnapshot('selectors');
   });
 
-  it('Should error on a RHEL product ID without granularity provided', () => {
+  it('should error on missing a reducer response', () => {
+    const state = {};
+    expect(graphCardSelectors.rhelGraphCard(state)).toMatchSnapshot('rhelGraphCard: missing reducer error');
+  });
+
+  it('should error on a RHEL product ID without granularity provided', () => {
     const state = {
       rhelGraph: {
+        component: {},
         capacity: {
           fulfilled: true,
           metaQuery: {},
@@ -25,9 +32,10 @@ describe('GraphCardSelectors', () => {
     expect(graphCardSelectors.rhelGraphCard(state)).toMatchSnapshot('rhelGraphCard: no granularity error');
   });
 
-  it('Should handle pending state on a RHEL product ID', () => {
+  it('should handle pending state on a RHEL product ID', () => {
     const state = {
       rhelGraph: {
+        component: {},
         capacity: {
           fulfilled: true,
           metaQuery: {
@@ -48,13 +56,75 @@ describe('GraphCardSelectors', () => {
     expect(graphCardSelectors.rhelGraphCard(state)).toMatchSnapshot('rhelGraphCard: pending');
   });
 
-  it('Should pass data through on a RHEL product ID when granularity provided mismatches between aggregated responses', () => {
+  it('should pass data through on a RHEL product ID when granularity provided mismatches between aggregated responses', () => {
     const state = {
       rhelGraph: {
+        component: {},
         capacity: {
           fulfilled: true,
           metaQuery: {
             [rhelApiTypes.RHSM_API_QUERY_GRANULARITY]: rhelApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.MONTHLY
+          },
+          data: {
+            [rhelApiTypes.RHSM_API_RESPONSE_CAPACITY_DATA]: [
+              {
+                [rhelApiTypes.RHSM_API_RESPONSE_CAPACITY_DATA_TYPES.DATE]: '2019-09-04T00:00:00.000Z',
+                [rhelApiTypes.RHSM_API_RESPONSE_CAPACITY_DATA_TYPES.SOCKETS]: 100,
+                [rhelApiTypes.RHSM_API_RESPONSE_CAPACITY_DATA_TYPES.HYPERVISOR_SOCKETS]: 50,
+                [rhelApiTypes.RHSM_API_RESPONSE_CAPACITY_DATA_TYPES.PHYSICAL_SOCKETS]: 50
+              }
+            ]
+          }
+        },
+        report: {
+          fulfilled: true,
+          metaQuery: {
+            [rhelApiTypes.RHSM_API_QUERY_GRANULARITY]: rhelApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
+          },
+          data: {
+            [rhelApiTypes.RHSM_API_RESPONSE_PRODUCTS_DATA]: [
+              {
+                [rhelApiTypes.RHSM_API_RESPONSE_PRODUCTS_DATA_TYPES.DATE]: '2019-09-04T00:00:00.000Z',
+                [rhelApiTypes.RHSM_API_RESPONSE_PRODUCTS_DATA_TYPES.SOCKETS]: 2,
+                [rhelApiTypes.RHSM_API_RESPONSE_PRODUCTS_DATA_TYPES.HYPERVISOR_SOCKETS]: 1,
+                [rhelApiTypes.RHSM_API_RESPONSE_PRODUCTS_DATA_TYPES.PHYSICAL_SOCKETS]: 1
+              }
+            ]
+          }
+        }
+      }
+    };
+
+    expect(graphCardSelectors.rhelGraphCard(state)).toMatchSnapshot('rhelGraphCard: granularity mismatch fulfilled');
+
+    expect(
+      graphCardSelectors.rhelGraphCard({
+        rhelGraph: {
+          capacity: {
+            ...state.rhelGraph.capacity,
+            metaQuery: {
+              [rhelApiTypes.RHSM_API_QUERY_GRANULARITY]: rhelApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
+            }
+          },
+          report: {
+            ...state.rhelGraph.report
+          }
+        }
+      })
+    ).toMatchSnapshot('rhelGraphCard: granularity mismatch on component');
+  });
+
+  it('should populate data on a RHEL product ID when api response provided mismatches index or date', () => {
+    const state = {
+      rhelGraph: {
+        component: {
+          graphGranularity: rhelApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY,
+          ...dateHelpers.getRangedDateTime(rhelApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY)
+        },
+        capacity: {
+          fulfilled: true,
+          metaQuery: {
+            [rhelApiTypes.RHSM_API_QUERY_GRANULARITY]: rhelApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
           },
           data: { [rhelApiTypes.RHSM_API_RESPONSE_CAPACITY_DATA]: [] }
         },
@@ -63,17 +133,32 @@ describe('GraphCardSelectors', () => {
           metaQuery: {
             [rhelApiTypes.RHSM_API_QUERY_GRANULARITY]: rhelApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
           },
-          data: { [rhelApiTypes.RHSM_API_RESPONSE_PRODUCTS_DATA]: [] }
+          data: {
+            [rhelApiTypes.RHSM_API_RESPONSE_PRODUCTS_DATA]: [
+              {
+                [rhelApiTypes.RHSM_API_RESPONSE_PRODUCTS_DATA_TYPES.DATE]: '2019-09-04T00:00:00.000Z',
+                [rhelApiTypes.RHSM_API_RESPONSE_PRODUCTS_DATA_TYPES.SOCKETS]: 2,
+                [rhelApiTypes.RHSM_API_RESPONSE_PRODUCTS_DATA_TYPES.HYPERVISOR_SOCKETS]: 1,
+                [rhelApiTypes.RHSM_API_RESPONSE_PRODUCTS_DATA_TYPES.PHYSICAL_SOCKETS]: 1
+              }
+            ]
+          }
         }
       }
     };
 
-    expect(graphCardSelectors.rhelGraphCard(state)).toMatchSnapshot('rhelGraphCard: granularity mismatch fulfilled');
+    expect(graphCardSelectors.rhelGraphCard(state)).toMatchSnapshot(
+      'rhelGraphCard: data populated on mismatch fulfilled'
+    );
   });
 
-  it('Should map a fulfilled RHEL product ID response to an aggregated output', () => {
+  it('should map a fulfilled RHEL product ID response to an aggregated output', () => {
     const state = {
       rhelGraph: {
+        component: {
+          graphGranularity: rhelApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY,
+          ...dateHelpers.getRangedDateTime(rhelApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY)
+        },
         capacity: {
           fulfilled: true,
           metaQuery: {


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(graphCardSelectors): confirm granularity loaded correctly
   * additional check to avoid loading prior cache
   * tests, expand and update selector

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- Appears as a caching issue, where the cache is a step behind the granularity dropdown selection. Initial loads are fine. This adds an additional check to confirm the granularity has been updated, and now runs all Redux for the graph card through Reselect.

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. Select `Monthly` granularity from the dropdown, then reselect `Daily` granularity, then reselect `Monthly`. Monthly should update the x axis ticks as a confirmation the data has loaded correctly and not the previous cached chart data.

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Relates to #79 