### PR TITLE
fix(tourView): issues/133 generic learn more link

### DIFF
--- a/src/components/tourView/__tests__/__snapshots__/tourView.test.js.snap
+++ b/src/components/tourView/__tests__/__snapshots__/tourView.test.js.snap
@@ -42,7 +42,7 @@ exports[`TourView Component should have a fallback title: title 1`] = `
       <EmptyStateSecondaryActions>
         <Component
           component="a"
-          href="https://access.redhat.com/documentation/subscription_central/2019-11/"
+          href="https://access.redhat.com/documentation/Subscription_Central/"
           target="_blank"
           variant="link"
         >
@@ -104,7 +104,7 @@ exports[`TourView Component should render a non-connected component: non-connect
       <EmptyStateSecondaryActions>
         <Component
           component="a"
-          href="https://access.redhat.com/documentation/subscription_central/2019-11/"
+          href="https://access.redhat.com/documentation/Subscription_Central/"
           target="_blank"
           variant="link"
         >
@@ -166,7 +166,7 @@ exports[`TourView Component should render a translated component: translated 1`]
       <EmptyStateSecondaryActions>
         <Component
           component="a"
-          href="https://access.redhat.com/documentation/subscription_central/2019-11/"
+          href="https://access.redhat.com/documentation/Subscription_Central/"
           target="_blank"
           variant="link"
         >

--- a/src/components/tourView/tourView.js
+++ b/src/components/tourView/tourView.js
@@ -56,7 +56,7 @@ const TourView = ({ t }) => (
             component="a"
             variant="link"
             target="_blank"
-            href="https://access.redhat.com/documentation/subscription_central/2019-11/"
+            href="https://access.redhat.com/documentation/Subscription_Central/"
           >
             {t('curiosity-tour.emptyStateLinkLearnMore')}
           </Button>


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(tourView): issues/133 generic learn more link

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- The current link is not incorrect, this is a simple adjustment that aligns the left nav "Documentation" link and "Learn more" links by using the same generic documentation redirect.
   - https://github.com/RedHatInsights/insights-chrome/commit/06d0349cf7351fd53fbb5f292bae882b5f7ae558

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. navigate towards the route `/soon` and click the "Learn more" link. It should now redirect towards `https://access.redhat.com/documentation/Subscription_Central/`

<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Relates to #133 #153 

@rblackbu