### PR TITLE
Issues/240 - Platform services debugging, auth empty state, and translate a node

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,9 +100,9 @@ Specific uses:
 This project makes use of reserved CSS class prefixes used by external resources. 
 > Updating elements with these classes should be done with the knowledge "you are affecting an external resource in a potentially unanticipated way".
 
-1. Prefix `uiux-`
+1. Prefix `uxui-`
 
-   CSS classes with the prefix `uiux-` are used by external resources to identify elements for use in 3rd party tooling. Changes to the class name or element should be broadcast towards our UI/UX team members. 
+   CSS classes with the prefix `uxui-` are used by external resources to identify elements for use in 3rd party tooling. Changes to the class name or element should be broadcast towards our UI/UX team members. 
 
 ### Reserved QE testing attributes
 This project makes use of reserved DOM attributes used by the QE team.
@@ -140,23 +140,32 @@ The name of the window value can be found under the dotenv file `.env`
    REACT_APP_UI_LOGGER_ID=curiosity
    ```
 
-#### Debugging the Graph Display
-You can apply a date override during local development by adding a `.env.local` (dotenv) file with the following line, in the repository root directory
+#### Debugging local development
+You can apply overrides during local development by adding a `.env.local` (dotenv) file in the repository root directory.
+
+Once you have made the dotenv file and/or changes, like the below "debug" flags, restart the project and the flags should be active.
+
+*Any changes you make to the `.env.local` file should be ignored with `.gitignore`.*
+
+##### Graph display
+You can apply a date override during **local development** (using `$ yarn start`) by adding the following line to your `.env.local` file.
    ```
    REACT_APP_DEBUG_DEFAULT_DATETIME=20190630
    ```
 
-*Any changes you make to the `.env.local` file should be ignored with `.gitignore`.*
+##### Admin role
+You can access the administrator role experience during **local development** (using `$ yarn start`) by adding the following line to your `.env.local` file.
+   ```
+   REACT_APP_DEBUG_ORG_ADMIN=true
+   ```
 
-#### Debugging Redux
-This project makes use of React & Redux. To enable Redux console logging, within the repository root directory, add a `.env.local` (dotenv) file with the follow line
+Combining this flag with [manipulating the http status on the API/service mocks](https://github.com/cdcabrera/apidoc-mock#more-examples-and-custom-responses) can be an effective emulation.
+
+##### Debugging Redux
+This project makes use of React & Redux. To enable Redux browser console logging add the following line to your `.env.local` file.
   ```
   REACT_APP_DEBUG_MIDDLEWARE=true
   ```
-
-Once you've made the change, restart the project and console browser logging should appear.
-
-*Any changes you make to the `.env.local` file should be ignored with `.gitignore`.*
 
 #### Unit Testing
 To run the unit tests with a watch during development you'll need to open an additional terminal instance, then run

--- a/public/locales/en-US.json
+++ b/public/locales/en-US.json
@@ -1,8 +1,8 @@
 {
   "curiosity-auth": {
     "pending": "Authenticating...",
-    "authorizedTitle": "Unauthorized",
-    "authorizedCopy": "You do not have permission to access reporting. Contact your administrator."
+    "authorizedTitle": "You do not have access to {{appName}}.",
+    "authorizedCopy": "Contact your organization administrator(s) for more information."
   },
   "curiosity-graph": {
     "cardHeading": "CPU usage",

--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -35,10 +35,12 @@ const noopPromise = Promise.resolve({});
  * Associated with the i18n package, and typically used as a default prop.
  *
  * @param {string} key
- * @param {string} value
+ * @param {string|object} value
+ * @param {Array} components
  * @returns {string}
  */
-const noopTranslate = (key, value) => `t(${key}${(value && `, ${value}`) || ''})`;
+const noopTranslate = (key, value, components) =>
+  `t(${key}${(value && `, ${value}`) || ''}${(components && `, ${components}`) || ''})`;
 
 /**
  * Is dev mode active.

--- a/src/components/authentication/__tests__/__snapshots__/authentication.test.js.snap
+++ b/src/components/authentication/__tests__/__snapshots__/authentication.test.js.snap
@@ -61,7 +61,8 @@ exports[`Authorization Component should render a non-connected component error: 
   <MessageView
     icon={[Function]}
     message="t(curiosity-auth.authorizedCopy, ...)"
