### PR TITLE
fix(userServices): issues/43 catch empty response objects

### DIFF
--- a/src/services/__tests__/__snapshots__/userServices.test.js.snap
+++ b/src/services/__tests__/__snapshots__/userServices.test.js.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`UserServices should return a failed authorized user on an unexpected response: failed authorized user: unexpected 1`] = `
+Object {
+  "message": "{ getUser } = insights.chrome.auth",
+  "status": 418,
+}
+`;
+
+exports[`UserServices should return a failed authorized user on empty response: failed authorized user: empty object 1`] = `
+Object {
+  "message": "{ getUser } = insights.chrome.auth",
+  "status": 418,
+}
+`;
+
 exports[`UserServices should return a failed authorized user: failed authorized user 1`] = `
 Object {
   "message": "{ getUser } = insights.chrome.auth, insights.chrome.auth.getUser is not a function",

--- a/src/services/__tests__/userServices.test.js
+++ b/src/services/__tests__/userServices.test.js
@@ -63,4 +63,22 @@ describe('UserServices', () => {
       done();
     });
   });
+
+  it('should return a failed authorized user on empty response', done => {
+    window.insights.chrome.auth.getUser = jest.fn().mockImplementation(() => ({}));
+
+    userServices.authorizeUser().catch(error => {
+      expect(error).toMatchSnapshot('failed authorized user: empty object');
+      done();
+    });
+  });
+
+  it('should return a failed authorized user on an unexpected response', done => {
+    window.insights.chrome.auth.getUser = jest.fn().mockImplementation(() => 'lorem ipsum');
+
+    userServices.authorizeUser().catch(error => {
+      expect(error).toMatchSnapshot('failed authorized user: unexpected');
+      done();
+    });
+  });
 });

--- a/src/services/userServices.js
+++ b/src/services/userServices.js
@@ -1,5 +1,6 @@
 import Cookies from 'js-cookie';
 import LocaleCode from 'locale-code';
+import _isPlainObject from 'lodash/isPlainObject';
 import { getUser } from './platformServices';
 
 const authorizeUser = async () => {
@@ -12,7 +13,7 @@ const authorizeUser = async () => {
     message = e.message;
   }
 
-  if (userData) {
+  if (_isPlainObject(userData) && Object.keys(userData).length) {
     return Promise.resolve({ data: userData, message, status: 200 });
   }
 


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(userServices): issues/43 catch empty response objects
   * expand generic auth response check, object and has keys

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- Catches a scenario where the original user data response check would pass a valid empty object.

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->
### Environment check
1. Log into CI/QA with a malformed user that returns an empty object response (typically associated with a lacking account number)
1. Navigate to the Subscription Watch app
1. You should be redirected towards the "Tour View"

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Updates #43 