### PR TITLE
fix(authentication,optinView): issues/240 expand unit tests

### DIFF
--- a/src/components/authentication/__tests__/__snapshots__/authentication.test.js.snap
+++ b/src/components/authentication/__tests__/__snapshots__/authentication.test.js.snap
@@ -205,7 +205,7 @@ exports[`Authorization Component should render a non-connected component pending
 />
 `;
 
-exports[`Authorization Component should return a message on 401 error: 401 error 1`] = `
+exports[`Authorization Component should return a message on 401 admin error: 401 admin error 1`] = `
 <PageLayout>
   <PageHeader
     key=".0"
@@ -307,6 +307,12 @@ exports[`Authorization Component should return a message on 401 error: 401 error
 </PageLayout>
 `;
 
+exports[`Authorization Component should return a message on 401 error: 401 error 1`] = `"401 redirect"`;
+
+exports[`Authorization Component should return a redirect on 403 error: 403 admin error 1`] = `"403 redirect"`;
+
 exports[`Authorization Component should return a redirect on 403 error: 403 error 1`] = `"403 redirect"`;
+
+exports[`Authorization Component should return a redirect on 418 error: 418 admin error 1`] = `"418 redirect"`;
 
 exports[`Authorization Component should return a redirect on 418 error: 418 error 1`] = `"418 redirect"`;

--- a/src/components/authentication/__tests__/authentication.test.js
+++ b/src/components/authentication/__tests__/authentication.test.js
@@ -47,11 +47,8 @@ describe('Authorization Component', () => {
 
     component.setProps({
       session: {
-        admin: true,
-        authorized: false,
-        error: true,
-        errorMessage: 'Authentication credentials were not provided.',
-        pending: false
+        ...props.session,
+        admin: true
       }
     });
 
@@ -82,6 +79,15 @@ describe('Authorization Component', () => {
     );
 
     expect(component.html()).toMatchSnapshot('418 error');
+
+    component.setProps({
+      session: {
+        ...props.session,
+        admin: true
+      }
+    });
+
+    expect(component.html()).toMatchSnapshot('418 admin error');
   });
 
   it('should return a redirect on 403 error', () => {
@@ -108,6 +114,15 @@ describe('Authorization Component', () => {
     );
 
     expect(component.html()).toMatchSnapshot('403 error');
+
+    component.setProps({
+      session: {
+        ...props.session,
+        admin: true
+      }
+    });
+
+    expect(component.html()).toMatchSnapshot('403 admin error');
   });
 
   it('should return a message on 401 error', () => {
@@ -117,12 +132,9 @@ describe('Authorization Component', () => {
         push: helpers.noop
       },
       session: {
-        admin: true,
+        admin: false,
         authorized: false,
-        error: true,
-        errorStatus: 401,
-        errorMessage: `Unauthorized`,
-        pending: false
+        errorStatus: 401
       }
     };
     const component = mount(
@@ -133,7 +145,30 @@ describe('Authorization Component', () => {
       </BrowserRouter>
     );
 
-    expect(component.find('PageLayout')).toMatchSnapshot('401 error');
+    expect(component.html()).toMatchSnapshot('401 error');
+  });
+
+  it('should return a message on 401 admin error', () => {
+    const props = {
+      history: {
+        listen: helpers.noop,
+        push: helpers.noop
+      },
+      session: {
+        admin: true,
+        authorized: false,
+        errorStatus: 401
+      }
+    };
+    const component = mount(
+      <BrowserRouter>
+        <Authentication {...props}>
+          <span className="test">lorem</span>
+        </Authentication>
+      </BrowserRouter>
+    );
+
+    expect(component.find('PageLayout')).toMatchSnapshot('401 admin error');
   });
 
   it('should render a non-connected component pending', () => {

--- a/src/components/optinView/__tests__/__snapshots__/optinView.test.js.snap
+++ b/src/components/optinView/__tests__/__snapshots__/optinView.test.js.snap
@@ -147,3 +147,203 @@ exports[`OptinView Component should render a non-connected component: non-connec
   </Card>
 </PageLayout>
 `;
+
+exports[`OptinView Component should render an organization administrator view: error admin view 1`] = `
+<CardFooter>
+  <p>
+    t(curiosity-optin.cardIsErrorDescription, [object Object], [object Object])
+  </p>
+</CardFooter>
+`;
+
+exports[`OptinView Component should render an organization administrator view: fulfilled admin view 1`] = `
+<CardFooter>
+  <Form>
+    <ActionGroup>
+      <Component
+        isDisabled={true}
+        variant="primary"
+      >
+        t(curiosity-optin.buttonIsActive, [object Object])
+      </Component>
+    </ActionGroup>
+    <p>
+      t(curiosity-optin.cardIsActiveDescription)
+    </p>
+  </Form>
+</CardFooter>
+`;
+
+exports[`OptinView Component should render an organization administrator view: initial admin view 1`] = `
+<PageLayout>
+  <Card>
+    <Flex
+      breakpointMods={
+        Array [
+          Object {
+            "modifier": "column",
+          },
+          Object {
+            "breakpoint": "md",
+            "modifier": "row",
+          },
+        ]
+      }
+    >
+      <Flex
+        breakpointMods={
+          Array [
+            Object {
+              "modifier": "flex-2",
+            },
+          ]
+        }
+      >
+        <FlexItem>
+          <CardHeader
+            key="heading1Title"
+          >
+            <Title
+              size="2xl"
+            >
+              t(curiosity-optin.cardTitle, [object Object])
+            </Title>
+          </CardHeader>
+          <CardBody
+            key="heading1Desc"
+          >
+            t(curiosity-optin.cardDescription, [object Object])
+          </CardBody>
+          <CardHeader
+            key="heading2Title"
+          >
+            <Title
+              headingLevel="h2"
+              size="xl"
+            >
+              t(curiosity-optin.cardSeeTitle)
+            </Title>
+          </CardHeader>
+          <CardBody
+            key="heading2Desc"
+          >
+            t(curiosity-optin.cardSeeDescription)
+          </CardBody>
+          <CardHeader
+            key="heading3Title"
+          >
+            <Title
+              headingLevel="h2"
+              size="xl"
+            >
+              t(curiosity-optin.cardReportTitle)
+            </Title>
+          </CardHeader>
+          <CardBody
+            key="heading3Desc"
+          >
+            t(curiosity-optin.cardReportDescription)
+          </CardBody>
+          <CardHeader
+            key="heading4Title"
+          >
+            <Title
+              headingLevel="h2"
+              size="xl"
+            >
+              t(curiosity-optin.cardFilterTitle)
+            </Title>
+          </CardHeader>
+          <CardBody
+            key="heading4Desc"
+          >
+            t(curiosity-optin.cardFilterDescription)
+          </CardBody>
+          <CardFooter>
+            <Form>
+              <ActionGroup>
+                <Component
+                  onClick={[Function]}
+                  variant="primary"
+                >
+                  t(curiosity-optin.buttonActivate, [object Object])
+                </Component>
+              </ActionGroup>
+            </Form>
+          </CardFooter>
+        </FlexItem>
+      </Flex>
+      <Flex
+        breakpointMods={
+          Array [
+            Object {
+              "modifier": "flex-1",
+            },
+            Object {
+              "modifier": "align-self-center",
+            },
+          ]
+        }
+      >
+        <FlexItem>
+          <CardBody>
+            <Card
+              className="curiosity-optin-tour"
+            >
+              <CardHead>
+                <CardHeadMain>
+                  <Brand
+                    alt="t(curiosity-optin.tourTitleImageAlt)"
+                    aria-hidden={true}
+                    className="curiosity-optin-image"
+                    src="graph4x.png"
+                    srcSet="graph4x.png 1064w, graph2x.png 600w"
+                  />
+                </CardHeadMain>
+              </CardHead>
+              <CardHeader>
+                <Title
+                  headingLevel="h3"
+                  size="2xl"
+                >
+                  t(curiosity-optin.tourTitle)
+                </Title>
+              </CardHeader>
+              <CardBody>
+                t(curiosity-optin.tourDescription)
+              </CardBody>
+              <CardFooter>
+                <Component
+                  className="uxui-curiosity__button-tour"
+                  variant="secondary"
+                >
+                  t(curiosity-optin.buttonTour)
+                </Component>
+              </CardFooter>
+            </Card>
+          </CardBody>
+        </FlexItem>
+      </Flex>
+    </Flex>
+  </Card>
+</PageLayout>
+`;
+
+exports[`OptinView Component should render an organization administrator view: pending admin view 1`] = `
+<CardFooter>
+  <Form>
+    <ActionGroup>
+      <Component
+        isDisabled={true}
+        variant="primary"
+      >
+        <Spinner
+          size="sm"
+        />
+         
+        t(curiosity-optin.buttonActivate, [object Object])
+      </Component>
+    </ActionGroup>
+  </Form>
+</CardFooter>
+`;

--- a/src/components/optinView/__tests__/optinView.test.js
+++ b/src/components/optinView/__tests__/optinView.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { OptinView } from '../optinView';
 
 describe('OptinView Component', () => {
@@ -8,5 +8,52 @@ describe('OptinView Component', () => {
 
     const component = shallow(<OptinView {...props} />);
     expect(component).toMatchSnapshot('non-connected');
+  });
+
+  it('should render an organization administrator view', () => {
+    const props = {
+      session: {
+        admin: true
+      }
+    };
+
+    const component = shallow(<OptinView {...props} />);
+    expect(component).toMatchSnapshot('initial admin view');
+
+    component.setProps({
+      pending: true
+    });
+    expect(component.find('CardFooter').first()).toMatchSnapshot('pending admin view');
+
+    component.setProps({
+      pending: false,
+      error: true
+    });
+    expect(component.find('CardFooter').first()).toMatchSnapshot('error admin view');
+
+    component.setProps({
+      pending: false,
+      error: false,
+      fulfilled: true
+    });
+    expect(component.find('CardFooter').first()).toMatchSnapshot('fulfilled admin view');
+  });
+
+  it('should submit an opt-in form', () => {
+    const props = {
+      session: {
+        admin: true
+      }
+    };
+
+    const component = mount(<OptinView {...props} />);
+    const componentInstance = component.instance();
+    const spy = jest.spyOn(componentInstance, 'onSubmitOptIn');
+
+    component.update();
+    componentInstance.forceUpdate();
+
+    component.find('form button').simulate('click');
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(authentication,optinView): issues/240 expand unit tests

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- Baseline opt-in tests
- Expanded to include authenticaton

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`

<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
#240 