-    title="t(curiosity-auth.authorizedTitle, ...)"
+    pageTitle={null}
+    title="t(curiosity-auth.authorizedTitle, [object Object])"
   >
     <PageLayout>
       <PageHeader
@@ -73,7 +74,7 @@ exports[`Authorization Component should render a non-connected component error: 
             widget-type="InsightsPageHeader"
           >
             <PageHeaderTitle
-              title="t(curiosity-auth.authorizedTitle, ...)"
+              title="Subscription Watch"
             >
               <Title
                 className=""
@@ -85,7 +86,7 @@ exports[`Authorization Component should render a non-connected component error: 
                   widget-type="InsightsPageHeaderTitle"
                 >
                    
-                  t(curiosity-auth.authorizedTitle, ...)
+                  Subscription Watch
                    
                 </h1>
               </Title>
@@ -107,10 +108,20 @@ exports[`Authorization Component should render a non-connected component error: 
             <div
               className="pf-c-empty-state fadein"
             >
+              <Title
+                headingLevel="h2"
+                size="lg"
+              >
+                <h2
+                  className="pf-c-title pf-m-lg"
+                >
+                  t(curiosity-auth.authorizedTitle, [object Object])
+                </h2>
+              </Title>
               <EmptyStateIcon
                 icon={[Function]}
               >
-                <BanIcon
+                <LockIcon
                   aria-hidden="true"
                   className="pf-c-empty-state__icon"
                   color="currentColor"
@@ -130,15 +141,15 @@ exports[`Authorization Component should render a non-connected component error: 
                         "verticalAlign": "-0.125em",
                       }
                     }
-                    viewBox="0 0 512 512"
+                    viewBox="0 0 448 512"
                     width="1em"
                   >
                     <path
-                      d="M256 8C119.034 8 8 119.033 8 256s111.034 248 248 248 248-111.034 248-248S392.967 8 256 8zm130.108 117.892c65.448 65.448 70 165.481 20.677 235.637L150.47 105.216c70.204-49.356 170.226-44.735 235.638 20.676zM125.892 386.108c-65.448-65.448-70-165.481-20.677-235.637L361.53 406.784c-70.203 49.356-170.226 44.736-235.638-20.676z"
+                      d="M400 224h-24v-72C376 68.2 307.8 0 224 0S72 68.2 72 152v72H48c-26.5 0-48 21.5-48 48v192c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V272c0-26.5-21.5-48-48-48zm-104 0H152v-72c0-39.7 32.3-72 72-72s72 32.3 72 72v72z"
                       transform=""
                     />
                   </svg>
-                </BanIcon>
+                </LockIcon>
               </EmptyStateIcon>
               <EmptyStateBody>
                 <div
