### PR TITLE
fix(graphCardSelectors): issues/185 apply response schemas

### DIFF
--- a/src/components/chartArea/chartArea.js
+++ b/src/components/chartArea/chartArea.js
@@ -377,7 +377,7 @@ ChartArea.propTypes = {
       data: PropTypes.arrayOf(
         PropTypes.shape({
           x: PropTypes.number.isRequired,
-          y: PropTypes.number.isRequired,
+          y: PropTypes.number,
           tooltip: PropTypes.string,
           xAxisLabel: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.instanceOf(Date)])
         })

--- a/src/components/graphCard/__tests__/__snapshots__/graphCardHelpers.test.js.snap
+++ b/src/components/graphCard/__tests__/__snapshots__/graphCardHelpers.test.js.snap
@@ -20,19 +20,19 @@ Object {
 
 exports[`GraphCardHelpers getTooltips should return a formatted tooltip based on data and granularity: granularity data display 1`] = `
 Object {
-  "daily": "t(curiosity-graph.thresholdLabel, [object Object]): 100
+  "daily": "t(curiosity-graph.thresholdLabel): 100
 t(curiosity-graph.hypervisorSocketsLabel, [object Object]): 50
 t(curiosity-graph.physicalSocketsLabel, [object Object]): 50
 t(curiosity-graph.dateLabel): June 1",
-  "monthly": "t(curiosity-graph.thresholdLabel, [object Object]): 100
+  "monthly": "t(curiosity-graph.thresholdLabel): 100
 t(curiosity-graph.hypervisorSocketsLabel, [object Object]): 50
 t(curiosity-graph.physicalSocketsLabel, [object Object]): 50
 t(curiosity-graph.dateLabel): June 2019",
-  "quarterly": "t(curiosity-graph.thresholdLabel, [object Object]): 100
+  "quarterly": "t(curiosity-graph.thresholdLabel): 100
 t(curiosity-graph.hypervisorSocketsLabel, [object Object]): 50
 t(curiosity-graph.physicalSocketsLabel, [object Object]): 50
 t(curiosity-graph.dateLabel): June 2019",
-  "weekly": "t(curiosity-graph.thresholdLabel, [object Object]): 100
+  "weekly": "t(curiosity-graph.thresholdLabel): 100
 t(curiosity-graph.hypervisorSocketsLabel, [object Object]): 50
 t(curiosity-graph.physicalSocketsLabel, [object Object]): 50
 t(curiosity-graph.dateLabel): June 1",

--- a/src/components/graphCard/graphCard.js
+++ b/src/components/graphCard/graphCard.js
@@ -96,12 +96,11 @@ class GraphCard extends React.Component {
             duration: 250,
             onLoad: { duration: 250 }
           },
-          legendLabel: t(`curiosity-graph.${key}Label`, { product: productShortLabel }),
-          isStacked: key !== 'threshold',
-          isThreshold: key === 'threshold'
+          isStacked: !/^threshold/.test(key),
+          isThreshold: /^threshold/.test(key)
         };
 
-        if (key === 'threshold') {
+        if (/^threshold/.test(key)) {
           tempFiltered.animate = {
             duration: 100,
             onLoad: { duration: 100 }
@@ -110,6 +109,9 @@ class GraphCard extends React.Component {
           tempFiltered.stroke = chartColorGreenDark.value;
           tempFiltered.strokeDasharray = '4,3';
           tempFiltered.strokeWidth = 2.5;
+          tempFiltered.legendLabel = t(`curiosity-graph.thresholdLabel`);
+        } else {
+          tempFiltered.legendLabel = t(`curiosity-graph.${key}Label`, { product: productShortLabel });
         }
 
         return tempFiltered;
@@ -125,7 +127,6 @@ class GraphCard extends React.Component {
     return <ChartArea key={helpers.generateId()} {...chartAreaProps} dataSets={filteredGraphData(graphData)} />;
   }
 
-  // ToDo: combine "curiosity-skeleton-container" into a single class w/ --loading and BEM style
   render() {
     const { cardTitle, error, graphGranularity, selectOptionsType, pending, t } = this.props;
     const { options } = graphCardTypes.getGranularityOptions(selectOptionsType);

--- a/src/components/graphCard/graphCardHelpers.js
+++ b/src/components/graphCard/graphCardHelpers.js
@@ -77,8 +77,8 @@ const getTooltips = ({ itemsByKey, granularity, product = '' }) => {
     }
 
     if (itemsByKey[key].y) {
-      if (key === 'threshold') {
-        thresholdString = `${translate(`curiosity-graph.${key}Label`, { product })}: ${itemsByKey[key].y}\n`;
+      if (/^threshold/.test(key)) {
+        thresholdString = `${translate(`curiosity-graph.thresholdLabel`)}: ${itemsByKey[key].y}\n`;
       } else {
         dataFacets.push(`${translate(`curiosity-graph.${key}Label`, { product })}: ${itemsByKey[key].y}\n`);
       }

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -30,8 +30,8 @@ msgstr \\"\\"
 msgid \\"curiosity-graph.dropdownMonthly\\"
 msgstr \\"\\"
 
-#: src/components/graphCard/graphCard.js:139
-#: src/components/graphCard/graphCard.js:143
+#: src/components/graphCard/graphCard.js:140
+#: src/components/graphCard/graphCard.js:144
 msgid \\"curiosity-graph.dropdownPlaceholder\\"
 msgstr \\"\\"
 
@@ -49,6 +49,11 @@ msgstr \\"\\"
 
 #: src/components/rhelView/rhelView.js:35
 msgid \\"curiosity-graph.socketsHeading\\"
+msgstr \\"\\"
+
+#: src/components/graphCard/graphCard.js:112
+#: src/components/graphCard/graphCardHelpers.js:81
+msgid \\"curiosity-graph.thresholdLabel\\"
 msgstr \\"\\"
 
 #: src/components/tourView/tourView.js:50

--- a/src/components/openshiftView/__tests__/__snapshots__/openshiftView.test.js.snap
+++ b/src/components/openshiftView/__tests__/__snapshots__/openshiftView.test.js.snap
@@ -16,7 +16,7 @@ exports[`OpenshiftView Component should have a fallback title: title 1`] = `
             "stroke": "#06c",
           },
           Object {
-            "id": "threshold",
+            "id": "thresholdCores",
           },
         ]
       }
