### PR TITLE
fix(dateHelpers): end of day adjustment for display

### DIFF
--- a/src/common/__tests__/__snapshots__/dateHelpers.test.js.snap
+++ b/src/common/__tests__/__snapshots__/dateHelpers.test.js.snap
@@ -3,17 +3,17 @@
 exports[`DateHelpers should have specific functions: dateHelpers 1`] = `
 Object {
   "defaultDateTime": Object {
-    "endDate": 2019-07-20T00:00:00.000Z,
+    "endDate": 2019-07-20T23:59:59.999Z,
     "startDate": 2019-06-20T00:00:00.000Z,
   },
   "getCurrentDate": [Function],
   "getRangedDateTime": [Function],
   "monthlyDateTime": Object {
-    "endDate": 2019-07-01T00:00:00.000Z,
+    "endDate": 2019-07-01T23:59:59.999Z,
     "startDate": 2018-07-01T00:00:00.000Z,
   },
   "quarterlyDateTime": Object {
-    "endDate": 2019-07-01T00:00:00.000Z,
+    "endDate": 2019-07-01T23:59:59.999Z,
     "startDate": 2016-07-01T00:00:00.000Z,
   },
   "setRangedDateTime": [Function],
@@ -36,7 +36,7 @@ Object {
     "yearShort": "MMM YYYY",
   },
   "weeklyDateTime": Object {
-    "endDate": 2019-07-14T00:00:00.000Z,
+    "endDate": 2019-07-14T23:59:59.999Z,
     "startDate": 2019-04-21T00:00:00.000Z,
   },
 }
@@ -47,28 +47,28 @@ Array [
   Object {
     "granularity": "daily",
     "range": Object {
-      "endDate": 2019-07-20T00:00:00.000Z,
+      "endDate": 2019-07-20T23:59:59.999Z,
       "startDate": 2019-06-20T00:00:00.000Z,
     },
   },
   Object {
     "granularity": "weekly",
     "range": Object {
-      "endDate": 2019-07-14T00:00:00.000Z,
+      "endDate": 2019-07-14T23:59:59.999Z,
       "startDate": 2019-04-21T00:00:00.000Z,
     },
   },
   Object {
     "granularity": "monthly",
     "range": Object {
-      "endDate": 2019-07-01T00:00:00.000Z,
+      "endDate": 2019-07-01T23:59:59.999Z,
       "startDate": 2018-07-01T00:00:00.000Z,
     },
   },
   Object {
     "granularity": "quarterly",
     "range": Object {
-      "endDate": 2019-07-01T00:00:00.000Z,
+      "endDate": 2019-07-01T23:59:59.999Z,
       "startDate": 2016-07-01T00:00:00.000Z,
     },
   },
@@ -79,7 +79,7 @@ exports[`DateHelpers should return a predictable range of time: range of time 1`
 Object {
   "currentDate": "20190720",
   "rangeDateTime": Object {
-    "endDate": 2019-07-20T00:00:00.000Z,
+    "endDate": 2019-07-20T23:59:59.999Z,
     "startDate": 2019-07-15T00:00:00.000Z,
   },
 }

--- a/src/common/dateHelpers.js
+++ b/src/common/dateHelpers.js
@@ -14,6 +14,7 @@ const setRangedDateTime = ({ date, subtract, measurement }) => ({
   endDate: moment
     .utc(date)
     .startOf(measurement)
+    .endOf('days')
     .toDate()
 });
 

--- a/src/redux/reducers/__tests__/__snapshots__/rhelGraphReducer.test.js.snap
+++ b/src/redux/reducers/__tests__/__snapshots__/rhelGraphReducer.test.js.snap
@@ -135,7 +135,7 @@ Object {
   "result": Object {
     "capacity": Object {},
     "component": Object {
-      "endDate": 2019-07-20T00:00:00.000Z,
+      "endDate": 2019-07-20T23:59:59.999Z,
       "graphGranularity": undefined,
       "startDate": 2019-06-20T00:00:00.000Z,
     },

--- a/src/redux/selectors/__tests__/__snapshots__/graphCardSelectors.test.js.snap
+++ b/src/redux/selectors/__tests__/__snapshots__/graphCardSelectors.test.js.snap
@@ -58,7 +58,7 @@ Object {
 
 exports[`GraphCardSelectors should map a fulfilled RHEL product ID response to an aggregated output: rhelGraphCard: fulfilled granularity 1`] = `
 Object {
-  "endDate": 2019-07-20T00:00:00.000Z,
+  "endDate": 2019-07-20T23:59:59.999Z,
   "error": false,
   "fulfilled": true,
   "graphData": Object {
@@ -169,7 +169,7 @@ Object {
 
 exports[`GraphCardSelectors should populate data on a RHEL product ID when the api response is missing expected properties: rhelGraphCard: data populated, missing properties 1`] = `
 Object {
-  "endDate": 2019-07-20T00:00:00.000Z,
+  "endDate": 2019-07-20T23:59:59.999Z,
   "error": false,
   "fulfilled": true,
   "graphData": Object {
@@ -234,7 +234,7 @@ Object {
 
 exports[`GraphCardSelectors should populate data on a RHEL product ID when the api response provided mismatches index or date: rhelGraphCard: data populated on mismatch fulfilled 1`] = `
 Object {
-  "endDate": 2019-07-20T00:00:00.000Z,
+  "endDate": 2019-07-20T23:59:59.999Z,
   "error": false,
   "fulfilled": true,
   "graphData": Object {


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(dateHelpers): end of day adjustment for display

<!-- ### Notes -->
<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. once you log in and are able to see data you should no longer see a "data dive" before the largest x axis value, see below screenshots

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
### Original
![Screen Shot 2019-11-19 at 2 22 05 PM](https://user-images.githubusercontent.com/3761375/69178642-02897d00-0ad8-11ea-8eef-ebde77a28d41.png)


### Updated
![Screen Shot 2019-11-19 at 2 21 44 PM](https://user-images.githubusercontent.com/3761375/69178659-09b08b00-0ad8-11ea-9260-2481d8fb5a2e.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing