### PR TITLE
fix(graphCardSelectors): improve sync for multiple api calls

### DIFF
--- a/src/components/graphCard/__tests__/__snapshots__/graphCard.test.js.snap
+++ b/src/components/graphCard/__tests__/__snapshots__/graphCard.test.js.snap
@@ -37,7 +37,7 @@ exports[`GraphCard Component should render a non-connected component: non-connec
           ]
         }
         placeholder="t(curiosity-graph.dropdownPlaceholder)"
-        selectedOptions={null}
+        selectedOptions="daily"
         variant="single"
       />
     </CardActions>
@@ -144,7 +144,7 @@ exports[`GraphCard Component should render multiple states: error with 403 statu
           ]
         }
         placeholder="t(curiosity-graph.dropdownPlaceholder)"
-        selectedOptions={null}
+        selectedOptions="daily"
         variant="single"
       />
     </CardActions>
@@ -247,7 +247,7 @@ exports[`GraphCard Component should render multiple states: error with 500 statu
           ]
         }
         placeholder="t(curiosity-graph.dropdownPlaceholder)"
-        selectedOptions={null}
+        selectedOptions="daily"
         variant="single"
       />
     </CardActions>
@@ -350,7 +350,7 @@ exports[`GraphCard Component should render multiple states: fulfilled 1`] = `
           ]
         }
         placeholder="t(curiosity-graph.dropdownPlaceholder)"
-        selectedOptions={null}
+        selectedOptions="daily"
         variant="single"
       />
     </CardActions>
@@ -453,7 +453,7 @@ exports[`GraphCard Component should render multiple states: pending 1`] = `
           ]
         }
         placeholder="t(curiosity-graph.dropdownPlaceholder)"
-        selectedOptions={null}
+        selectedOptions="daily"
         variant="single"
       />
     </CardActions>

--- a/src/components/graphCard/__tests__/graphCard.test.js
+++ b/src/components/graphCard/__tests__/graphCard.test.js
@@ -2,10 +2,11 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { ChartArea } from '../../chartArea/chartArea';
 import { GraphCard } from '../graphCard';
+import { RHSM_API_QUERY_GRANULARITY_TYPES as GRANULARITY_TYPES } from '../../../types/rhsmApiTypes';
 
 describe('GraphCard Component', () => {
   it('should render a non-connected component', () => {
-    const props = { productId: 'lorem' };
+    const props = { graphGranularity: GRANULARITY_TYPES.DAILY, productId: 'lorem' };
     const component = shallow(<GraphCard {...props} />);
 
     expect(component).toMatchSnapshot('non-connected');
@@ -13,9 +14,8 @@ describe('GraphCard Component', () => {
 
   it('should render multiple states', () => {
     const props = {
+      graphGranularity: GRANULARITY_TYPES.DAILY,
       productId: 'lorem',
-      startDate: new Date('2019-06-01T00:00:00Z'),
-      endDate: new Date('2019-06-30T23:59:59Z'),
       graphData: {
         physicalSockets: [
           {

--- a/src/components/graphCard/graphCard.js
+++ b/src/components/graphCard/graphCard.js
@@ -17,23 +17,20 @@ class GraphCard extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { graphGranularity } = this.props;
+    const { graphGranularity, productId } = this.props;
 
-    if (graphGranularity !== prevProps.graphGranularity) {
+    if (graphGranularity !== prevProps.graphGranularity || productId !== prevProps.productId) {
       this.onUpdateGraphData();
     }
   }
 
   onUpdateGraphData = () => {
-    const { getGraphReportsCapacity, graphGranularity, productId, selectOptionsType } = this.props;
+    const { getGraphReportsCapacity, graphGranularity, productId } = this.props;
 
-    if (productId) {
-      const { selected } = graphCardTypes.getGranularityOptions(selectOptionsType);
-      const updatedGranularity = graphGranularity || selected;
-
-      const { startDate, endDate } = dateHelpers.getRangedDateTime(updatedGranularity);
+    if (graphGranularity && productId) {
+      const { startDate, endDate } = dateHelpers.getRangedDateTime(graphGranularity);
       const query = {
-        [rhsmApiTypes.RHSM_API_QUERY_GRANULARITY]: updatedGranularity,
+        [rhsmApiTypes.RHSM_API_QUERY_GRANULARITY]: graphGranularity,
         [rhsmApiTypes.RHSM_API_QUERY_START_DATE]: startDate.toISOString(),
         [rhsmApiTypes.RHSM_API_QUERY_END_DATE]: endDate.toISOString()
       };
@@ -42,17 +39,13 @@ class GraphCard extends React.Component {
     }
   };
 
-  onSelect = event => {
-    const { graphGranularity, viewId } = this.props;
+  onSelect = (event = {}) => {
     const { value } = event;
 
-    if (graphGranularity !== value) {
-      store.dispatch({
-        type: reduxTypes.rhsm.SET_GRAPH_GRANULARITY_RHSM,
-        graphGranularity: value,
-        viewId
-      });
-    }
+    store.dispatch({
+      type: reduxTypes.rhsm.SET_GRAPH_GRANULARITY_RHSM,
+      granularity: value
+    });
   };
 
   /**
@@ -177,7 +170,7 @@ GraphCard.propTypes = {
   ),
   getGraphReportsCapacity: PropTypes.func,
   graphData: PropTypes.object,
-  graphGranularity: PropTypes.oneOf([...Object.values(GRANULARITY_TYPES)]),
+  graphGranularity: PropTypes.oneOf([...Object.values(GRANULARITY_TYPES)]).isRequired,
   pending: PropTypes.bool,
   productId: PropTypes.string.isRequired,
   selectOptionsType: PropTypes.oneOf(['default']),
@@ -193,7 +186,6 @@ GraphCard.defaultProps = {
   filterGraphData: [],
   getGraphReportsCapacity: helpers.noop,
   graphData: {},
-  graphGranularity: null,
   pending: false,
   selectOptionsType: 'default',
   t: helpers.noopTranslate,

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -14,8 +14,8 @@ exports[`I18n Component should generate a predictable pot output snapshot: pot o
 msgstr \\"\\"
 \\"Content-Type: text/plain; charset=UTF-8\\\\n\\"
 
