### PR TITLE
fix(platformServices,userServices): issues/43 centralize globals

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -60,6 +60,7 @@
     "no-plusplus": 0,
     "no-restricted-properties": [0, {"object": "Math", "property": "pow"}],
     "no-underscore-dangle": 0,
+    "prefer-promise-reject-errors": 1,
     "prettier/prettier": [
       "error",
       {

--- a/src/redux/actions/__tests__/__snapshots__/platformActions.test.js.snap
+++ b/src/redux/actions/__tests__/__snapshots__/platformActions.test.js.snap
@@ -7,18 +7,6 @@ Object {
 }
 `;
 
-exports[`PlatformActions Should return a dispatch object for the onNavigation method: dispatch object 1`] = `
-Object {
-  "meta": Object {
-    "data": Object {
-      "callback": undefined,
-    },
-  },
-  "payload": Promise {},
-  "type": "PLATFORM_ON_NAV",
-}
-`;
-
 exports[`PlatformActions Should return a dispatch object for the setAppName method: dispatch object 1`] = `
 Object {
   "meta": Object {
@@ -31,12 +19,21 @@ Object {
 }
 `;
 
-exports[`PlatformActions Should return a dispatch object for the setNavigation method: dispatch object 1`] = `
-Object {
-  "meta": Object {
-    "data": undefined,
+exports[`PlatformActions Should return a function for the onNavigation method: expected process 1`] = `"lorem ipsum"`;
+
+exports[`PlatformActions Should return a function for the onNavigation method: function 1`] = `[Function]`;
+
+exports[`PlatformActions Should return a function for the setNavigation method: expected process 1`] = `
+Array [
+  Object {
+    "active": false,
+    "id": "lorem",
   },
-  "payload": Promise {},
-  "type": "PLATFORM_SET_NAV",
-}
+  Object {
+    "active": false,
+    "id": "ipsum",
+  },
+]
 `;
+
+exports[`PlatformActions Should return a function for the setNavigation method: function 1`] = `[Function]`;

--- a/src/redux/actions/__tests__/platformActions.test.js
+++ b/src/redux/actions/__tests__/platformActions.test.js
@@ -1,32 +1,29 @@
 import { platformActions } from '../platformActions';
-import { helpers } from '../../../common';
 
 describe('PlatformActions', () => {
-  beforeAll(() => {
-    window.insights = {
-      chrome: {
-        auth: helpers.noop,
-        identifyApp: helpers.noop,
-        init: helpers.noop,
-        navigation: helpers.noop,
-        on: helpers.noop
-      }
-    };
-  });
-
   it('Should return a dispatch object for the initializeChrome method', () => {
     expect(platformActions.initializeChrome()).toMatchSnapshot('dispatch object');
   });
 
-  it('Should return a dispatch object for the onNavigation method', () => {
-    expect(platformActions.onNavigation()).toMatchSnapshot('dispatch object');
+  it('Should return a function for the onNavigation method', () => {
+    expect(platformActions.onNavigation()).toMatchSnapshot('function');
+
+    window.insights.chrome.on = jest.fn().mockImplementation((id, value) => value('lorem'));
+    const dispatch = obj => obj;
+    expect(platformActions.onNavigation(event => `${event} ipsum`)(dispatch)).toMatchSnapshot('expected process');
   });
 
   it('Should return a dispatch object for the setAppName method', () => {
     expect(platformActions.setAppName()).toMatchSnapshot('dispatch object');
   });
 
-  it('Should return a dispatch object for the setNavigation method', () => {
-    expect(platformActions.setNavigation()).toMatchSnapshot('dispatch object');
+  it('Should return a function for the setNavigation method', () => {
+    expect(platformActions.setNavigation()).toMatchSnapshot('function');
+
+    window.insights.chrome.navigation = jest.fn().mockImplementation(value => value);
+    const dispatch = obj => obj;
+    expect(platformActions.setNavigation([{ id: 'lorem' }, { id: 'ipsum' }])(dispatch)).toMatchSnapshot(
+      'expected process'
+    );
   });
 });

--- a/src/redux/actions/__tests__/rhsmActions.test.js
+++ b/src/redux/actions/__tests__/rhsmActions.test.js
@@ -41,7 +41,6 @@ describe('RhsmActions', () => {
 
     dispatcher(store.dispatch).then(() => {
       const response = store.getState().graph;
-
       expect(response.report.fulfilled).toBe(true);
       done();
     });

--- a/src/redux/actions/platformActions.js
+++ b/src/redux/actions/platformActions.js
@@ -6,13 +6,12 @@ const initializeChrome = () => ({
   payload: platformServices.initializeChrome()
 });
 
-const onNavigation = callback => ({
-  type: platformTypes.PLATFORM_ON_NAV,
-  payload: platformServices.onNavigation(callback),
-  meta: {
-    data: { callback }
-  }
-});
+const onNavigation = callback => dispatch => {
+  dispatch({
+    type: platformTypes.PLATFORM_ON_NAV
+  });
+  return platformServices.onNavigation(callback);
+};
 
 const setAppName = name => ({
   type: platformTypes.PLATFORM_APP_NAME,
@@ -22,11 +21,12 @@ const setAppName = name => ({
   }
 });
 
-const setNavigation = data => ({
-  type: platformTypes.PLATFORM_SET_NAV,
-  payload: platformServices.setNavigation(data),
-  meta: { data }
-});
+const setNavigation = data => dispatch => {
+  dispatch({
+    type: platformTypes.PLATFORM_SET_NAV
+  });
+  return platformServices.setNavigation(data);
+};
 
 const platformActions = { initializeChrome, onNavigation, setAppName, setNavigation };
 

--- a/src/services/__tests__/__snapshots__/platformServices.test.js.snap
+++ b/src/services/__tests__/__snapshots__/platformServices.test.js.snap
@@ -1,16 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PlatformServices should return a failed authorized user: failed authorized user 1`] = `
-Object {
-  "message": "{ getUser } = insights.chrome.auth",
-  "status": 418,
-}
-`;
+exports[`PlatformServices should return a failed getUser: failed authorized user 1`] = `[Error: { getUser } = insights.chrome.auth, insights.chrome.auth.getUser is not a function]`;
 
-exports[`PlatformServices should return a successful authorized user: success authorized user 1`] = `
+exports[`PlatformServices should return a successful getUser with a specific response: specific success for authorized user 1`] = `"lorem ipsum"`;
+
+exports[`PlatformServices should return a successful getUser: success authorized user 1`] = `
 Object {
-  "data": "lorem ipsum",
-  "message": "{ getUser } = insights.chrome.auth",
-  "status": 200,
+  "identity": Object {
+    "account_number": "0",
+    "type": "User",
+  },
 }
 `;

--- a/src/services/__tests__/__snapshots__/userServices.test.js.snap
+++ b/src/services/__tests__/__snapshots__/userServices.test.js.snap
@@ -1,11 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`UserServices should return a failed authorized user: failed authorized user 1`] = `
+Object {
+  "message": "{ getUser } = insights.chrome.auth, insights.chrome.auth.getUser is not a function",
+  "status": 418,
+}
+`;
+
 exports[`UserServices should return a specific locale cookie value 1`] = `
 Object {
   "data": Object {
     "key": "English",
     "value": "en-US",
   },
+}
+`;
+
+exports[`UserServices should return a successful authorized user: success authorized user 1`] = `
+Object {
+  "data": Object {
+    "identity": Object {
+      "account_number": "0",
+      "type": "User",
+    },
+  },
+  "message": "{ getUser } = insights.chrome.auth",
+  "status": 200,
 }
 `;
 

--- a/src/services/__tests__/platformServices.test.js
+++ b/src/services/__tests__/platformServices.test.js
@@ -1,19 +1,6 @@
-import { helpers } from '../../common';
 import platformServices from '../platformServices';
 
 describe('PlatformServices', () => {
-  beforeAll(() => {
-    window.insights = {
-      chrome: {
-        auth: helpers.noop,
-        identifyApp: helpers.noop,
-        init: helpers.noop,
-        navigation: helpers.noop,
-        on: helpers.noop
-      }
-    };
-  });
-
   it('should export a specific number of methods and classes', () => {
     expect(Object.keys(platformServices)).toHaveLength(5);
   });
@@ -28,9 +15,9 @@ describe('PlatformServices', () => {
 
   /**
    *  timeout errors associated with this test sometimes stem from endpoint
-   *  settings or missing globals, see "before" above
+   *  settings or missing globals, see "before" above, or the "setupTests" config
    */
-  it('should return promises for every method', done => {
+  it('should return async for most methods and resolve successfully', done => {
     const promises = Object.keys(platformServices).map(value => platformServices[value]());
 
     Promise.all(promises).then(success => {
@@ -39,17 +26,24 @@ describe('PlatformServices', () => {
     });
   });
 
-  it('should return a successful authorized user', done => {
-    window.insights.chrome.auth.getUser = jest.fn().mockImplementation(() => Promise.resolve('lorem ipsum'));
-
+  it('should return a successful getUser', done => {
     platformServices.getUser().then(value => {
       expect(value).toMatchSnapshot('success authorized user');
       done();
     });
   });
 
-  it('should return a failed authorized user', done => {
-    window.insights.chrome.auth.getUser = jest.fn().mockImplementation(() => undefined);
+  it('should return a successful getUser with a specific response', done => {
+    window.insights.chrome.auth.getUser = jest.fn().mockImplementation(() => Promise.resolve('lorem ipsum'));
+
+    platformServices.getUser().then(value => {
+      expect(value).toMatchSnapshot('specific success for authorized user');
+      done();
+    });
+  });
+
+  it('should return a failed getUser', done => {
+    window.insights.chrome.auth.getUser = undefined;
 
     platformServices.getUser().catch(error => {
       expect(error).toMatchSnapshot('failed authorized user');

--- a/src/services/__tests__/rhsmServices.test.js
+++ b/src/services/__tests__/rhsmServices.test.js
@@ -28,7 +28,7 @@ describe('RhsmServices', () => {
 
   /**
    *  timeout errors associated with this test sometimes stem from endpoint
-   *  settings or missing globals, see "before" above
+   *  settings or missing globals, see "before" above, or the "setupTests" config
    */
   it('should return promises for every method', done => {
     const promises = Object.keys(rhsmServices).map(value => rhsmServices[value]());

--- a/src/services/__tests__/userServices.test.js
+++ b/src/services/__tests__/userServices.test.js
@@ -14,7 +14,7 @@ describe('UserServices', () => {
 
   /**
    *  timeout errors associated with this test sometimes stem from endpoint
-   *  settings or missing globals, see "before" above
+   *  settings or missing globals, see "before" above, or the "setupTests" config
    */
   it('should return promises for every method', done => {
     const promises = Object.keys(userServices).map(value => userServices[value]());
@@ -44,6 +44,22 @@ describe('UserServices', () => {
     Cookies.get = jest.fn().mockImplementation(() => 'test_US');
     userServices.getLocale().then(locale => {
       expect(locale).toMatchSnapshot();
+      done();
+    });
+  });
+
+  it('should return a successful authorized user', done => {
+    userServices.authorizeUser().then(value => {
+      expect(value).toMatchSnapshot('success authorized user');
+      done();
+    });
+  });
+
+  it('should return a failed authorized user', done => {
+    window.insights.chrome.auth.getUser = undefined;
+
+    userServices.authorizeUser().catch(error => {
+      expect(error).toMatchSnapshot('failed authorized user');
       done();
     });
   });

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { userServices } from './userServices';
+import { platformServices } from './platformServices';
 
 const serviceConfig = (passedConfig = {}) => ({
   headers: {},
@@ -8,7 +8,7 @@ const serviceConfig = (passedConfig = {}) => ({
 });
 
 const serviceCall = async config => {
-  await userServices.authorizeUser();
+  await platformServices.getUser();
   return axios(serviceConfig(config));
 };
 

--- a/src/services/userServices.js
+++ b/src/services/userServices.js
@@ -1,6 +1,29 @@
 import Cookies from 'js-cookie';
 import LocaleCode from 'locale-code';
-import { getUser as authorizeUser } from './platformServices';
+import { getUser } from './platformServices';
+
+const authorizeUser = async () => {
+  let message = '{ getUser } = insights.chrome.auth';
+  let userData;
+
+  try {
+    userData = await getUser();
+  } catch (e) {
+    message = e.message;
+  }
+
+  if (userData) {
+    return Promise.resolve({ data: userData, message, status: 200 });
+  }
+
+  const emulatedErrorResponse = {
+    ...new Error(message),
+    message,
+    status: 418
+  };
+
+  return Promise.reject(emulatedErrorResponse);
+};
 
 const getLocaleFromCookie = () => {
   const value = (Cookies.get(process.env.REACT_APP_CONFIG_SERVICE_LOCALES_COOKIE) || '').replace('_', '-');

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,6 +3,26 @@ import Adapter from 'enzyme-adapter-react-16';
 
 configure({ adapter: new Adapter() });
 
+global.window.insights = {
+  chrome: {
+    auth: {
+      getUser: () =>
+        new Promise(resolve =>
+          resolve({
+            identity: {
+              account_number: '0',
+              type: 'User'
+            }
+          })
+        )
+    },
+    identifyApp: Function.prototype,
+    init: Function.prototype,
+    navigation: Function.prototype,
+    on: Function.prototype
+  }
+};
+
 /*
  * For applying a global Jest "beforeAll", based on
  * jest-prop-type-error, https://www.npmjs.com/package/jest-prop-type-error


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(platformServices,userServices): issues/43 centralize globals
   * build, lint promise reject errors
   * build, setupTests, apply platform global mock
   * platformServices, restructure getUser, navigation methods
   * userServices, restructure authorizeUser
   * config, use platformService instead of emulated response
   * platformActions, allow nav methods to return unlistener responses

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- Updates issue #43 based on CI/dev testing
- Applies state broadcasts within Redux for platform global method calls
- Corrects how the `setNavigation` and `onNavigation` wrappers pass `un-listeners` back
- Aligns more closely with the platform's ask regarding calling `getUser` on every API call. Part of the goal was to help avoid some of the sensitivity around the modal redirect. 
   - @jeperry per discussion

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm you can:
   - log in and navigate to the Subs Watch `rhel-sw/all` route
   - navigate between products in the left hand menu
   - the only potential error should be around assigning the `app name` (this involves updating "the source of truth to resolve")
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Updates #43 