### PR TITLE
fix(rhelActions,tourView): issues/133 disable toast notifications

### DIFF
--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -58,7 +58,7 @@ msgstr \\"\\"
 msgid \\"curiosity-tour.emptyStateIconAlt\\"
 msgstr \\"\\"
 
-#: src/components/tourView/tourView.js:56
+#: src/components/tourView/tourView.js:57
 msgid \\"curiosity-tour.emptyStateLink\\"
 msgstr \\"\\"
 

--- a/src/components/tourView/__tests__/__snapshots__/tourView.test.js.snap
+++ b/src/components/tourView/__tests__/__snapshots__/tourView.test.js.snap
@@ -40,6 +40,7 @@ exports[`TourView Component should have a fallback title: title 1`] = `
         <Component
           component="a"
           href="https://access.redhat.com/documentation/subscription_central/2019-11/"
+          rel="noopener noreferrer"
           target="_blank"
           variant="link"
         >
@@ -91,6 +92,7 @@ exports[`TourView Component should render a non-connected component: non-connect
         <Component
           component="a"
           href="https://access.redhat.com/documentation/subscription_central/2019-11/"
+          rel="noopener noreferrer"
           target="_blank"
           variant="link"
         >
@@ -142,6 +144,7 @@ exports[`TourView Component should render a translated component: translated 1`]
         <Component
           component="a"
           href="https://access.redhat.com/documentation/subscription_central/2019-11/"
+          rel="noopener noreferrer"
           target="_blank"
           variant="link"
         >

--- a/src/components/tourView/tourView.js
+++ b/src/components/tourView/tourView.js
@@ -51,6 +51,7 @@ const TourView = ({ t }) => (
             component="a"
             variant="link"
             target="_blank"
+            rel="noopener noreferrer"
             href="https://access.redhat.com/documentation/subscription_central/2019-11/"
           >
             {t('curiosity-tour.emptyStateLink')}

--- a/src/redux/actions/rhelActions.js
+++ b/src/redux/actions/rhelActions.js
@@ -1,6 +1,7 @@
 import { rhelTypes } from '../types';
 import rhelServices from '../../services/rhelServices';
 
+// ToDo: add notifications settings back once "auth" end point available from API
 const getGraphReportsRhel = (id = null, query = {}) => dispatch =>
   dispatch({
     type: rhelTypes.GET_GRAPH_REPORT_RHEL,
@@ -8,16 +9,11 @@ const getGraphReportsRhel = (id = null, query = {}) => dispatch =>
     meta: {
       data: { id },
       query,
-      notifications: {
-        rejected: {
-          variant: 'info',
-          title: 'Reporting connection has failed',
-          description: 'Product ID: Red Hat Enterprise Linux'
-        }
-      }
+      notifications: {}
     }
   });
 
+// ToDo: add notifications settings back once "auth" end point available from API
 const getGraphCapacityRhel = (id = null, query = {}) => dispatch =>
   dispatch({
     type: rhelTypes.GET_GRAPH_CAPACITY_RHEL,
@@ -25,13 +21,7 @@ const getGraphCapacityRhel = (id = null, query = {}) => dispatch =>
     meta: {
       data: { id },
       query,
-      notifications: {
-        rejected: {
-          variant: 'info',
-          title: 'Capacity connection has failed',
-          description: 'Product ID: Red Hat Enterprise Linux'
-        }
-      }
+      notifications: {}
     }
   });
 


### PR DESCRIPTION


## What's included
<!-- Summary of changes/additions -->
- fix(rhelActions,tourView): issues/133 disable toast notifications
   * rhelActions, disable toasts until API provides auth endpoint
   * tourView, anchor tag ref attribute

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- This change disables all error toast notifications from appearing for the `tally` and `capacity` endpoints. The notifications partially interfere with the display and general intent of "redirecting" the user to the guided tour/learn more view.
- This notification change can be reverted if/when the API provides an `auth` endpoint the GUI can access **before** trying to load the `tally` and `capacity` endpoints.

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screen Shot 2019-11-22 at 1 10 32 AM (2)](https://user-images.githubusercontent.com/3761375/69402145-f3b3ed80-0cc4-11ea-9461-39c33d3259d1.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Updates #133 