@@ -45,7 +45,7 @@ exports[`OpenshiftView Component should render a non-connected component: non-co
             "stroke": "#06c",
           },
           Object {
-            "id": "threshold",
+            "id": "thresholdCores",
           },
         ]
       }

--- a/src/components/openshiftView/openshiftView.js
+++ b/src/components/openshiftView/openshiftView.js
@@ -25,7 +25,7 @@ class OpenshiftView extends React.Component {
             key={routeDetail.pathParameter}
             filterGraphData={[
               { id: 'cores', fill: chartColorBlueLight.value, stroke: chartColorBlueDark.value },
-              { id: 'threshold' }
+              { id: 'thresholdCores' }
             ]}
             productId={routeDetail.pathParameter}
             viewId={routeDetail.pathId}

--- a/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
+++ b/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
@@ -21,7 +21,7 @@ exports[`RhelView Component should have a fallback title: title 1`] = `
             "stroke": "#009596",
           },
           Object {
-            "id": "threshold",
+            "id": "thresholdSockets",
           },
         ]
       }
@@ -55,7 +55,7 @@ exports[`RhelView Component should render a non-connected component: non-connect
             "stroke": "#009596",
           },
           Object {
-            "id": "threshold",
+            "id": "thresholdSockets",
           },
         ]
       }

--- a/src/components/rhelView/rhelView.js
+++ b/src/components/rhelView/rhelView.js
@@ -7,8 +7,8 @@ import {
   chart_color_cyan_100 as chartColorCyanLight,
   chart_color_cyan_300 as chartColorCyanDark
 } from '@patternfly/react-tokens';
-import GraphCard from '../graphCard/graphCard';
 import { PageLayout, PageHeader, PageSection } from '../pageLayout/pageLayout';
+import GraphCard from '../graphCard/graphCard';
 import { helpers } from '../../common';
 
 class RhelView extends React.Component {
@@ -28,7 +28,7 @@ class RhelView extends React.Component {
             filterGraphData={[
               { id: 'physicalSockets', fill: chartColorBlueLight.value, stroke: chartColorBlueDark.value },
               { id: 'hypervisorSockets', fill: chartColorCyanLight.value, stroke: chartColorCyanDark.value },
-              { id: 'threshold' }
+              { id: 'thresholdSockets' }
             ]}
             productId={routeDetail.pathParameter}
             viewId={routeDetail.pathId}

--- a/src/redux/selectors/__tests__/__snapshots__/graphCardSelectors.test.js.snap
+++ b/src/redux/selectors/__tests__/__snapshots__/graphCardSelectors.test.js.snap
@@ -2,27 +2,20 @@
 
 exports[`GraphCardSelectors should handle pending state on a product ID: graphCard: pending 1`] = `
 Object {
-  "error": undefined,
+  "error": false,
   "errorStatus": undefined,
-  "fulfilled": undefined,
-  "graphData": Object {
-    "cores": Array [],
-    "hypervisorCores": Array [],
-    "hypervisorSockets": Array [],
-    "physicalCores": Array [],
-    "physicalSockets": Array [],
-    "sockets": Array [],
-    "threshold": Array [],
-  },
+  "fulfilled": false,
+  "graphData": Object {},
   "graphGranularity": "daily",
   "initialLoad": true,
   "pending": true,
+  "syncing": false,
 }
 `;
 
 exports[`GraphCardSelectors should map a fulfilled product ID response to an aggregated output: graphCard: fulfilled granularity 1`] = `
 Object {
-  "error": undefined,
+  "error": false,
   "errorStatus": undefined,
   "fulfilled": true,
   "graphData": Object {
@@ -41,6 +34,40 @@ Object {
         "date": 2019-09-06T00:00:00.000Z,
         "x": 2,
         "y": 4,
+      },
+    ],
+    "date": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": "2019-09-04T00:00:00.000Z",
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": "2019-09-05T00:00:00.000Z",
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": "2019-09-06T00:00:00.000Z",
+      },
+    ],
+    "hasData": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": 0,
       },
     ],
     "hypervisorCores": Array [
@@ -128,7 +155,126 @@ Object {
         "y": 4,
       },
     ],
