### PR TITLE
feat(rhelView): issues/226 display cloud metering data

### DIFF
--- a/public/locales/en-US.json
+++ b/public/locales/en-US.json
@@ -17,6 +17,7 @@
     "dateLabel": "Date",
     "coresLabel": "Cores",
     "socketsLabel": "Sockets",
+    "cloudSocketsLabel": "Public cloud",
     "hypervisorCoresLabel": "Virtualized cores",
     "hypervisorSocketsLabel": "Virtualized {{product}}",
     "physicalCoresLabel": "Physical cores",

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -15,7 +15,7 @@ msgstr \\"\\"
 \\"Content-Type: text/plain; charset=UTF-8\\\\n\\"
 
 #: src/components/openshiftView/openshiftView.js:92
-#: src/components/rhelView/rhelView.js:47
+#: src/components/rhelView/rhelView.js:49
 msgid \\"curiosity-graph.cardHeading\\"
 msgstr \\"\\"
 

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -15,7 +15,6 @@ msgstr \\"\\"
 \\"Content-Type: text/plain; charset=UTF-8\\\\n\\"
 
 #: src/components/openshiftView/openshiftView.js:92
-#: src/components/rhelView/rhelView.js:49
 msgid \\"curiosity-graph.cardHeading\\"
 msgstr \\"\\"
 
@@ -46,6 +45,10 @@ msgstr \\"\\"
 
 #: src/components/graphCard/graphCardHelpers.js:92
 msgid \\"curiosity-graph.noDataLabel\\"
+msgstr \\"\\"
+
+#: src/components/rhelView/rhelView.js:49
+msgid \\"curiosity-graph.socketsHeading\\"
 msgstr \\"\\"
 
 #: src/components/graphCard/graphCard.js:134

--- a/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
+++ b/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
@@ -17,7 +17,7 @@ exports[`RhelView Component should have a fallback title: title 1`] = `
   </PageToolbar>
   <PageSection>
     <Connect(GraphCard)
-      cardTitle="t(curiosity-graph.cardHeading)"
+      cardTitle="t(curiosity-graph.socketsHeading)"
       filterGraphData={
         Array [
           Object {
@@ -71,7 +71,7 @@ exports[`RhelView Component should render a non-connected component: non-connect
   </PageToolbar>
   <PageSection>
     <Connect(GraphCard)
