### PR TITLE
fix(i18n): issues/159 correct locale load sequence

### DIFF
--- a/src/components/i18n/__tests__/i18n.test.js
+++ b/src/components/i18n/__tests__/i18n.test.js
@@ -7,6 +7,14 @@ import { I18n, translate, translateComponent } from '../i18n';
 import { helpers } from '../../../common';
 import enLocales from '../../../../public/locales/en-US';
 
+/**
+ * Emulate for component render checks
+ */
+jest.mock('i18next');
+
+/**
+ * Help generate a POT output.
+ */
 const textExtractor = () => {
   const extractor = new GettextExtractor();
   extractor

--- a/src/components/i18n/i18n.js
+++ b/src/components/i18n/i18n.js
@@ -17,6 +17,8 @@ const translateComponent = component => (!helpers.TEST_MODE && withTranslation()
  * the scenes appears more predictable.
  */
 class I18n extends React.Component {
+  state = { isLoaded: false };
+
   componentDidMount() {
     this.i18nInit();
   }
@@ -29,31 +31,38 @@ class I18n extends React.Component {
     }
   }
 
-  i18nInit() {
+  i18nInit = async () => {
     const { fallbackLng, loadPath, locale } = this.props;
 
-    i18next
-      .use(XHR)
-      .use(initReactI18next)
-      .init({
-        backend: {
-          loadPath
-        },
-        fallbackLng,
-        lng: locale,
-        debug: !helpers.PROD_MODE,
-        ns: ['default'],
-        defaultNS: 'default',
-        react: {
-          useSuspense: false
-        }
-      });
-  }
+    try {
+      await i18next
+        .use(XHR)
+        .use(initReactI18next)
+        .init({
+          backend: {
+            loadPath
+          },
+          fallbackLng,
+          lng: locale,
+          debug: !helpers.PROD_MODE,
+          ns: ['default'],
+          defaultNS: 'default',
+          react: {
+            useSuspense: false
+          }
+        });
+    } catch (e) {
+      // ToDo: eval the need for an isError state ref
+    }
+
+    this.setState({ isLoaded: true });
+  };
 
   render() {
+    const { isLoaded } = this.state;
     const { children } = this.props;
 
-    return <React.Fragment>{children}</React.Fragment>;
+    return (isLoaded && <React.Fragment>{children}</React.Fragment>) || <React.Fragment />;
   }
 }
 
@@ -70,4 +79,4 @@ I18n.defaultProps = {
   locale: null
 };
 
-export { I18n as default, I18n, translate, translateComponent };
+export { I18n as default, I18n, i18next, translate, translateComponent };


### PR DESCRIPTION


## What's included
<!-- Summary of changes/additions -->
- fix(i18n): correct locale load sequence
   * minor race condition apparent after package updates

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- The issue is exposed as a warning on local and proxy level development prior to this update.
- A side effect of this update is `locale` should be one of the very first things that you'll see in the Redux state layer.

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
### Local run check
Before you update your local create a branch based of of `upstream/ci`  and run through a `$ yarn start` with the  browser console open, the React warning should be displayed. Once you see that then...
1. update the NPM packages with `$ yarn`
1. `$ yarn start` make sure the browser dev console is open
1. And confirm the warning is no longer present. 
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
#### Error message
![Screen Shot 2020-01-14 at 7 41 17 PM](https://user-images.githubusercontent.com/3761375/72394951-e71ca600-3705-11ea-8a45-10b0fbf386b8.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
#159 