-#: src/components/openshiftView/openshiftView.js:64
-#: src/components/rhelView/rhelView.js:31
+#: src/components/openshiftView/openshiftView.js:66
+#: src/components/rhelView/rhelView.js:33
 msgid \\"curiosity-graph.cardHeading\\"
 msgstr \\"\\"
 
@@ -31,8 +31,8 @@ msgstr \\"\\"
 msgid \\"curiosity-graph.dropdownMonthly\\"
 msgstr \\"\\"
 
-#: src/components/graphCard/graphCard.js:141
-#: src/components/graphCard/graphCard.js:145
+#: src/components/graphCard/graphCard.js:134
+#: src/components/graphCard/graphCard.js:138
 msgid \\"curiosity-graph.dropdownPlaceholder\\"
 msgstr \\"\\"
 
@@ -48,7 +48,7 @@ msgstr \\"\\"
 msgid \\"curiosity-graph.noDataLabel\\"
 msgstr \\"\\"
 
-#: src/components/graphCard/graphCard.js:112
+#: src/components/graphCard/graphCard.js:105
 #: src/components/graphCard/graphCardHelpers.js:81
 msgid \\"curiosity-graph.thresholdLabel\\"
 msgstr \\"\\"

--- a/src/components/openshiftView/__tests__/__snapshots__/openshiftView.test.js.snap
+++ b/src/components/openshiftView/__tests__/__snapshots__/openshiftView.test.js.snap
@@ -20,6 +20,7 @@ exports[`OpenshiftView Component should have a fallback title: title 1`] = `
           },
         ]
       }
+      graphGranularity="daily"
       key="lorem ipsum"
       productId="lorem ipsum"
       productShortLabel="OpenShift"
@@ -73,6 +74,7 @@ exports[`OpenshiftView Component should render a non-connected component: non-co
           },
         ]
       }
+      graphGranularity="daily"
       key="lorem ipsum"
       productId="lorem ipsum"
       productShortLabel="OpenShift"

--- a/src/components/openshiftView/openshiftView.js
+++ b/src/components/openshiftView/openshiftView.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withTranslation } from 'react-i18next';
 import {
   chart_color_blue_100 as chartColorBlueLight,
   chart_color_blue_300 as chartColorBlueDark
 } from '@patternfly/react-tokens';
 import { PageLayout, PageHeader, PageSection } from '../pageLayout/pageLayout';