-    "threshold": Array [
+    "thresholdCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": 0,
+      },
+    ],
+    "thresholdDate": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": "2019-09-04T00:00:00.000Z",
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": "2019-09-05T00:00:00.000Z",
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": "2019-09-06T00:00:00.000Z",
+      },
+    ],
+    "thresholdHasInfiniteQuantity": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": 0,
+      },
+    ],
+    "thresholdHypervisorCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": 0,
+      },
+    ],
+    "thresholdHypervisorSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 50,
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": 50,
+      },
+    ],
+    "thresholdPhysicalCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": 0,
+      },
+    ],
+    "thresholdPhysicalSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 50,
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": 50,
+      },
+    ],
+    "thresholdSockets": Array [
       Object {
         "date": 2019-09-04T00:00:00.000Z,
         "x": 0,
@@ -149,69 +295,49 @@ Object {
   "graphGranularity": "daily",
   "initialLoad": false,
   "pending": false,
+  "syncing": false,
 }
 `;
 
 exports[`GraphCardSelectors should pass minimal data on a product ID without a product ID provided: graphCard: no product id error 1`] = `
 Object {
-  "error": undefined,
+  "error": false,
   "errorStatus": undefined,
-  "fulfilled": undefined,
-  "graphData": Object {
-    "cores": Array [],
-    "hypervisorCores": Array [],
-    "hypervisorSockets": Array [],
-    "physicalCores": Array [],
-    "physicalSockets": Array [],
-    "sockets": Array [],
-    "threshold": Array [],
-  },
+  "fulfilled": false,
+  "graphData": Object {},
   "initialLoad": true,
-  "pending": undefined,
+  "pending": false,
+  "syncing": false,
 }
 `;
 
 exports[`GraphCardSelectors should pass minimal data on a product ID without granularity provided: graphCard: no granularity error 1`] = `
 Object {
-  "error": undefined,
+  "error": false,
   "errorStatus": undefined,
-  "fulfilled": undefined,
-  "graphData": Object {
-    "cores": Array [],
-    "hypervisorCores": Array [],
-    "hypervisorSockets": Array [],
-    "physicalCores": Array [],
-    "physicalSockets": Array [],
-    "sockets": Array [],
-    "threshold": Array [],
-  },
+  "fulfilled": false,
+  "graphData": Object {},
   "initialLoad": true,
-  "pending": undefined,
+  "pending": false,
+  "syncing": false,
 }
 `;
 
 exports[`GraphCardSelectors should pass minimal data on missing a reducer response: graphCard: missing reducer error 1`] = `
 Object {
-  "error": undefined,
+  "error": false,
   "errorStatus": undefined,
-  "fulfilled": undefined,
-  "graphData": Object {
-    "cores": Array [],
-    "hypervisorCores": Array [],
-    "hypervisorSockets": Array [],
-    "physicalCores": Array [],
-    "physicalSockets": Array [],
-    "sockets": Array [],
-    "threshold": Array [],
-  },
+  "fulfilled": false,
+  "graphData": Object {},
   "initialLoad": true,
-  "pending": undefined,
+  "pending": false,
+  "syncing": false,
 }
 `;
 
 exports[`GraphCardSelectors should populate data from the in memory cache: granularity cached data: ERROR, no component reportCapacity mismatch 1`] = `
 Object {
-  "error": undefined,
+  "error": false,
   "errorStatus": undefined,
   "fulfilled": true,
   "graphData": Object {
@@ -220,6 +346,20 @@ Object {
         "date": 2019-09-04T00:00:00.000Z,
         "x": 0,
         "y": 2,
+      },
+    ],
+    "date": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": "2019-09-04T00:00:00.000Z",
+      },
+    ],
+    "hasData": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
       },
     ],
     "hypervisorCores": Array [
@@ -257,7 +397,56 @@ Object {
         "y": 2,
       },
     ],