-      cardTitle="t(curiosity-graph.cardHeading)"
+      cardTitle="t(curiosity-graph.socketsHeading)"
       filterGraphData={
         Array [
           Object {

--- a/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
+++ b/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
@@ -31,6 +31,11 @@ exports[`RhelView Component should have a fallback title: title 1`] = `
             "stroke": "#009596",
           },
           Object {
+            "fill": "#b2b0ea",
+            "id": "cloudSockets",
+            "stroke": "#5752d1",
+          },
+          Object {
             "id": "thresholdSockets",
           },
         ]
@@ -78,6 +83,11 @@ exports[`RhelView Component should render a non-connected component: non-connect
             "fill": "#a2d9d9",
             "id": "hypervisorSockets",
             "stroke": "#009596",
+          },
+          Object {
+            "fill": "#b2b0ea",
+            "id": "cloudSockets",
+            "stroke": "#5752d1",
           },
           Object {
             "id": "thresholdSockets",

--- a/src/components/rhelView/rhelView.js
+++ b/src/components/rhelView/rhelView.js
@@ -4,7 +4,9 @@ import {
   chart_color_blue_100 as chartColorBlueLight,
   chart_color_blue_300 as chartColorBlueDark,
   chart_color_cyan_100 as chartColorCyanLight,
-  chart_color_cyan_300 as chartColorCyanDark
+  chart_color_cyan_300 as chartColorCyanDark,
+  chart_color_purple_100 as chartColorPurpleLight,
+  chart_color_purple_300 as chartColorPurpleDark
 } from '@patternfly/react-tokens';
 import { PageLayout, PageHeader, PageSection, PageToolbar } from '../pageLayout/pageLayout';
 import { RHSM_API_QUERY_GRANULARITY_TYPES as GRANULARITY_TYPES, rhsmApiTypes } from '../../types/rhsmApiTypes';
@@ -86,6 +88,7 @@ RhelView.defaultProps = {
   initialFilters: [
     { id: 'physicalSockets', fill: chartColorBlueLight.value, stroke: chartColorBlueDark.value },
     { id: 'hypervisorSockets', fill: chartColorCyanLight.value, stroke: chartColorCyanDark.value },
+    { id: 'cloudSockets', fill: chartColorPurpleLight.value, stroke: chartColorPurpleDark.value },
     { id: 'thresholdSockets' }
   ],
   t: helpers.noopTranslate,

--- a/src/components/rhelView/rhelView.js
+++ b/src/components/rhelView/rhelView.js
@@ -46,7 +46,7 @@ class RhelView extends React.Component {
             graphQuery={graphQuery}
             productId={routeDetail.pathParameter}
             viewId={viewId}
-            cardTitle={t('curiosity-graph.cardHeading')}
+            cardTitle={t('curiosity-graph.socketsHeading')}
             productShortLabel={viewId}
           />
         </PageSection>

--- a/src/redux/selectors/__tests__/__snapshots__/graphCardSelectors.test.js.snap
+++ b/src/redux/selectors/__tests__/__snapshots__/graphCardSelectors.test.js.snap
@@ -16,6 +16,57 @@ Object {
   "errorStatus": undefined,
   "fulfilled": true,
   "graphData": Object {
+    "cloudCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": 0,
+      },
+    ],
+    "cloudInstanceCount": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": 0,
+      },
+    ],
+    "cloudSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": 0,
+      },
+    ],
     "cores": Array [
       Object {
         "date": 2019-09-04T00:00:00.000Z,
@@ -133,6 +184,57 @@ Object {
         "date": 2019-09-06T00:00:00.000Z,
         "x": 2,
         "y": 4,
+      },
+    ],
+    "thresholdCloudCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": null,
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": null,
+      },
+    ],
+    "thresholdCloudInstanceCount": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": null,
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": null,
+      },
+    ],
+    "thresholdCloudSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": null,
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": null,
       },
     ],
     "thresholdCores": Array [
@@ -278,6 +380,27 @@ Object {
   "errorStatus": undefined,
   "fulfilled": true,
   "graphData": Object {
+    "cloudCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "cloudInstanceCount": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "cloudSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
     "cores": Array [
       Object {
         "date": 2019-09-04T00:00:00.000Z,
@@ -325,6 +448,27 @@ Object {
         "date": 2019-09-04T00:00:00.000Z,
         "x": 0,
         "y": 2,
+      },
+    ],
+    "thresholdCloudCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdCloudInstanceCount": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdCloudSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
       },
     ],
     "thresholdCores": Array [
@@ -387,6 +531,27 @@ Object {
   "errorStatus": undefined,
   "fulfilled": true,
   "graphData": Object {
+    "cloudCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "cloudInstanceCount": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "cloudSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
     "cores": Array [
       Object {
         "date": 2019-09-04T00:00:00.000Z,
@@ -434,6 +599,27 @@ Object {
         "date": 2019-09-04T00:00:00.000Z,
         "x": 0,
         "y": 2,
+      },
+    ],
+    "thresholdCloudCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdCloudInstanceCount": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdCloudSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
       },
     ],
     "thresholdCores": Array [
@@ -496,6 +682,27 @@ Object {
   "errorStatus": undefined,
   "fulfilled": true,
   "graphData": Object {
+    "cloudCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "cloudInstanceCount": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "cloudSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
     "cores": Array [
       Object {
         "date": 2019-09-04T00:00:00.000Z,
@@ -543,6 +750,27 @@ Object {
         "date": 2019-09-04T00:00:00.000Z,
         "x": 0,
         "y": 2,
+      },
+    ],
+    "thresholdCloudCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdCloudInstanceCount": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdCloudSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
       },
     ],
     "thresholdCores": Array [
@@ -605,6 +833,57 @@ Object {
   "errorStatus": undefined,
   "fulfilled": true,
   "graphData": Object {
+    "cloudCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": 0,
+      },
+    ],
+    "cloudInstanceCount": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": 0,
+      },
+    ],
+    "cloudSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": 0,
+      },
+    ],
     "cores": Array [
       Object {
         "date": 2019-09-04T00:00:00.000Z,
@@ -722,6 +1001,57 @@ Object {
         "date": 2019-09-06T00:00:00.000Z,
         "x": 2,
         "y": 4,
+      },
+    ],
+    "thresholdCloudCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": 0,
+      },
+    ],
+    "thresholdCloudInstanceCount": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": 0,
+      },
+    ],
+    "thresholdCloudSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-05T00:00:00.000Z,
+        "x": 1,
+        "y": 0,
+      },
+      Object {
+        "date": 2019-09-06T00:00:00.000Z,
+        "x": 2,
+        "y": 0,
       },
     ],
     "thresholdCores": Array [
@@ -854,6 +1184,27 @@ Object {
   "errorStatus": undefined,
   "fulfilled": true,
   "graphData": Object {
+    "cloudCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "cloudInstanceCount": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "cloudSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
     "cores": Array [
       Object {
         "date": 2019-09-04T00:00:00.000Z,
@@ -901,6 +1252,27 @@ Object {
         "date": 2019-09-04T00:00:00.000Z,
         "x": 0,
         "y": 2,
+      },
+    ],
+    "thresholdCloudCores": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdCloudInstanceCount": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
+      },
+    ],
+    "thresholdCloudSockets": Array [
+      Object {
+        "date": 2019-09-04T00:00:00.000Z,
+        "x": 0,
+        "y": 0,
       },
     ],
     "thresholdCores": Array [

--- a/src/services/rhsmServices.js
+++ b/src/services/rhsmServices.js
@@ -87,98 +87,112 @@ const getApiVersion = () =>
  *           "sockets": 50,
  *           "physical_sockets": 50,
  *           "hypervisor_sockets": 0,
- *           "has_data": true
+ *           "has_data": true,
+ *           "cloud_sockets": 20
  *         },
  *         {
  *           "date": "2018-07-20T00:00:00Z",
  *           "sockets": 50,
  *           "physical_sockets": 50,
  *           "hypervisor_sockets": 0,
- *           "has_data": true
+ *           "has_data": true,
+ *           "cloud_sockets": 20
  *         },
  *         {
  *           "date": "2019-07-20T00:00:00Z",
  *           "sockets": 0,
  *           "physical_sockets": 0,
  *           "hypervisor_sockets": 0,
- *           "has_data": true
+ *           "has_data": true,
+ *           "cloud_sockets": 20
  *         },
  *         {
  *           "date": "2019-07-21T00:00:00Z",
  *           "sockets": 24,
  *           "physical_sockets": 24,
  *           "hypervisor_sockets": 0,
- *           "has_data": true
+ *           "has_data": true,
+ *           "cloud_sockets": 20
  *         },
  *         {
  *           "date": "2019-07-22T00:00:00Z",
  *           "sockets": 0,
  *           "physical_sockets": 0,
  *           "hypervisor_sockets": 0,
- *           "has_data": false
+ *           "has_data": false,
+ *           "cloud_sockets": 0
  *         },
  *         {
  *           "date": "2019-07-23T00:00:00Z",
  *           "sockets": 0,
  *           "physical_sockets": 0,
  *           "hypervisor_sockets": 0,
- *           "has_data": false
+ *           "has_data": false,
+ *           "cloud_sockets": 0
  *         },
  *         {
  *           "date": "2019-07-24T00:00:00Z",
  *           "sockets": 76,
  *           "physical_sockets": 36,
  *           "hypervisor_sockets": 40,
- *           "has_data": true
+ *           "has_data": true,
+ *           "cloud_sockets": 0
  *         },
  *         {
  *           "date": "2019-07-25T00:00:00Z",
  *           "sockets": 90,
  *           "physical_sockets": 40,
  *           "hypervisor_sockets": 50,
- *           "has_data": true
+ *           "has_data": true,
+ *           "cloud_sockets": 0
  *         },
  *         {
  *           "date": "2019-07-26T00:00:00Z",
  *           "sockets": 104,
  *           "physical_sockets": 44,
  *           "hypervisor_sockets": 60,
- *           "has_data": true
+ *           "has_data": true,
+ *           "cloud_sockets": 0
  *         },
  *         {
  *           "date": "2019-07-27T00:00:00Z",
  *           "sockets": 78,
  *           "physical_sockets": 48,
  *           "hypervisor_sockets": 30,
- *           "has_data": true
+ *           "has_data": true,
+ *           "cloud_sockets": 0
  *         },
  *         {
  *           "date": "2019-07-28T00:00:00Z",
  *           "sockets": 82,
  *           "physical_sockets": 52,
  *           "hypervisor_sockets": 30,
- *           "has_data": true
+ *           "has_data": true,
+ *           "cloud_sockets": 0
  *         },
  *         {
  *           "date": "2019-07-29T00:00:00Z",
  *           "sockets": 86,
  *           "physical_sockets": 56,
  *           "hypervisor_sockets": 30,
- *           "has_data": true
+ *           "has_data": true,
+ *           "cloud_sockets": 60
  *         },
  *         {
  *           "date": "2019-07-30T00:00:00Z",
  *           "sockets": 90,
  *           "physical_sockets": 60,
  *           "hypervisor_sockets": 30,
- *           "has_data": true
+ *           "has_data": true,
+ *           "cloud_sockets": 40
  *         },
  *         {
  *           "date": "2019-07-31T00:00:00Z",
  *           "sockets": 144,
  *           "physical_sockets": 64,
  *           "hypervisor_sockets": 80,
- *           "has_data": true
+ *           "has_data": true,
+ *           "cloud_sockets": 40
  *         }
  *       ],
  *       "links": {

--- a/src/types/__tests__/__snapshots__/rhsmApiTypes.test.js.snap
+++ b/src/types/__tests__/__snapshots__/rhsmApiTypes.test.js.snap
@@ -34,6 +34,9 @@ Object {
   "RHSM_API_QUERY_START_DATE": "beginning",
   "RHSM_API_RESPONSE_CAPACITY_DATA": "data",
   "RHSM_API_RESPONSE_CAPACITY_DATA_TYPES": Object {
+    "CLOUD_CORES": "cloud_cores",
+    "CLOUD_INSTANCES": "cloud_instance_count",
+    "CLOUD_SOCKETS": "cloud_sockets",
     "CORES": "cores",
     "DATE": "date",
     "HAS_INFINITE": "has_infinite_quantity",
@@ -49,6 +52,9 @@ Object {
   },
   "RHSM_API_RESPONSE_PRODUCTS_DATA": "data",
   "RHSM_API_RESPONSE_PRODUCTS_DATA_TYPES": Object {
+    "CLOUD_CORES": "cloud_cores",
+    "CLOUD_INSTANCES": "cloud_instance_count",
+    "CLOUD_SOCKETS": "cloud_sockets",
     "CORES": "cores",
     "DATE": "date",
     "HAS_DATA": "has_data",
@@ -95,6 +101,9 @@ Object {
     "RHSM_API_QUERY_START_DATE": "beginning",
     "RHSM_API_RESPONSE_CAPACITY_DATA": "data",
     "RHSM_API_RESPONSE_CAPACITY_DATA_TYPES": Object {
+      "CLOUD_CORES": "cloud_cores",
+      "CLOUD_INSTANCES": "cloud_instance_count",
+      "CLOUD_SOCKETS": "cloud_sockets",
       "CORES": "cores",
       "DATE": "date",
       "HAS_INFINITE": "has_infinite_quantity",
@@ -110,6 +119,9 @@ Object {
     },
     "RHSM_API_RESPONSE_PRODUCTS_DATA": "data",
     "RHSM_API_RESPONSE_PRODUCTS_DATA_TYPES": Object {
+      "CLOUD_CORES": "cloud_cores",
+      "CLOUD_INSTANCES": "cloud_instance_count",
+      "CLOUD_SOCKETS": "cloud_sockets",
       "CORES": "cores",
       "DATE": "date",
       "HAS_DATA": "has_data",
@@ -157,6 +169,9 @@ Object {
     "RHSM_API_QUERY_START_DATE": "beginning",
     "RHSM_API_RESPONSE_CAPACITY_DATA": "data",
     "RHSM_API_RESPONSE_CAPACITY_DATA_TYPES": Object {
+      "CLOUD_CORES": "cloud_cores",
+      "CLOUD_INSTANCES": "cloud_instance_count",
+      "CLOUD_SOCKETS": "cloud_sockets",
       "CORES": "cores",
       "DATE": "date",
       "HAS_INFINITE": "has_infinite_quantity",
@@ -172,6 +187,9 @@ Object {
     },
     "RHSM_API_RESPONSE_PRODUCTS_DATA": "data",
     "RHSM_API_RESPONSE_PRODUCTS_DATA_TYPES": Object {
+      "CLOUD_CORES": "cloud_cores",
+      "CLOUD_INSTANCES": "cloud_instance_count",
+      "CLOUD_SOCKETS": "cloud_sockets",
       "CORES": "cores",
       "DATE": "date",
       "HAS_DATA": "has_data",
@@ -223,6 +241,9 @@ Object {
   "RHSM_API_QUERY_START_DATE": "beginning",
   "RHSM_API_RESPONSE_CAPACITY_DATA": "data",
   "RHSM_API_RESPONSE_CAPACITY_DATA_TYPES": Object {
+    "CLOUD_CORES": "cloud_cores",
+    "CLOUD_INSTANCES": "cloud_instance_count",
+    "CLOUD_SOCKETS": "cloud_sockets",
     "CORES": "cores",
     "DATE": "date",
     "HAS_INFINITE": "has_infinite_quantity",
@@ -238,6 +259,9 @@ Object {
   },
   "RHSM_API_RESPONSE_PRODUCTS_DATA": "data",
   "RHSM_API_RESPONSE_PRODUCTS_DATA_TYPES": Object {
+    "CLOUD_CORES": "cloud_cores",
+    "CLOUD_INSTANCES": "cloud_instance_count",
+    "CLOUD_SOCKETS": "cloud_sockets",
     "CORES": "cores",
     "DATE": "date",
     "HAS_DATA": "has_data",

--- a/src/types/rhsmApiTypes.js
+++ b/src/types/rhsmApiTypes.js
@@ -13,6 +13,9 @@ const RHSM_API_RESPONSE_CAPACITY_DATA = 'data';
  *     HYPERVISOR_CORES: string, HAS_INFINITE: string, PHYSICAL_CORES: string}}
  */
 const RHSM_API_RESPONSE_CAPACITY_DATA_TYPES = {
+  CLOUD_CORES: 'cloud_cores',
+  CLOUD_INSTANCES: 'cloud_instance_count',
+  CLOUD_SOCKETS: 'cloud_sockets',
   CORES: 'cores',
   DATE: 'date',
   HYPERVISOR_CORES: 'hypervisor_cores',
@@ -55,6 +58,9 @@ const RHSM_API_RESPONSE_PRODUCTS_DATA = 'data';
  *     PHYSICAL_SOCKETS: string, HYPERVISOR_CORES: string, PHYSICAL_CORES: string}}
  */
 const RHSM_API_RESPONSE_PRODUCTS_DATA_TYPES = {
+  CLOUD_CORES: 'cloud_cores',
+  CLOUD_INSTANCES: 'cloud_instance_count',
+  CLOUD_SOCKETS: 'cloud_sockets',
   CORES: 'cores',
   DATE: 'date',
   HYPERVISOR_CORES: 'hypervisor_cores',


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- feat(rhelView): issues/226 display cloud metering data
   * i18, public cloud string
   * rhelView, filter for cloud meter sockets
   * rhsmServices, mock for cloud meter properties
   * rhsmApiTypes, add cloud meter types

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
Confirmation is needed on:
- [x] the Public cloud purple used. Currently it is
   - `chart_color_purple_100`
   - `chart_color_purple_300`
- [x] the API property to use. The choices are `cloud_cores`, `cloud_instance_count` and `cloud_sockets`. Currently it is
   - `cloud_sockets`
   - CONFIRMED
- [x] confirm the copy associated with the legend label as "Public clout"
   - CONFIRMED
- [x] are cloud metering based totals included in the general `sockets` Capacity/Threshold API response property we're currently using
   - MOSTLY confirmed

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. You should see something similar to the attached screenshot below.
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
  
![Screen Shot 2020-03-25 at 12 42 22 PM](https://user-images.githubusercontent.com/3761375/77563415-a2e11b00-6e97-11ea-8a3f-c71495aed1c8.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Updates #226 

@rblackbu