### PR TITLE
fix(graphCardSelectors): issues/176 graph error blur

### DIFF
--- a/src/components/graphCard/__tests__/__snapshots__/graphCard.test.js.snap
+++ b/src/components/graphCard/__tests__/__snapshots__/graphCard.test.js.snap
@@ -49,6 +49,7 @@ exports[`GraphCard Component should render a non-connected component: non-connec
         dataSets={Array []}
         domain={Object {}}
         height={275}
+        key="generatedid-"
         padding={
           Object {
             "bottom": 75,
@@ -186,6 +187,7 @@ exports[`GraphCard Component should render multiple states: error with 403 statu
         }
         domain={Object {}}
         height={275}
+        key="generatedid-"
         padding={
           Object {
             "bottom": 75,
@@ -287,6 +289,7 @@ exports[`GraphCard Component should render multiple states: error with 500 statu
         }
         domain={Object {}}
         height={275}
+        key="generatedid-"
         padding={
           Object {
             "bottom": 75,
@@ -388,6 +391,7 @@ exports[`GraphCard Component should render multiple states: fulfilled 1`] = `
         }
         domain={Object {}}
         height={275}
+        key="generatedid-"
         padding={
           Object {
             "bottom": 75,

--- a/src/components/graphCard/graphCard.js
+++ b/src/components/graphCard/graphCard.js
@@ -114,8 +114,7 @@ class GraphCard extends React.Component {
 
       return Object.keys(data).map(key => filtered(key));
     };
-
-    return <ChartArea {...chartAreaProps} dataSets={filteredGraphData(graphData)} />;
+    return <ChartArea key={helpers.generateId()} {...chartAreaProps} dataSets={filteredGraphData(graphData)} />;
   }
 
   // ToDo: combine "curiosity-skeleton-container" into a single class w/ --loading and BEM style

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -30,8 +30,8 @@ msgstr \\"\\"
 msgid \\"curiosity-graph.dropdownMonthly\\"
 msgstr \\"\\"
 
-#: src/components/graphCard/graphCard.js:132
-#: src/components/graphCard/graphCard.js:136
+#: src/components/graphCard/graphCard.js:131
+#: src/components/graphCard/graphCard.js:135
 msgid \\"curiosity-graph.dropdownPlaceholder\\"
 msgstr \\"\\"
 

--- a/src/redux/selectors/__tests__/__snapshots__/graphCardSelectors.test.js.snap
+++ b/src/redux/selectors/__tests__/__snapshots__/graphCardSelectors.test.js.snap
@@ -210,7 +210,68 @@ Object {
 }
 `;
 
-exports[`GraphCardSelectors should pass data through on a product ID when granularity provided mismatches between aggregated responses: rhelGraphCard: granularity mismatch fulfilled 1`] = `
+exports[`GraphCardSelectors should pass data through on a product ID when granularity provided mismatches between aggregated responses: rhelGraphCard: granularity mismatch on API 1`] = `
+Object {
+  "error": false,
+  "errorStatus": null,
+  "fulfilled": true,
+  "graphData": Object {
+    "cores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 2,
+      },
+    ],
+    "hypervisorCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 1,
+      },
+    ],
+    "hypervisorSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 1,
+      },
+    ],
+    "physicalCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 1,
+      },
+    ],
+    "physicalSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 1,
+      },
+    ],
+    "sockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 2,
+      },
+    ],
+    "threshold": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 100,
+      },
+    ],
+  },
+  "initialLoad": false,
+  "pending": false,
+}
+`;
+
+exports[`GraphCardSelectors should pass data through on a product ID when granularity provided mismatches between aggregated responses: rhelGraphCard: granularity mismatch on API fulfilled 1`] = `
 Object {
   "error": true,
   "errorStatus": null,
@@ -229,7 +290,148 @@ Object {
 }
 `;
 
-exports[`GraphCardSelectors should pass data through on a product ID when granularity provided mismatches between aggregated responses: rhelGraphCard: granularity mismatch on component 1`] = `
+exports[`GraphCardSelectors should populate data from the in memory cache: granularity cached data: ERROR, no component, report and capacity mismatch 1`] = `
+Object {
+  "error": true,
+  "errorStatus": null,
+  "fulfilled": false,
+  "graphData": Object {
+    "cores": Array [],
+    "hypervisorCores": Array [],
+    "hypervisorSockets": Array [],
+    "physicalCores": Array [],
+    "physicalSockets": Array [],
+    "sockets": Array [],
+    "threshold": Array [],
+  },
+  "initialLoad": true,
+  "pending": false,
+}
+`;
+
+exports[`GraphCardSelectors should populate data from the in memory cache: granularity cached data: cached data 1`] = `
+Object {
+  "error": false,
+  "errorStatus": null,
+  "fulfilled": true,
+  "graphData": Object {
+    "cores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 2,
+      },
+    ],
+    "hypervisorCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 1,
+      },
+    ],
+    "hypervisorSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 1,
+      },
+    ],
+    "physicalCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 1,
+      },
+    ],
+    "physicalSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 1,
+      },
+    ],
+    "sockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 2,
+      },
+    ],
+    "threshold": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 100,
+      },
+    ],
+  },
+  "initialLoad": false,
+  "pending": false,
+}
+`;
+
+exports[`GraphCardSelectors should populate data from the in memory cache: granularity cached data: component and capacity match 1`] = `
+Object {
+  "error": false,
+  "errorStatus": null,
+  "fulfilled": true,
+  "graphData": Object {
+    "cores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 2,
+      },
+    ],
+    "hypervisorCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 1,
+      },
+    ],
+    "hypervisorSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 1,
+      },
+    ],
+    "physicalCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 1,
+      },
+    ],
+    "physicalSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 1,
+      },
+    ],
+    "sockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 2,
+      },
+    ],
+    "threshold": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 100,
+      },
+    ],
+  },
+  "initialLoad": false,
+  "pending": false,
+}
+`;
+
+exports[`GraphCardSelectors should populate data from the in memory cache: granularity cached data: component and report match 1`] = `
 Object {
   "error": false,
   "errorStatus": null,

--- a/src/redux/selectors/__tests__/graphCardSelectors.test.js
+++ b/src/redux/selectors/__tests__/graphCardSelectors.test.js
@@ -19,7 +19,7 @@ describe('GraphCardSelectors', () => {
         capacity: {
           fulfilled: true,
           metaData: {
-            id: 'Lorem Ipsum'
+            id: 'Lorem Ipsum ID missing granularity'
           },
           metaQuery: {},
           data: { [rhsmApiTypes.RHSM_API_RESPONSE_CAPACITY_DATA]: [] }
@@ -27,7 +27,7 @@ describe('GraphCardSelectors', () => {
         report: {
           fulfilled: true,
           metaData: {
-            id: 'Lorem Ipsum'
+            id: 'Lorem Ipsum ID missing granularity'
           },
           metaQuery: {},
           data: { [rhsmApiTypes.RHSM_API_RESPONSE_PRODUCTS_DATA]: [] }
@@ -71,7 +71,7 @@ describe('GraphCardSelectors', () => {
         capacity: {
           fulfilled: true,
           metaData: {
-            id: 'Lorem Ipsum'
+            id: 'Lorem Ipsum ID pending state'
           },
           metaQuery: {
             [rhsmApiTypes.RHSM_API_QUERY_GRANULARITY]: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
@@ -81,7 +81,7 @@ describe('GraphCardSelectors', () => {
         report: {
           pending: true,
           metaData: {
-            id: 'Lorem Ipsum'
+            id: 'Lorem Ipsum ID pending state'
           },
           metaQuery: {
             [rhsmApiTypes.RHSM_API_QUERY_GRANULARITY]: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
@@ -101,7 +101,7 @@ describe('GraphCardSelectors', () => {
         capacity: {
           fulfilled: true,
           metaData: {
-            id: 'Lorem Ipsum'
+            id: 'Lorem Ipsum mismatched granularity'
           },
           metaQuery: {
             [rhsmApiTypes.RHSM_API_QUERY_GRANULARITY]: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.MONTHLY
@@ -120,7 +120,7 @@ describe('GraphCardSelectors', () => {
         report: {
           fulfilled: true,
           metaData: {
-            id: 'Lorem Ipsum'
+            id: 'Lorem Ipsum mismatched granularity'
           },
           metaQuery: {
             [rhsmApiTypes.RHSM_API_QUERY_GRANULARITY]: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
@@ -142,7 +142,7 @@ describe('GraphCardSelectors', () => {
       }
     };
 
-    expect(graphCardSelectors.graphCard(state)).toMatchSnapshot('rhelGraphCard: granularity mismatch fulfilled');
+    expect(graphCardSelectors.graphCard(state)).toMatchSnapshot('rhelGraphCard: granularity mismatch on API fulfilled');
 
     expect(
       graphCardSelectors.graphCard({
@@ -158,7 +158,7 @@ describe('GraphCardSelectors', () => {
           }
         }
       })
-    ).toMatchSnapshot('rhelGraphCard: granularity mismatch on component');
+    ).toMatchSnapshot('rhelGraphCard: granularity mismatch on API');
   });
 
   it('should populate data on a product ID when the api response provided mismatches index or date', () => {
@@ -171,7 +171,7 @@ describe('GraphCardSelectors', () => {
         capacity: {
           fulfilled: true,
           metaData: {
-            id: 'Lorem Ipsum'
+            id: 'Lorem Ipsum mismatched index or date'
           },
           metaQuery: {
             [rhsmApiTypes.RHSM_API_QUERY_GRANULARITY]: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
@@ -181,7 +181,7 @@ describe('GraphCardSelectors', () => {
         report: {
           fulfilled: true,
           metaData: {
-            id: 'Lorem Ipsum'
+            id: 'Lorem Ipsum mismatched index or date'
           },
           metaQuery: {
             [rhsmApiTypes.RHSM_API_QUERY_GRANULARITY]: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
@@ -216,7 +216,7 @@ describe('GraphCardSelectors', () => {
         capacity: {
           fulfilled: true,
           metaData: {
-            id: 'Lorem Ipsum'
+            id: 'Lorem Ipsum missing expected properties'
           },
           metaQuery: {
             [rhsmApiTypes.RHSM_API_QUERY_GRANULARITY]: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
@@ -247,7 +247,7 @@ describe('GraphCardSelectors', () => {
         report: {
           fulfilled: true,
           metaData: {
-            id: 'Lorem Ipsum'
+            id: 'Lorem Ipsum missing expected properties'
           },
           metaQuery: {
             [rhsmApiTypes.RHSM_API_QUERY_GRANULARITY]: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
@@ -288,7 +288,7 @@ describe('GraphCardSelectors', () => {
         capacity: {
           fulfilled: true,
           metaData: {
-            id: 'Lorem Ipsum'
+            id: 'Lorem Ipsum fulfilled aggregated output'
           },
           metaQuery: {
             [rhsmApiTypes.RHSM_API_QUERY_GRANULARITY]: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
@@ -319,7 +319,7 @@ describe('GraphCardSelectors', () => {
         report: {
           fulfilled: true,
           metaData: {
-            id: 'Lorem Ipsum'
+            id: 'Lorem Ipsum fulfilled aggregated output'
           },
           metaQuery: {
             [rhsmApiTypes.RHSM_API_QUERY_GRANULARITY]: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
@@ -360,5 +360,136 @@ describe('GraphCardSelectors', () => {
     };
 
     expect(graphCardSelectors.graphCard(state)).toMatchSnapshot('rhelGraphCard: fulfilled granularity');
+  });
+
+  it('should populate data from the in memory cache', () => {
+    const stateDailyGranularityFulfilled = {
+      graph: {
+        component: {},
+        capacity: {
+          fulfilled: true,
+          metaData: {
+            id: 'Lorem Ipsum ID cached'
+          },
+          metaQuery: {
+            [rhsmApiTypes.RHSM_API_QUERY_GRANULARITY]: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
+          },
+          data: {
+            [rhsmApiTypes.RHSM_API_RESPONSE_CAPACITY_DATA]: [
+              {
+                [rhsmApiTypes.RHSM_API_RESPONSE_CAPACITY_DATA_TYPES.DATE]: '2019-09-04T00:00:00.000Z',
+                [rhsmApiTypes.RHSM_API_RESPONSE_CAPACITY_DATA_TYPES.SOCKETS]: 100,
+                [rhsmApiTypes.RHSM_API_RESPONSE_CAPACITY_DATA_TYPES.HYPERVISOR_SOCKETS]: 50,
+                [rhsmApiTypes.RHSM_API_RESPONSE_CAPACITY_DATA_TYPES.PHYSICAL_SOCKETS]: 50
+              }
+            ]
+          }
+        },
+        report: {
+          fulfilled: true,
+          metaData: {
+            id: 'Lorem Ipsum ID cached'
+          },
+          metaQuery: {
+            [rhsmApiTypes.RHSM_API_QUERY_GRANULARITY]: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
+          },
+          data: {
+            [rhsmApiTypes.RHSM_API_RESPONSE_PRODUCTS_DATA]: [
+              {
+                [rhsmApiTypes.RHSM_API_RESPONSE_PRODUCTS_DATA_TYPES.DATE]: '2019-09-04T00:00:00.000Z',
+                [rhsmApiTypes.RHSM_API_RESPONSE_PRODUCTS_DATA_TYPES.CORES]: 2,
+                [rhsmApiTypes.RHSM_API_RESPONSE_PRODUCTS_DATA_TYPES.SOCKETS]: 2,
+                [rhsmApiTypes.RHSM_API_RESPONSE_PRODUCTS_DATA_TYPES.HYPERVISOR_CORES]: 1,
+                [rhsmApiTypes.RHSM_API_RESPONSE_PRODUCTS_DATA_TYPES.HYPERVISOR_SOCKETS]: 1,
+                [rhsmApiTypes.RHSM_API_RESPONSE_PRODUCTS_DATA_TYPES.PHYSICAL_CORES]: 1,
+                [rhsmApiTypes.RHSM_API_RESPONSE_PRODUCTS_DATA_TYPES.PHYSICAL_SOCKETS]: 1
+              }
+            ]
+          }
+        }
+      }
+    };
+
+    graphCardSelectors.graphCard(stateDailyGranularityFulfilled);
+
+    const stateDailyGranularityPending = {
+      graph: {
+        component: {},
+        capacity: {
+          ...stateDailyGranularityFulfilled.graph.capacity,
+          pending: true
+        },
+        report: {
+          ...stateDailyGranularityFulfilled.graph.report,
+          pending: true
+        }
+      }
+    };
+
+    expect(graphCardSelectors.graphCard(stateDailyGranularityPending)).toMatchSnapshot(
+      'granularity cached data: cached data'
+    );
+
+    const stateDailyComponentCapacityGranularity = {
+      component: {
+        graphGranularity: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
+      },
+      graph: {
+        component: {},
+        capacity: {
+          ...stateDailyGranularityFulfilled.graph.capacity,
+          fulfilled: true
+        },
+        report: {
+          ...stateDailyGranularityFulfilled.graph.report,
+          pending: true
+        }
+      }
+    };
+
+    expect(graphCardSelectors.graphCard(stateDailyComponentCapacityGranularity)).toMatchSnapshot(
+      'granularity cached data: component and capacity match'
+    );
+
+    const stateDailyComponentReportGranularity = {
+      component: {
+        graphGranularity: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
+      },
+      graph: {
+        component: {},
+        capacity: {
+          ...stateDailyGranularityFulfilled.graph.capacity,
+          pending: true
+        },
+        report: {
+          ...stateDailyGranularityFulfilled.graph.report,
+          fulfilled: true
+        }
+      }
+    };
+
+    expect(graphCardSelectors.graphCard(stateDailyComponentReportGranularity)).toMatchSnapshot(
+      'granularity cached data: component and report match'
+    );
+
+    const stateDailyReportCapacityGranularityMismatch = {
+      component: {},
+      graph: {
+        component: {},
+        capacity: {
+          ...stateDailyGranularityFulfilled.graph.capacity,
+          metaQuery: {
+            [rhsmApiTypes.RHSM_API_QUERY_GRANULARITY]: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.WEEKLY
+          }
+        },
+        report: {
+          ...stateDailyGranularityFulfilled.graph.report
+        }
+      }
+    };
+
+    expect(graphCardSelectors.graphCard(stateDailyReportCapacityGranularityMismatch)).toMatchSnapshot(
+      'granularity cached data: ERROR, no component, report and capacity mismatch'
+    );
   });
 });

--- a/src/redux/selectors/graphCardSelectors.js
+++ b/src/redux/selectors/graphCardSelectors.js
@@ -18,18 +18,13 @@ const graphCardSelector = createSelector(
     const reportProductId = _get(report, ['metaData', 'id'], null);
     const capacityProductId = _get(capacity, ['metaData', 'id'], null);
 
-    let productId = null;
+    const productId = (reportProductId === capacityProductId && reportProductId) || null;
     let granularity = null;
 
-    if (
-      (graphGranularity && graphGranularity === reportGranularity && graphGranularity === capacityGranularity) ||
-      (!graphGranularity && reportGranularity === capacityGranularity)
-    ) {
+    if (graphGranularity === reportGranularity || reportGranularity === capacityGranularity) {
       granularity = reportGranularity;
-    }
-
-    if (reportProductId === capacityProductId) {
-      productId = reportProductId;
+    } else if (graphGranularity === capacityGranularity) {
+      granularity = capacityGranularity;
     }
 
     const cachedGranularity = (granularity && productId && graphCardCache[`${productId}_${granularity}`]) || {};


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(graphCardSelectors): issues/176 graph error blur
   * graphCardSelectors, granularity check against api response times
   * graphCard, apply key to aid reload, i18n snapshot

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- Appears a selector check and API response times fill out the other part of #176 
   - Prior to this fix the error blur would appear when making the granularity switch quickly. We tried a resolution around certain redirect/authentication scenarios (#184 ) but this currently has the appearance of playing a minor part.
   - The fallback check for catching said error is still in place. The condition check for applying granularity from multiple sources has been updated to make more of an allowance for variation in API response times and focus on helping push the cached version of the response out instead of an immediate error response.
   - Based on the current fixes the appearance of the majority of underlying issues stems from simple race conditions around async setup. The global platform method, combined with weaving/aggregating the RHSM API responses occasionally get out of sync when actions are taken quickly. Hence the fallback error check that was placed in our `graphCardSelectors` was performing its roll and responding with an error.
- This highlights the need to either head back towards a `Promise.all` or investigate a resource, such as Apollo GraphQL, to aid in aggregating multiple REST API calls.
      - `Promise.all` solution... https://github.com/RedHatInsights/curiosity-frontend/commit/0b596847550b43449e7100722dbdcb5a384d384d


## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. select a granularity, then select another granularity from the dropdown/select. each granularity type should now be cached...
1. now quickly use the dropdown/select to jump back and forth multiple times between the granularity... take note of
   - the x axis ticks should reflect the granularity accordingly
   - the data displayed should also reflect the granularity
   - the blur display should now fire only in scenarios where there is no cache available while switching quickly. 

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Updates #176 
Relates #185 