-    "threshold": Array [
+    "thresholdCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdDate": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": "2019-09-04T00:00:00.000Z",
+      },
+    ],
+    "thresholdHasInfiniteQuantity": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdHypervisorCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdHypervisorSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 50,
+      },
+    ],
+    "thresholdPhysicalCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdPhysicalSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 50,
+      },
+    ],
+    "thresholdSockets": Array [
       Object {
         "date": 2019-09-04T00:00:00.000Z,
         "x": 0,
@@ -267,12 +456,13 @@ Object {
   },
   "initialLoad": false,
   "pending": false,
+  "syncing": false,
 }
 `;
 
 exports[`GraphCardSelectors should populate data from the in memory cache: granularity cached data: cached data 1`] = `
 Object {
-  "error": undefined,
+  "error": false,
   "errorStatus": undefined,
   "fulfilled": true,
   "graphData": Object {
@@ -281,6 +471,20 @@ Object {
         "date": 2019-09-04T00:00:00.000Z,
         "x": 0,
         "y": 2,
+      },
+    ],
+    "date": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": "2019-09-04T00:00:00.000Z",
+      },
+    ],
+    "hasData": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
       },
     ],
     "hypervisorCores": Array [
@@ -318,7 +522,56 @@ Object {
         "y": 2,
       },
     ],
-    "threshold": Array [
+    "thresholdCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdDate": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": "2019-09-04T00:00:00.000Z",
+      },
+    ],
+    "thresholdHasInfiniteQuantity": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdHypervisorCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdHypervisorSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 50,
+      },
+    ],
+    "thresholdPhysicalCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdPhysicalSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 50,
+      },
+    ],
+    "thresholdSockets": Array [
       Object {
         "date": 2019-09-04T00:00:00.000Z,
         "x": 0,
@@ -329,12 +582,13 @@ Object {
   "graphGranularity": "daily",
   "initialLoad": false,
   "pending": false,
+  "syncing": false,
 }
 `;
 
 exports[`GraphCardSelectors should populate data from the in memory cache: granularity cached data: component and reportCapacity match 1`] = `
 Object {
-  "error": undefined,
+  "error": false,
   "errorStatus": undefined,
   "fulfilled": true,
   "graphData": Object {
@@ -343,6 +597,20 @@ Object {
         "date": 2019-09-04T00:00:00.000Z,
         "x": 0,
         "y": 2,
+      },
+    ],
+    "date": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": "2019-09-04T00:00:00.000Z",
+      },
+    ],
+    "hasData": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
       },
     ],
     "hypervisorCores": Array [
@@ -380,7 +648,56 @@ Object {
         "y": 2,
       },
     ],