@@ -160,7 +171,8 @@ exports[`Authorization Component should render a non-connected component pending
 <MessageView
   icon={[Function]}
   message="t(curiosity-auth.pending, ...)"
-  title=" "
+  pageTitle=" "
+  title={null}
 />
 `;
 
@@ -175,7 +187,7 @@ exports[`Authorization Component should return a message on 401 error: 401 error
         widget-type="InsightsPageHeader"
       >
         <PageHeaderTitle
-          title="t(curiosity-auth.authorizedTitle, ...)"
+          title="Subscription Watch"
         >
           <Title
             className=""
@@ -187,7 +199,7 @@ exports[`Authorization Component should return a message on 401 error: 401 error
               widget-type="InsightsPageHeaderTitle"
             >
                
-              t(curiosity-auth.authorizedTitle, ...)
+              Subscription Watch
                
             </h1>
           </Title>
@@ -209,10 +221,20 @@ exports[`Authorization Component should return a message on 401 error: 401 error
         <div
           className="pf-c-empty-state fadein"
         >
+          <Title
+            headingLevel="h2"
+            size="lg"
+          >
+            <h2
+              className="pf-c-title pf-m-lg"
+            >
+              t(curiosity-auth.authorizedTitle, [object Object])
+            </h2>
+          </Title>
           <EmptyStateIcon
             icon={[Function]}
           >
-            <BanIcon
+            <LockIcon
               aria-hidden="true"
               className="pf-c-empty-state__icon"
               color="currentColor"
@@ -232,15 +254,15 @@ exports[`Authorization Component should return a message on 401 error: 401 error
                     "verticalAlign": "-0.125em",
                   }
                 }
-                viewBox="0 0 512 512"
+                viewBox="0 0 448 512"
                 width="1em"
               >
                 <path
-                  d="M256 8C119.034 8 8 119.033 8 256s111.034 248 248 248 248-111.034 248-248S392.967 8 256 8zm130.108 117.892c65.448 65.448 70 165.481 20.677 235.637L150.47 105.216c70.204-49.356 170.226-44.735 235.638 20.676zM125.892 386.108c-65.448-65.448-70-165.481-20.677-235.637L361.53 406.784c-70.203 49.356-170.226 44.736-235.638-20.676z"
+                  d="M400 224h-24v-72C376 68.2 307.8 0 224 0S72 68.2 72 152v72H48c-26.5 0-48 21.5-48 48v192c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V272c0-26.5-21.5-48-48-48zm-104 0H152v-72c0-39.7 32.3-72 72-72s72 32.3 72 72v72z"
                   transform=""
                 />
               </svg>
-            </BanIcon>
+            </LockIcon>
           </EmptyStateIcon>
           <EmptyStateBody>
             <div

--- a/src/components/authentication/authentication.js
+++ b/src/components/authentication/authentication.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { BanIcon, BinocularsIcon } from '@patternfly/react-icons';
+import { BinocularsIcon, LockIcon } from '@patternfly/react-icons';
 import { connectRouterTranslate, reduxActions } from '../../redux';
 import { helpers } from '../../common';
 import { Redirect, routerHelpers, routerTypes } from '../router/router';
@@ -55,7 +55,7 @@ class Authentication extends Component {
     }
 
     if (session.pending) {
-      return <MessageView title="&nbsp;" message={t('curiosity-auth.pending', '...')} icon={BinocularsIcon} />;
+      return <MessageView pageTitle="&nbsp;" message={t('curiosity-auth.pending', '...')} icon={BinocularsIcon} />;
     }
 
     if (session.errorStatus === 403 || session.errorStatus === 418) {
@@ -67,9 +67,9 @@ class Authentication extends Component {
 
     return (
       <MessageView
-        title={t('curiosity-auth.authorizedTitle', '...')}
+        title={t('curiosity-auth.authorizedTitle', { appName: helpers.UI_DISPLAY_NAME })}
         message={t('curiosity-auth.authorizedCopy', '...')}
-        icon={BanIcon}
+        icon={LockIcon}
       />
     );
   }

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -14,6 +14,10 @@ exports[`I18n Component should generate a predictable pot output snapshot: pot o
 msgstr \\"\\"
 \\"Content-Type: text/plain; charset=UTF-8\\\\n\\"
 
+#: src/components/authentication/authentication.js:70
+msgid \\"curiosity-auth.authorizedTitle\\"
+msgstr \\"\\"
+
 #: src/components/openshiftView/openshiftView.js:90
 msgid \\"curiosity-graph.cardHeading\\"
 msgstr \\"\\"
@@ -125,11 +129,6 @@ msgstr \\"\\"
 #: src/components/authentication/authentication.js:71
 msgctxt \\"...\\"
 msgid \\"curiosity-auth.authorizedCopy\\"
-msgstr \\"\\"
-
-#: src/components/authentication/authentication.js:70
-msgctxt \\"...\\"
-msgid \\"curiosity-auth.authorizedTitle\\"
 msgstr \\"\\"
 
 #: src/components/authentication/authentication.js:58

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -9,6 +9,8 @@ Object {
 }
 `;
 
+exports[`I18n Component should attempt to perform translate with a node: translated node 1`] = `"<div>t(lorem.ipsum, [object Object], [object Object])</div>"`;
+
 exports[`I18n Component should generate a predictable pot output snapshot: pot output 1`] = `
 "msgid \\"\\"
 msgstr \\"\\"

--- a/src/components/i18n/__tests__/i18n.test.js
+++ b/src/components/i18n/__tests__/i18n.test.js
@@ -60,6 +60,17 @@ describe('I18n Component', () => {
     expect(component.html()).toMatchSnapshot('children');
   });
 
+  it('should attempt to perform translate with a node', () => {
+    const ExampleComponent = () => <div>{translate('lorem.ipsum', { hello: 'world' }, [<span id="test" />])}</div>;
+
+    ExampleComponent.propTypes = {};
+    ExampleComponent.defaultProps = {};
+
+    const component = shallow(<ExampleComponent />);
+
+    expect(component.html()).toMatchSnapshot('translated node');
+  });
+
   it('should attempt to perform a component translate', () => {
     const ExampleComponent = ({ t }) => <div>{t('lorem.ipsum', 'hello world')}</div>;
 

--- a/src/components/i18n/i18n.js
+++ b/src/components/i18n/i18n.js
@@ -2,12 +2,36 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import i18next from 'i18next';
 import XHR from 'i18next-xhr-backend';
-import { initReactI18next, withTranslation } from 'react-i18next';
+import { initReactI18next, Trans, withTranslation } from 'react-i18next';
 import { helpers } from '../../common/helpers';
 
-const translate = (str, placeholder = null) =>
-  (!helpers.TEST_MODE && i18next.t(str, placeholder)) || helpers.noopTranslate(str, placeholder);
+/**
+ * Apply a string towards a key. Optional replacement values and component/nodes.
+ * See, https://react.i18next.com/
+ *
+ * @param {string} translateKey
+ * @param {string|Array} values A default string if the key can't be found. An array of objects (key/value) pairs used to replace string tokes. i.e. "[{ hello: 'world' }]"
+ * @param {Array} components An array of HTML/React nodes used to replace string tokens. i.e. "[<span />, <React.Fragment />]"
+ * @returns {string|Node}
+ */
+const translate = (translateKey, values = null, components) => {
+  if (helpers.TEST_MODE) {
+    return helpers.noopTranslate(translateKey, values, components);
+  }
 
+  if (components) {
+    return <Trans i18nKey={translateKey} values={values} components={components} />;
+  }
+
+  return i18next.t(translateKey, values);
+};
+
+/**
+ * Apply string replacements against a component.
+ *
+ * @param {Node} component
+ * @returns {Node}
+ */
 const translateComponent = component => (!helpers.TEST_MODE && withTranslation()(component)) || component;
 
 /**

--- a/src/components/messageView/__tests__/__snapshots__/messageView.test.js.snap
+++ b/src/components/messageView/__tests__/__snapshots__/messageView.test.js.snap
@@ -15,12 +15,18 @@ exports[`MessageView Component should have fallback conditions for all props: fa
 exports[`MessageView Component should render a non-connected component: non-connected 1`] = `
 <PageLayout>
   <PageHeader>
-    lorem
+    Subscription Watch
   </PageHeader>
   <EmptyState
     className="fadein"
     variant="full"
   >
+    <Title
+      headingLevel="h2"
+      size="lg"
+    >
+      lorem
+    </Title>
     <EmptyStateIcon
       icon={[Function]}
     />

--- a/src/components/messageView/messageView.js
+++ b/src/components/messageView/messageView.js
@@ -1,22 +1,32 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { EmptyState as PfEmptyState, EmptyStateBody, EmptyStateIcon, EmptyStateVariant } from '@patternfly/react-core';
+import {
+  EmptyState as PfEmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  Title
+} from '@patternfly/react-core';
 import { PageLayout, PageHeader } from '../pageLayout/pageLayout';
 import { helpers } from '../../common';
 
 /**
- * FixMe: Patternfly EmptyStateIcon PropType is not intuitive
- * Requires the use of a function proptype?!?
+ * FixMe: Patternfly EmptyStateIcon PropType registers as function?
  */
 /**
  * Render a message view.
  *
  * @returns {Node}
  */
-const MessageView = ({ icon, message, title }) => (
+const MessageView = ({ icon, message, pageTitle, title }) => (
   <PageLayout>
-    <PageHeader>{title || helpers.UI_DISPLAY_CONFIG_NAME}</PageHeader>
+    <PageHeader>{pageTitle || helpers.UI_DISPLAY_NAME}</PageHeader>
     <PfEmptyState variant={EmptyStateVariant.full} className="fadein">
+      {title && (
+        <Title headingLevel="h2" size="lg">
+          {title}
+        </Title>
+      )}
       {icon && <EmptyStateIcon icon={icon} />}
       {message && <EmptyStateBody>{message}</EmptyStateBody>}
     </PfEmptyState>
@@ -31,6 +41,7 @@ const MessageView = ({ icon, message, title }) => (
 MessageView.propTypes = {
   icon: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   message: PropTypes.string,
+  pageTitle: PropTypes.string,
   title: PropTypes.string
 };
 
@@ -42,6 +53,7 @@ MessageView.propTypes = {
 MessageView.defaultProps = {
   icon: null,
   message: null,
+  pageTitle: null,
   title: null
 };
 

--- a/src/services/platformServices.js
+++ b/src/services/platformServices.js
@@ -1,4 +1,6 @@
+import _set from 'lodash/set';
 import { helpers } from '../common';
+import { platformApiTypes } from '../types';
 
 /**
  * Basic user authentication.
@@ -8,7 +10,19 @@ import { helpers } from '../common';
 const getUser = async () => {
   const { insights } = window;
   try {
-    return (helpers.DEV_MODE && { test: {} }) || (await insights.chrome.auth.getUser());
+    return (
+      (helpers.DEV_MODE &&
+        _set(
+          {},
+          [
+            platformApiTypes.PLATFORM_API_RESPONSE_USER_IDENTITY,
+            platformApiTypes.PLATFORM_API_RESPONSE_USER_IDENTITY_TYPES.USER,
+            platformApiTypes.PLATFORM_API_RESPONSE_USER_IDENTITY_USER_TYPES.ORG_ADMIN
+          ],
+          process.env.REACT_APP_DEBUG_ORG_ADMIN === 'true'
+        )) ||
+      (await insights.chrome.auth.getUser())
+    );
   } catch (e) {
     throw new Error(`{ getUser } = insights.chrome.auth, ${e.message}`);
   }


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(platformServices): issue/240 admin API debugging behavior
- fix(authentication,messageView): auth empty state 
   * authentication, update auth empty state
   * messageView, add pageTitle prop
- feat(i18n): issues/240 expose translating a node 
   * helpers, noopTranslate
   * i18n, add node translate, annotations

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- Support additions for #240 

## How to test
<!-- Are there directions to test/review? -->
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
  
![Screen Shot 2020-04-09 at 6 54 00 PM](https://user-images.githubusercontent.com/3761375/78947520-8d711100-7a93-11ea-8217-e4eba83b798c.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
#240 