+import { RHSM_API_QUERY_GRANULARITY_TYPES as GRANULARITY_TYPES } from '../../types/rhsmApiTypes';
+import { connectTranslate } from '../../redux';
 import GraphCard from '../graphCard/graphCard';
 import { Select } from '../select/select';
 import { helpers } from '../../common';
@@ -48,7 +49,7 @@ class OpenshiftView extends React.Component {
 
   render() {
     const { filters } = this.state;
-    const { routeDetail, t } = this.props;
+    const { granularity, routeDetail, t } = this.props;
 
     return (
       <PageLayout>
@@ -59,6 +60,7 @@ class OpenshiftView extends React.Component {
           <GraphCard
             key={routeDetail.pathParameter}
             filterGraphData={filters}
+            graphGranularity={granularity}
             productId={routeDetail.pathParameter}
             viewId={routeDetail.pathId}
             cardTitle={t('curiosity-graph.cardHeading')}
@@ -73,6 +75,7 @@ class OpenshiftView extends React.Component {
 }
 
 OpenshiftView.propTypes = {
+  granularity: PropTypes.oneOf([...Object.values(GRANULARITY_TYPES)]),
   initialOption: PropTypes.oneOf(['cores', 'sockets']),
   initialFilters: PropTypes.array,
   routeDetail: PropTypes.shape({
@@ -86,6 +89,7 @@ OpenshiftView.propTypes = {
 };
 
 OpenshiftView.defaultProps = {
+  granularity: GRANULARITY_TYPES.DAILY,
   initialOption: 'cores',
   initialFilters: [
     { id: 'cores', fill: chartColorBlueLight.value, stroke: chartColorBlueDark.value },
@@ -96,6 +100,8 @@ OpenshiftView.defaultProps = {
   t: helpers.noopTranslate
 };
 
-const TranslatedOpenshiftView = withTranslation()(OpenshiftView);
+const mapStateToProps = state => ({ ...state.view });
 
-export { TranslatedOpenshiftView as default, TranslatedOpenshiftView, OpenshiftView };
+const ConnectedOpenshiftView = connectTranslate(mapStateToProps)(OpenshiftView);
+
+export { ConnectedOpenshiftView as default, ConnectedOpenshiftView, OpenshiftView };

--- a/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
+++ b/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
@@ -25,6 +25,7 @@ exports[`RhelView Component should have a fallback title: title 1`] = `
           },
         ]
       }
+      graphGranularity="daily"
       key="lorem ipsum"
       productId="lorem ipsum"
       productShortLabel="RHEL"
@@ -59,6 +60,7 @@ exports[`RhelView Component should render a non-connected component: non-connect
           },
         ]
       }
+      graphGranularity="daily"
       key="lorem ipsum"
       productId="lorem ipsum"
       productShortLabel="RHEL"

--- a/src/components/rhelView/rhelView.js
+++ b/src/components/rhelView/rhelView.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withTranslation } from 'react-i18next';
 import {
   chart_color_blue_100 as chartColorBlueLight,
   chart_color_blue_300 as chartColorBlueDark,
@@ -8,6 +7,8 @@ import {
   chart_color_cyan_300 as chartColorCyanDark
 } from '@patternfly/react-tokens';
 import { PageLayout, PageHeader, PageSection } from '../pageLayout/pageLayout';
+import { RHSM_API_QUERY_GRANULARITY_TYPES as GRANULARITY_TYPES } from '../../types/rhsmApiTypes';
+import { connectTranslate } from '../../redux';
 import GraphCard from '../graphCard/graphCard';
 import { helpers } from '../../common';
 
@@ -15,7 +16,7 @@ class RhelView extends React.Component {
   componentDidMount() {}
 
   render() {
-    const { initialFilters, routeDetail, t } = this.props;
+    const { granularity, initialFilters, routeDetail, t } = this.props;
 
     return (
       <PageLayout>
@@ -26,6 +27,7 @@ class RhelView extends React.Component {
           <GraphCard
             key={routeDetail.pathParameter}
             filterGraphData={initialFilters}
+            graphGranularity={granularity}
             productId={routeDetail.pathParameter}
             viewId={routeDetail.pathId}
             cardTitle={t('curiosity-graph.cardHeading')}
@@ -38,6 +40,7 @@ class RhelView extends React.Component {
 }
 
 RhelView.propTypes = {
+  granularity: PropTypes.oneOf([...Object.values(GRANULARITY_TYPES)]),
   initialFilters: PropTypes.array,
   routeDetail: PropTypes.shape({
     pathParameter: PropTypes.string.isRequired,
@@ -50,6 +53,7 @@ RhelView.propTypes = {
 };
 
 RhelView.defaultProps = {
+  granularity: GRANULARITY_TYPES.DAILY,
   initialFilters: [
     { id: 'physicalSockets', fill: chartColorBlueLight.value, stroke: chartColorBlueDark.value },
     { id: 'hypervisorSockets', fill: chartColorCyanLight.value, stroke: chartColorCyanDark.value },
@@ -58,6 +62,8 @@ RhelView.defaultProps = {
   t: helpers.noopTranslate
 };
 
-const TranslatedRhelView = withTranslation()(RhelView);
+const mapStateToProps = state => ({ ...state.view });
 
-export { TranslatedRhelView as default, TranslatedRhelView, RhelView };
+const ConnectedRhelView = connectTranslate(mapStateToProps)(RhelView);
+
+export { ConnectedRhelView as default, ConnectedRhelView, RhelView };

--- a/src/components/router/__tests__/__snapshots__/routerHelpers.test.js.snap
+++ b/src/components/router/__tests__/__snapshots__/routerHelpers.test.js.snap
@@ -19,7 +19,13 @@ Object {
     "title": "Red Hat Enterprise Linux",
   },
   "navRoute": Object {
-    "component": [Function],
+    "component": Object {
+      "$$typeof": Symbol(react.memo),
+      "WrappedComponent": [Function],
+      "compare": null,
+      "displayName": "Connect(RhelView)",
+      "type": [Function],
+    },
     "default": true,
     "disabled": false,
     "exact": true,
@@ -33,7 +39,13 @@ Object {
     "to": "/rhel-sw/all",
   },
   "route": Object {
-    "component": [Function],
+    "component": Object {
+      "$$typeof": Symbol(react.memo),
+      "WrappedComponent": [Function],
+      "compare": null,
+      "displayName": "Connect(RhelView)",
+      "type": [Function],
+    },
     "disabled": false,
     "exact": true,
     "redirect": true,
@@ -55,7 +67,13 @@ Object {
     "title": "Red Hat Enterprise Linux",
   },
   "navRoute": Object {
-    "component": [Function],
+    "component": Object {
+      "$$typeof": Symbol(react.memo),
+      "WrappedComponent": [Function],
+      "compare": null,
+      "displayName": "Connect(RhelView)",
+      "type": [Function],
+    },
     "default": true,
     "disabled": false,
     "exact": true,
@@ -69,7 +87,13 @@ Object {
     "to": "/rhel-sw/all",
   },
   "route": Object {
-    "component": [Function],
+    "component": Object {
+      "$$typeof": Symbol(react.memo),
+      "WrappedComponent": [Function],
+      "compare": null,
+      "displayName": "Connect(RhelView)",
+      "type": [Function],
+    },
     "disabled": false,
     "exact": true,
     "redirect": true,
@@ -99,7 +123,13 @@ Object {
     "title": "Red Hat Enterprise Linux",
   },
   "navRoute": Object {
-    "component": [Function],
+    "component": Object {
+      "$$typeof": Symbol(react.memo),
+      "WrappedComponent": [Function],
+      "compare": null,
+      "displayName": "Connect(RhelView)",
+      "type": [Function],
+    },
     "default": true,
     "disabled": false,
     "exact": true,
@@ -134,7 +164,13 @@ Object {
     "title": "ARM",
   },
   "navRoute": Object {
-    "component": [Function],
+    "component": Object {
+      "$$typeof": Symbol(react.memo),
+      "WrappedComponent": [Function],
+      "compare": null,
+      "displayName": "Connect(RhelView)",
+      "type": [Function],
+    },
     "disabled": false,
     "exact": true,
     "id": "arm",

--- a/src/components/router/__tests__/__snapshots__/routerTypes.test.js.snap
+++ b/src/components/router/__tests__/__snapshots__/routerTypes.test.js.snap
@@ -55,7 +55,13 @@ exports[`RouterTypes should return specific properties: platformRedirect 1`] = `
 exports[`RouterTypes should return specific properties: routes 1`] = `
 Array [
   Object {
-    "component": [Function],
+    "component": Object {
+      "$$typeof": Symbol(react.memo),
+      "WrappedComponent": [Function],
+      "compare": null,
+      "displayName": "Connect(RhelView)",
+      "type": [Function],
+    },
     "disabled": false,
     "exact": true,
     "redirect": true,
@@ -64,7 +70,13 @@ Array [
     "to": "/rhel-sw/all",
   },
   Object {
-    "component": [Function],
+    "component": Object {
+      "$$typeof": Symbol(react.memo),
+      "WrappedComponent": [Function],
+      "compare": null,
+      "displayName": "Connect(RhelView)",
+      "type": [Function],
+    },
     "disabled": false,
     "exact": true,
     "id": "rhel-sw",
@@ -73,7 +85,13 @@ Array [
     "to": "/rhel-sw/:variant",
   },
   Object {
-    "component": [Function],
+    "component": Object {
+      "$$typeof": Symbol(react.memo),
+      "WrappedComponent": [Function],
+      "compare": null,
+      "displayName": "Connect(OpenshiftView)",
+      "type": [Function],
+    },
     "disabled": false,
     "exact": true,
     "id": "openshift-sw",

--- a/src/redux/reducers/__tests__/__snapshots__/graphReducer.test.js.snap
+++ b/src/redux/reducers/__tests__/__snapshots__/graphReducer.test.js.snap
@@ -14,7 +14,6 @@ Object {
       "metaQuery": undefined,
       "pending": false,
     },
-    "component": Object {},
     "report": Object {},
     "reportCapacity": Object {},
   },
@@ -26,7 +25,6 @@ exports[`GraphReducer should handle all defined error types: rejected types GET_
 Object {
   "result": Object {
     "capacity": Object {},
-    "component": Object {},
     "report": Object {},
     "reportCapacity": Object {
       "error": true,
@@ -48,7 +46,6 @@ exports[`GraphReducer should handle all defined error types: rejected types GET_
 Object {
   "result": Object {
     "capacity": Object {},
-    "component": Object {},
     "report": Object {
       "error": true,
       "errorMessage": "MESSAGE",
@@ -83,7 +80,6 @@ Object {
       "metaQuery": undefined,
       "pending": false,
     },
-    "component": Object {},
     "report": Object {},
     "reportCapacity": Object {},
   },
@@ -95,7 +91,6 @@ exports[`GraphReducer should handle all defined fulfilled types: fulfilled types
 Object {
   "result": Object {
     "capacity": Object {},
-    "component": Object {},
     "report": Object {},
     "reportCapacity": Object {
       "data": Object {
@@ -120,7 +115,6 @@ exports[`GraphReducer should handle all defined fulfilled types: fulfilled types
 Object {
   "result": Object {
     "capacity": Object {},
-    "component": Object {},
     "report": Object {
       "data": Object {
         "test": "success",
@@ -154,7 +148,6 @@ Object {
       "metaQuery": undefined,
       "pending": true,
     },
-    "component": Object {},
     "report": Object {},
     "reportCapacity": Object {},
   },
@@ -166,7 +159,6 @@ exports[`GraphReducer should handle all defined pending types: pending types GET
 Object {
   "result": Object {
     "capacity": Object {},
-    "component": Object {},
     "report": Object {},
     "reportCapacity": Object {
       "error": false,
@@ -187,7 +179,6 @@ exports[`GraphReducer should handle all defined pending types: pending types GET
 Object {
   "result": Object {
     "capacity": Object {},
-    "component": Object {},
     "report": Object {
       "error": false,
       "errorMessage": "",
@@ -201,21 +192,5 @@ Object {
     "reportCapacity": Object {},
   },
   "type": "GET_GRAPH_REPORT_RHSM_PENDING",
-}
-`;
-
-exports[`GraphReducer should handle specific defined types: defined type SET_GRAPH_GRANULARITY_RHSM 1`] = `
-Object {
-  "result": Object {
-    "capacity": Object {},
-    "component": Object {
-      "dolor id": Object {
-        "graphGranularity": "lorem granularity",
-      },
-    },
-    "report": Object {},
-    "reportCapacity": Object {},
-  },
-  "type": "SET_GRAPH_GRANULARITY_RHSM",
 }
 `;

--- a/src/redux/reducers/__tests__/__snapshots__/viewReducer.test.js.snap
+++ b/src/redux/reducers/__tests__/__snapshots__/viewReducer.test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ViewReducer should handle specific defined types: defined type SET_GRAPH_GRANULARITY_RHSM 1`] = `
+Object {
+  "result": Object {
+    "granularity": "lorem granularity",
+  },
+  "type": "SET_GRAPH_GRANULARITY_RHSM",
+}
+`;

--- a/src/redux/reducers/__tests__/graphReducer.test.js
+++ b/src/redux/reducers/__tests__/graphReducer.test.js
@@ -7,22 +7,6 @@ describe('GraphReducer', () => {
     expect(graphReducer.initialState).toBeDefined();
   });
 
-  it('should handle specific defined types', () => {
-    const specificTypes = [types.SET_GRAPH_GRANULARITY_RHSM];
-
-    specificTypes.forEach(value => {
-      const dispatched = {
-        type: value,
-        graphGranularity: 'lorem granularity',
-        viewId: 'dolor id'
-      };
-
-      const resultState = graphReducer(undefined, dispatched);
-
-      expect({ type: value, result: resultState }).toMatchSnapshot(`defined type ${value}`);
-    });
-  });
-
   it('should handle all defined error types', () => {
     const specificTypes = [
       types.GET_GRAPH_REPORT_CAPACITY_RHSM,

--- a/src/redux/reducers/__tests__/viewReducer.test.js
+++ b/src/redux/reducers/__tests__/viewReducer.test.js
@@ -1,7 +1,24 @@
 import viewReducer from '../viewReducer';
+import { rhsmTypes as types } from '../../types';
 
 describe('ViewReducer', () => {
   it('should return the initial state', () => {
     expect(viewReducer.initialState).toBeDefined();
+  });
+
+  it('should handle specific defined types', () => {
+    const specificTypes = [types.SET_GRAPH_GRANULARITY_RHSM];
+
+    specificTypes.forEach(value => {
+      const dispatched = {
+        type: value,
+        granularity: 'lorem granularity',
+        viewId: 'dolor id'
+      };
+
+      const resultState = viewReducer(undefined, dispatched);
+
+      expect({ type: value, result: resultState }).toMatchSnapshot(`defined type ${value}`);
+    });
   });
 });

--- a/src/redux/reducers/graphReducer.js
+++ b/src/redux/reducers/graphReducer.js
@@ -1,41 +1,22 @@
-import { reduxTypes, rhsmTypes } from '../types';
+import { rhsmTypes } from '../types';
 import { reduxHelpers } from '../common/reduxHelpers';
 
 const initialState = {
   capacity: {},
-  component: {},
   report: {},
   reportCapacity: {}
 };
 
-const graphReducer = (state = initialState, action) => {
-  switch (action.type) {
-    case reduxTypes.rhsm.SET_GRAPH_GRANULARITY_RHSM:
-      return reduxHelpers.setStateProp(
-        'component',
-        {
-          [action.viewId]: {
-            graphGranularity: action.graphGranularity
-          }
-        },
-        {
-          state,
-          reset: false
-        }
-      );
-
-    default:
-      return reduxHelpers.generatedPromiseActionReducer(
-        [
-          { ref: 'reportCapacity', type: rhsmTypes.GET_GRAPH_REPORT_CAPACITY_RHSM },
-          { ref: 'capacity', type: rhsmTypes.GET_GRAPH_CAPACITY_RHSM },
-          { ref: 'report', type: rhsmTypes.GET_GRAPH_REPORT_RHSM }
-        ],
-        state,
-        action
-      );
-  }
-};
+const graphReducer = (state = initialState, action) =>
+  reduxHelpers.generatedPromiseActionReducer(
+    [
+      { ref: 'reportCapacity', type: rhsmTypes.GET_GRAPH_REPORT_CAPACITY_RHSM },
+      { ref: 'capacity', type: rhsmTypes.GET_GRAPH_CAPACITY_RHSM },
+      { ref: 'report', type: rhsmTypes.GET_GRAPH_REPORT_RHSM }
+    ],
+    state,
+    action
+  );
 
 graphReducer.initialState = initialState;
 

--- a/src/redux/reducers/viewReducer.js
+++ b/src/redux/reducers/viewReducer.js
@@ -1,15 +1,25 @@
-const initialState = {
-  view: {
-    data: [],
-    error: false,
-    errorStatus: null,
-    errorMessage: null,
-    pending: false,
-    fulfilled: false
+import { reduxTypes } from '../types';
+import { reduxHelpers } from '../common/reduxHelpers';
+
+const initialState = {};
+
+const viewReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case reduxTypes.rhsm.SET_GRAPH_GRANULARITY_RHSM:
+      return reduxHelpers.setStateProp(
+        null,
+        {
+          granularity: action.granularity
+        },
+        {
+          state,
+          initialState
+        }
+      );
+    default:
+      return state;
   }
 };
-
-const viewReducer = (state = initialState) => state;
 
 viewReducer.initialState = initialState;
 

--- a/src/redux/selectors/__tests__/__snapshots__/graphCardSelectors.test.js.snap
+++ b/src/redux/selectors/__tests__/__snapshots__/graphCardSelectors.test.js.snap
@@ -6,10 +6,8 @@ Object {
   "errorStatus": undefined,
   "fulfilled": false,
   "graphData": Object {},
-  "graphGranularity": "daily",
   "initialLoad": true,
   "pending": true,
-  "syncing": false,
 }
 `;
 
@@ -241,10 +239,8 @@ Object {
       },
     ],
   },
-  "graphGranularity": "daily",
   "initialLoad": false,
   "pending": false,
-  "syncing": false,
 }
 `;
 
@@ -256,7 +252,6 @@ Object {
   "graphData": Object {},
   "initialLoad": true,
   "pending": false,
-  "syncing": false,
 }
 `;
 
@@ -268,7 +263,6 @@ Object {
   "graphData": Object {},
   "initialLoad": true,
   "pending": false,
-  "syncing": false,
 }
 `;
 
@@ -280,7 +274,6 @@ Object {
   "graphData": Object {},
   "initialLoad": true,
   "pending": false,
-  "syncing": false,
 }
 `;
 
@@ -391,7 +384,6 @@ Object {
   },
   "initialLoad": false,
   "pending": false,
-  "syncing": false,
 }
 `;
 
@@ -500,10 +492,8 @@ Object {
       },
     ],
   },
-  "graphGranularity": "daily",
   "initialLoad": false,
   "pending": false,
-  "syncing": false,
 }
 `;
 
@@ -612,10 +602,8 @@ Object {
       },
     ],
   },
-  "graphGranularity": "daily",
   "initialLoad": false,
   "pending": false,
-  "syncing": false,
 }
 `;
 
@@ -864,10 +852,8 @@ Object {
       },
     ],
   },
-  "graphGranularity": "daily",
   "initialLoad": false,
   "pending": false,
-  "syncing": false,
 }
 `;
 
@@ -983,10 +969,8 @@ Object {
       },
     ],
   },
-  "graphGranularity": "daily",
   "initialLoad": false,
   "pending": false,
-  "syncing": false,
 }
 `;
 

--- a/src/redux/selectors/__tests__/graphCardSelectors.test.js
+++ b/src/redux/selectors/__tests__/graphCardSelectors.test.js
@@ -18,7 +18,6 @@ describe('GraphCardSelectors', () => {
     };
     const state = {
       graph: {
-        component: {},
         reportCapacity: {
           fulfilled: true,
           metaId: 'Lorem Ipsum ID missing granularity',
@@ -37,11 +36,11 @@ describe('GraphCardSelectors', () => {
   it('should pass minimal data on a product ID without a product ID provided', () => {
     const props = {
       viewId: 'test',
-      productId: undefined
+      productId: undefined,
+      graphGranularity: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
     };
     const state = {
       graph: {
-        component: {},
         reportCapacity: {
           fulfilled: true,
           metaId: undefined,
@@ -62,15 +61,11 @@ describe('GraphCardSelectors', () => {
   it('should handle pending state on a product ID', () => {
     const props = {
       viewId: 'test',
-      productId: 'Lorem Ipsum ID pending state'
+      productId: 'Lorem Ipsum ID pending state',
+      graphGranularity: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
     };
     const state = {
       graph: {
-        component: {
-          test: {
-            graphGranularity: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
-          }
-        },
         reportCapacity: {
           'Lorem Ipsum ID pending state': {
             pending: true,
@@ -93,15 +88,11 @@ describe('GraphCardSelectors', () => {
   it('should populate data on a product ID when the api response provided mismatches index or date', () => {
     const props = {
       viewId: 'test',
-      productId: 'Lorem Ipsum mismatched index or date'
+      productId: 'Lorem Ipsum mismatched index or date',
+      graphGranularity: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
     };
     const state = {
       graph: {
-        component: {
-          test: {
-            graphGranularity: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
-          }
-        },
         reportCapacity: {
           'Lorem Ipsum mismatched index or date': {
             fulfilled: true,
@@ -138,15 +129,11 @@ describe('GraphCardSelectors', () => {
   it('should populate data on a product ID when the api response is missing expected properties', () => {
     const props = {
       viewId: 'test',
-      productId: 'Lorem Ipsum missing expected properties'
+      productId: 'Lorem Ipsum missing expected properties',
+      graphGranularity: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
     };
     const state = {
       graph: {
-        component: {
-          test: {
-            graphGranularity: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
-          }
-        },
         reportCapacity: {
           'Lorem Ipsum missing expected properties': {
             fulfilled: true,
@@ -208,15 +195,11 @@ describe('GraphCardSelectors', () => {
   it('should map a fulfilled product ID response to an aggregated output', () => {
     const props = {
       viewId: 'test',
-      productId: 'Lorem Ipsum fulfilled aggregated output'
+      productId: 'Lorem Ipsum fulfilled aggregated output',
+      graphGranularity: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
     };
     const state = {
       graph: {
-        component: {
-          test: {
-            graphGranularity: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
-          }
-        },
         reportCapacity: {
           'Lorem Ipsum fulfilled aggregated output': {
             fulfilled: true,
@@ -293,15 +276,11 @@ describe('GraphCardSelectors', () => {
   it('should populate data from the in memory cache', () => {
     const props = {
       viewId: 'cache-test',
-      productId: 'Lorem Ipsum ID cached'
+      productId: 'Lorem Ipsum ID cached',
+      graphGranularity: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
     };
     const stateDailyGranularityFulfilled = {
       graph: {
-        component: {
-          'cache-test': {
-            graphGranularity: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
-          }
-        },
         reportCapacity: {
           'Lorem Ipsum ID cached': {
             fulfilled: true,
@@ -359,11 +338,6 @@ describe('GraphCardSelectors', () => {
 
     const stateDailyComponentCapacityGranularity = {
       graph: {
-        component: {
-          'cache-test': {
-            graphGranularity: rhsmApiTypes.RHSM_API_QUERY_GRANULARITY_TYPES.DAILY
-          }
-        },
         reportCapacity: {
           'Lorem Ipsum ID cached': {
             ...stateDailyGranularityFulfilled.graph.reportCapacity['Lorem Ipsum ID cached'],
@@ -379,7 +353,6 @@ describe('GraphCardSelectors', () => {
 
     const stateDailyReportCapacityGranularityMismatch = {
       graph: {
-        component: {},
         reportCapacity: {
           'Lorem Ipsum ID cached': {
             ...stateDailyGranularityFulfilled.graph.reportCapacity['Lorem Ipsum ID cached'],


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(graphCardSelectors): improve sync for multiple api calls
   * graphCard, require graphGranularity, relocate granularity to parent
   * graphCardSelectors, improve sync for multi api calls, aggregation
   * graphReducer, viewReducer, relocate granularity
   * i18n, test update
   * openShiftView, rhelView, relocate granularity
   * routerHelpers, routerTypes, test updates

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- Improves the sync graph display behavior when handling aggregated API calls. There is currently a scenario when one API call is significantly slower it can delay loading in various ways, such as causing the graph to display empty, then load after the fact. This set of updates aims to remove that, and reverts to the cached graph display more easily

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check, BEFORE syncing PR changes
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. Currently their is a 2 second delay baked into the mock server for the tally response. 
   - Confirm selecting granularity back and forth quickly results in an expected display with various loading discrepancies, such as a **missing graph**, a **severely delayed graph render**, or **blurred graph loading** display.
   - To alter the delay change `line 41` on `./src/services/rhsmServices.js` to another delay in milliseconds, or remove the line entirely to remove the delay

### Local run check, AFTER syncing PR changes
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. Currently their is a 2 second delay baked into the mock server for the tally response. 
   - Confirm selecting granularity back and forth quickly results in an expected display without errors, and adverse display mechanics as mentioned in the **before scenario** testing
   - To alter the delay change `line 41` on `./src/services/rhsmServices.js` to another delay in milliseconds, or remove the line entirely to remove the delay

<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Ongoing