-    "threshold": Array [
+    "thresholdCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdDate": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": "2019-09-04T00:00:00.000Z",
+      },
+    ],
+    "thresholdHasInfiniteQuantity": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdHypervisorCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdHypervisorSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 50,
+      },
+    ],
+    "thresholdPhysicalCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdPhysicalSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 50,
+      },
+    ],
+    "thresholdSockets": Array [
       Object {
         "date": 2019-09-04T00:00:00.000Z,
         "x": 0,
@@ -391,16 +708,51 @@ Object {
   "graphGranularity": "daily",
   "initialLoad": false,
   "pending": false,
+  "syncing": false,
 }
 `;
 
 exports[`GraphCardSelectors should populate data on a product ID when the api response is missing expected properties: graphCard: data populated, missing properties 1`] = `
 Object {
-  "error": undefined,
+  "error": false,
   "errorStatus": undefined,
   "fulfilled": true,
   "graphData": Object {
     "cores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": 0,
+      },
+    ],
+    "date": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": "2019-09-04T00:00:00.000Z",
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": "2019-09-05T00:00:00.000Z",
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": "2019-09-06T00:00:00.000Z",
+      },
+    ],
+    "hasData": Array [
       Object {
         "date": 2019-09-04T00:00:00.000Z,
         "x": 0,
@@ -502,7 +854,126 @@ Object {
         "y": 4,
       },
     ],
-    "threshold": Array [
+    "thresholdCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": 0,
+      },
+    ],
+    "thresholdDate": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": "2019-09-04T00:00:00.000Z",
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": "2019-09-05T00:00:00.000Z",
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": "2019-09-06T00:00:00.000Z",
+      },
+    ],
+    "thresholdHasInfiniteQuantity": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": 0,
+      },
+    ],
+    "thresholdHypervisorCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": 0,
+      },
+    ],
+    "thresholdHypervisorSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 50,
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": 50,
+      },
+    ],
+    "thresholdPhysicalCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": 0,
+      },
+    ],
+    "thresholdPhysicalSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 50,
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": 50,
+      },
+    ],
+    "thresholdSockets": Array [
       Object {
         "date": 2019-09-04T00:00:00.000Z,
         "x": 0,
@@ -523,12 +994,13 @@ Object {
   "graphGranularity": "daily",
   "initialLoad": false,
   "pending": false,
+  "syncing": false,
 }
 `;
 
 exports[`GraphCardSelectors should populate data on a product ID when the api response provided mismatches index or date: graphCard: data populated on mismatch fulfilled 1`] = `
 Object {
-  "error": undefined,
+  "error": false,
   "errorStatus": undefined,
   "fulfilled": true,
   "graphData": Object {
@@ -537,6 +1009,20 @@ Object {
         "date": 2019-09-04T00:00:00.000Z,
         "x": 0,
         "y": 2,
+      },
+    ],
+    "date": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": "2019-09-04T00:00:00.000Z",
+      },
+    ],
+    "hasData": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
       },
     ],
     "hypervisorCores": Array [
@@ -574,7 +1060,56 @@ Object {
         "y": 2,
       },
     ],
-    "threshold": Array [
+    "thresholdCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdDate": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdHasInfiniteQuantity": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdHypervisorCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdHypervisorSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdPhysicalCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdPhysicalSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdSockets": Array [
       Object {
         "date": 2019-09-04T00:00:00.000Z,
         "x": 0,
@@ -585,6 +1120,7 @@ Object {
   "graphGranularity": "daily",
   "initialLoad": false,
   "pending": false,
+  "syncing": false,
 }
 `;
 


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(graphCardSelectors): issues/185 apply response schemas
   * chartArea, allow null values to bypass y-axis prop isRequired
   * graphCard, threshold locale id check
   * graphCardHelpers, threshold locale check
   * graphCardSelectors, apply schemas to generate graph data
   * openshiftView, thresholdCores filterGraphData
   * rhelView, thresholdSockets filterGraphData

### Notes 
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- No visual updates, behind the scenes
- Applies a basic API schema map, of expected properties, to the Tally/Reporting and Capacity responses.
   - Relaxed the "isRequired" prop check on the Chart component y-axis. Should allow null values to pass without generating an error

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm...
   - no errors are generated beyond the potential platform optimization, platform app name warning, and maybe a sockjs warning
   - that selecting a granularity other than `daily` then using the left hand nav to change RHEL products maintains your granularity selection

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Updates #185 