### PR TITLE
fix(authentication,optinView): issues/240 optin for all users

### DIFF
--- a/public/locales/en-US.json
+++ b/public/locales/en-US.json
@@ -46,7 +46,6 @@
     "cardFilterDescription": "View your inventory by critical indicators like Service Level Agreement (SLA) and architecture.",
     "cardIsActiveDescription": "Data can take up to 24 hours to be processed and will appear on this page when ready",
     "cardIsErrorDescription": "An opt-in error has occurred. <0>Contact us</0> for more information",
-    "cardContactAdminDescription": "You must be an organization administrator with the org-admin role to view {{appName}}.",
     "notificationsErrorTitle": "{{appName}} opt-in failed",
     "notificationsErrorDescription": "Contact us for more information",
     "notificationsSuccessTitle": "{{appName}} activated",

--- a/src/components/authentication/__tests__/__snapshots__/authentication.test.js.snap
+++ b/src/components/authentication/__tests__/__snapshots__/authentication.test.js.snap
@@ -19,7 +19,6 @@ exports[`Authorization Component should render a non-connected component authori
   onNavigation={[Function]}
   session={
     Object {
-      "admin": true,
       "authorized": true,
       "error": false,
       "errorMessage": "",
@@ -37,7 +36,7 @@ exports[`Authorization Component should render a non-connected component authori
 </Authentication>
 `;
 
-exports[`Authorization Component should render a non-connected component error: non-connected admin error 1`] = `
+exports[`Authorization Component should render a non-connected component error: non-connected error 1`] = `
 <Authentication
   authorizeUser={[Function]}
   history={
@@ -50,7 +49,6 @@ exports[`Authorization Component should render a non-connected component error: 
   onNavigation={[Function]}
   session={
     Object {
-      "admin": true,
       "authorized": false,
       "error": true,
       "errorMessage": "Authentication credentials were not provided.",
@@ -169,33 +167,6 @@ exports[`Authorization Component should render a non-connected component error: 
 </Authentication>
 `;
 
-exports[`Authorization Component should render a non-connected component error: non-connected error 1`] = `
-<Authentication
-  authorizeUser={[Function]}
-  history={
-    Object {
-      "listen": [Function],
-      "push": [Function],
-    }
-  }
-  initializeChrome={[Function]}
-  onNavigation={[Function]}
-  session={
-    Object {
-      "admin": false,
-      "authorized": false,
-      "error": true,
-      "errorMessage": "Authentication credentials were not provided.",
-      "pending": false,
-    }
-  }
-  setAppName={[Function]}
-  t={[Function]}
->
-   redirect
-</Authentication>
-`;
-
 exports[`Authorization Component should render a non-connected component pending: non-connected pending 1`] = `
 <MessageView
   icon={[Function]}
@@ -205,7 +176,7 @@ exports[`Authorization Component should render a non-connected component pending
 />
 `;
 
-exports[`Authorization Component should return a message on 401 admin error: 401 admin error 1`] = `
+exports[`Authorization Component should return a message on 401 error: 401 error 1`] = `
 <PageLayout>
   <PageHeader
     key=".0"
@@ -307,12 +278,6 @@ exports[`Authorization Component should return a message on 401 admin error: 401
 </PageLayout>
 `;
 
-exports[`Authorization Component should return a message on 401 error: 401 error 1`] = `"401 redirect"`;
-
-exports[`Authorization Component should return a redirect on 403 error: 403 admin error 1`] = `"403 redirect"`;
-
 exports[`Authorization Component should return a redirect on 403 error: 403 error 1`] = `"403 redirect"`;
-
-exports[`Authorization Component should return a redirect on 418 error: 418 admin error 1`] = `"418 redirect"`;
 
 exports[`Authorization Component should return a redirect on 418 error: 418 error 1`] = `"418 redirect"`;

--- a/src/components/authentication/__tests__/authentication.test.js
+++ b/src/components/authentication/__tests__/authentication.test.js
@@ -10,7 +10,7 @@ describe('Authorization Component', () => {
 
   it('should render a connected component', () => {
     const store = generateEmptyStore({
-      user: { session: { admin: false, authorized: false, error: false, errorMessage: '', pending: false } }
+      user: { session: { authorized: false, error: false, errorMessage: '', pending: false } }
     });
 
     const component = shallow(
@@ -30,7 +30,6 @@ describe('Authorization Component', () => {
         push: helpers.noop
       },
       session: {
-        admin: false,
         authorized: false,
         error: true,
         errorMessage: 'Authentication credentials were not provided.',
@@ -44,15 +43,6 @@ describe('Authorization Component', () => {
     );
 
     expect(component).toMatchSnapshot('non-connected error');
-
-    component.setProps({
-      session: {
-        ...props.session,
-        admin: true
-      }
-    });
-
-    expect(component).toMatchSnapshot('non-connected admin error');
   });
 
   it('should return a redirect on 418 error', () => {
@@ -62,7 +52,6 @@ describe('Authorization Component', () => {
         push: helpers.noop
       },
       session: {
-        admin: false,
         authorized: false,
         error: true,
         errorStatus: 418,
@@ -79,15 +68,6 @@ describe('Authorization Component', () => {
     );
 
     expect(component.html()).toMatchSnapshot('418 error');
-
-    component.setProps({
-      session: {
-        ...props.session,
-        admin: true
-      }
-    });
-
-    expect(component.html()).toMatchSnapshot('418 admin error');
   });
 
   it('should return a redirect on 403 error', () => {
@@ -97,7 +77,6 @@ describe('Authorization Component', () => {
         push: helpers.noop
       },
       session: {
-        admin: false,
         authorized: false,
         error: true,
         errorStatus: 403,
@@ -114,15 +93,6 @@ describe('Authorization Component', () => {
     );
 
     expect(component.html()).toMatchSnapshot('403 error');
-
-    component.setProps({
-      session: {
-        ...props.session,
-        admin: true
-      }
-    });
-
-    expect(component.html()).toMatchSnapshot('403 admin error');
   });
 
   it('should return a message on 401 error', () => {
@@ -132,7 +102,6 @@ describe('Authorization Component', () => {
         push: helpers.noop
       },
       session: {
-        admin: false,
         authorized: false,
         errorStatus: 401
       }
@@ -145,30 +114,7 @@ describe('Authorization Component', () => {
       </BrowserRouter>
     );
 
-    expect(component.html()).toMatchSnapshot('401 error');
-  });
-
-  it('should return a message on 401 admin error', () => {
-    const props = {
-      history: {
-        listen: helpers.noop,
-        push: helpers.noop
-      },
-      session: {
-        admin: true,
-        authorized: false,
-        errorStatus: 401
-      }
-    };
-    const component = mount(
-      <BrowserRouter>
-        <Authentication {...props}>
-          <span className="test">lorem</span>
-        </Authentication>
-      </BrowserRouter>
-    );
-
-    expect(component.find('PageLayout')).toMatchSnapshot('401 admin error');
+    expect(component.find('PageLayout')).toMatchSnapshot('401 error');
   });
 
   it('should render a non-connected component pending', () => {
@@ -178,7 +124,6 @@ describe('Authorization Component', () => {
         push: helpers.noop
       },
       session: {
-        admin: false,
         authorized: false,
         error: false,
         errorMessage: '',
@@ -201,7 +146,6 @@ describe('Authorization Component', () => {
         push: helpers.noop
       },
       session: {
-        admin: true,
         authorized: true,
         error: false,
         errorMessage: '',

--- a/src/components/authentication/authentication.js
+++ b/src/components/authentication/authentication.js
@@ -50,7 +50,7 @@ class Authentication extends Component {
   render() {
     const { children, session, t } = this.props;
 
-    if (session.authorized && session.admin) {
+    if (session.authorized) {
       return <React.Fragment>{children}</React.Fragment>;
     }
 
@@ -58,7 +58,7 @@ class Authentication extends Component {
       return <MessageView pageTitle="&nbsp;" message={t('curiosity-auth.pending', '...')} icon={BinocularsIcon} />;
     }
 
-    if (!session.admin || session.errorStatus === 403 || session.errorStatus === 418) {
+    if (session.errorStatus === 403 || session.errorStatus === 418) {
       if (helpers.TEST_MODE) {
         return <React.Fragment>{session.errorStatus} redirect</React.Fragment>;
       }
@@ -93,7 +93,6 @@ Authentication.propTypes = {
   onNavigation: PropTypes.func,
   setAppName: PropTypes.func,
   session: PropTypes.shape({
-    admin: PropTypes.bool,
     authorized: PropTypes.bool,
     error: PropTypes.bool,
     errorMessage: PropTypes.string,
@@ -116,7 +115,6 @@ Authentication.defaultProps = {
   onNavigation: helpers.noop,
   setAppName: helpers.noop,
   session: {
-    admin: false,
     authorized: false,
     error: false,
     errorMessage: '',

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -62,60 +62,56 @@ msgstr \\"\\"
 msgid \\"curiosity-graph.thresholdLabel\\"
 msgstr \\"\\"
 
-#: src/components/optinView/optinView.js:109
-#: src/components/optinView/optinView.js:69
+#: src/components/optinView/optinView.js:58
+#: src/components/optinView/optinView.js:98
 msgid \\"curiosity-optin.buttonActivate\\"
 msgstr \\"\\"
 
-#: src/components/optinView/optinView.js:97
+#: src/components/optinView/optinView.js:86
 msgid \\"curiosity-optin.buttonIsActive\\"
 msgstr \\"\\"
 
-#: src/components/optinView/optinView.js:145
+#: src/components/optinView/optinView.js:134
 msgid \\"curiosity-optin.buttonTour\\"
 msgstr \\"\\"
 
-#: src/components/optinView/optinView.js:53
-msgid \\"curiosity-optin.cardContactAdminDescription\\"
-msgstr \\"\\"
-
-#: src/components/optinView/optinView.js:175
+#: src/components/optinView/optinView.js:164
 msgid \\"curiosity-optin.cardDescription\\"
 msgstr \\"\\"
 
-#: src/components/optinView/optinView.js:197
+#: src/components/optinView/optinView.js:186
 msgid \\"curiosity-optin.cardFilterDescription\\"
 msgstr \\"\\"
 
-#: src/components/optinView/optinView.js:194
+#: src/components/optinView/optinView.js:183
 msgid \\"curiosity-optin.cardFilterTitle\\"
 msgstr \\"\\"
 
-#: src/components/optinView/optinView.js:100
+#: src/components/optinView/optinView.js:89
 msgid \\"curiosity-optin.cardIsActiveDescription\\"
 msgstr \\"\\"
 
-#: src/components/optinView/optinView.js:79
+#: src/components/optinView/optinView.js:68
 msgid \\"curiosity-optin.cardIsErrorDescription\\"
 msgstr \\"\\"
 
-#: src/components/optinView/optinView.js:190
+#: src/components/optinView/optinView.js:179
 msgid \\"curiosity-optin.cardReportDescription\\"
 msgstr \\"\\"
 
-#: src/components/optinView/optinView.js:187
+#: src/components/optinView/optinView.js:176
 msgid \\"curiosity-optin.cardReportTitle\\"
 msgstr \\"\\"
 
-#: src/components/optinView/optinView.js:183
+#: src/components/optinView/optinView.js:172
 msgid \\"curiosity-optin.cardSeeDescription\\"
 msgstr \\"\\"
 
-#: src/components/optinView/optinView.js:180
+#: src/components/optinView/optinView.js:169
 msgid \\"curiosity-optin.cardSeeTitle\\"
 msgstr \\"\\"
 
-#: src/components/optinView/optinView.js:172
+#: src/components/optinView/optinView.js:161
 msgid \\"curiosity-optin.cardTitle\\"
 msgstr \\"\\"
 
@@ -135,15 +131,15 @@ msgstr \\"\\"
 msgid \\"curiosity-optin.notificationsSuccessTitle\\"
 msgstr \\"\\"
 
-#: src/components/optinView/optinView.js:142
+#: src/components/optinView/optinView.js:131
 msgid \\"curiosity-optin.tourDescription\\"
 msgstr \\"\\"
 
-#: src/components/optinView/optinView.js:139
+#: src/components/optinView/optinView.js:128
 msgid \\"curiosity-optin.tourTitle\\"
 msgstr \\"\\"
 
-#: src/components/optinView/optinView.js:131
+#: src/components/optinView/optinView.js:120
 msgid \\"curiosity-optin.tourTitleImageAlt\\"
 msgstr \\"\\"
 

--- a/src/components/optinView/__tests__/__snapshots__/optinView.test.js.snap
+++ b/src/components/optinView/__tests__/__snapshots__/optinView.test.js.snap
@@ -86,9 +86,16 @@ exports[`OptinView Component should render a non-connected component: non-connec
             t(curiosity-optin.cardFilterDescription)
           </CardBody>
           <CardFooter>
-            <p>
-              t(curiosity-optin.cardContactAdminDescription, [object Object])
-            </p>
+            <Form>
+              <ActionGroup>
+                <Component
+                  onClick={[Function]}
+                  variant="primary"
+                >
+                  t(curiosity-optin.buttonActivate, [object Object])
+                </Component>
+              </ActionGroup>
+            </Form>
           </CardFooter>
         </FlexItem>
       </Flex>
@@ -148,7 +155,7 @@ exports[`OptinView Component should render a non-connected component: non-connec
 </PageLayout>
 `;
 
-exports[`OptinView Component should render an organization administrator view: error admin view 1`] = `
+exports[`OptinView Component should render an API state driven view: error view 1`] = `
 <CardFooter>
   <p>
     t(curiosity-optin.cardIsErrorDescription, [object Object], [object Object])
@@ -156,7 +163,7 @@ exports[`OptinView Component should render an organization administrator view: e
 </CardFooter>
 `;
 
-exports[`OptinView Component should render an organization administrator view: fulfilled admin view 1`] = `
+exports[`OptinView Component should render an API state driven view: fulfilled view 1`] = `
 <CardFooter>
   <Form>
     <ActionGroup>
@@ -174,7 +181,7 @@ exports[`OptinView Component should render an organization administrator view: f
 </CardFooter>
 `;
 
-exports[`OptinView Component should render an organization administrator view: initial admin view 1`] = `
+exports[`OptinView Component should render an API state driven view: initial view 1`] = `
 <PageLayout>
   <Card>
     <Flex
@@ -329,7 +336,7 @@ exports[`OptinView Component should render an organization administrator view: i
 </PageLayout>
 `;
 
-exports[`OptinView Component should render an organization administrator view: pending admin view 1`] = `
+exports[`OptinView Component should render an API state driven view: pending view 1`] = `
 <CardFooter>
   <Form>
     <ActionGroup>

--- a/src/components/optinView/__tests__/optinView.test.js
+++ b/src/components/optinView/__tests__/optinView.test.js
@@ -10,41 +10,33 @@ describe('OptinView Component', () => {
     expect(component).toMatchSnapshot('non-connected');
   });
 
-  it('should render an organization administrator view', () => {
-    const props = {
-      session: {
-        admin: true
-      }
-    };
+  it('should render an API state driven view', () => {
+    const props = {};
 
     const component = shallow(<OptinView {...props} />);
-    expect(component).toMatchSnapshot('initial admin view');
+    expect(component).toMatchSnapshot('initial view');
 
     component.setProps({
       pending: true
     });
-    expect(component.find('CardFooter').first()).toMatchSnapshot('pending admin view');
+    expect(component.find('CardFooter').first()).toMatchSnapshot('pending view');
 
     component.setProps({
       pending: false,
       error: true
     });
-    expect(component.find('CardFooter').first()).toMatchSnapshot('error admin view');
+    expect(component.find('CardFooter').first()).toMatchSnapshot('error view');
 
     component.setProps({
       pending: false,
       error: false,
       fulfilled: true
     });
-    expect(component.find('CardFooter').first()).toMatchSnapshot('fulfilled admin view');
+    expect(component.find('CardFooter').first()).toMatchSnapshot('fulfilled view');
   });
 
   it('should submit an opt-in form', () => {
-    const props = {
-      session: {
-        admin: true
-      }
-    };
+    const props = {};
 
     const component = mount(<OptinView {...props} />);
     const componentInstance = component.instance();

--- a/src/components/optinView/optinView.js
+++ b/src/components/optinView/optinView.js
@@ -43,18 +43,7 @@ class OptinView extends React.Component {
   };
 
   /**
-   * Render non-org-admin content.
-   *
-   * @returns {Node}
-   */
-  renderContactAdmin() {
-    const { t } = this.props;
-
-    return <p>{t('curiosity-optin.cardContactAdminDescription', { appName: helpers.UI_DISPLAY_NAME })}</p>;
-  }
-
-  /**
-   * Render org-admin opt-in form states.
+   * Render opt-in form states.
    *
    * @returns {Node}
    */
@@ -155,7 +144,7 @@ class OptinView extends React.Component {
    * @returns {Node}
    */
   render() {
-    const { session, t } = this.props;
+    const { t } = this.props;
 
     return (
       <PageLayout>
@@ -196,7 +185,7 @@ class OptinView extends React.Component {
                 </CardHeader>
                 <CardBody key="heading4Desc">{t('curiosity-optin.cardFilterDescription')}</CardBody>
 
-                <CardFooter>{(session.admin && this.renderOptinForm()) || this.renderContactAdmin()}</CardFooter>
+                <CardFooter>{this.renderOptinForm()}</CardFooter>
               </FlexItem>
             </Flex>
             <Flex
@@ -216,16 +205,13 @@ class OptinView extends React.Component {
 /**
  * Prop types.
  *
- * @type {{t: Function, session: object, updateAccountOptIn: Function, pending: boolean,
- *     fulfilled: boolean, error: boolean}}
+ * @type {{t: Function, updateAccountOptIn: Function, pending: boolean, fulfilled: boolean,
+ *     error: boolean}}
  */
 OptinView.propTypes = {
   error: PropTypes.bool,
   fulfilled: PropTypes.bool,
   pending: PropTypes.bool,
-  session: PropTypes.shape({
-    admin: PropTypes.bool
-  }),
   t: PropTypes.func,
   updateAccountOptIn: PropTypes.func
 };
@@ -233,16 +219,13 @@ OptinView.propTypes = {
 /**
  * Default props.
  *
- * @type {{t: Function, session: {admin: boolean}, updateAccountOptIn: Function,
- *     pending: boolean, fulfilled: boolean, error: boolean}}
+ * @type {{t: Function, updateAccountOptIn: Function, pending: boolean,
+ *     fulfilled: boolean, error: boolean}}
  */
 OptinView.defaultProps = {
   error: false,
   fulfilled: false,
   pending: false,
-  session: {
-    admin: false
-  },
   t: helpers.noopTranslate,
   updateAccountOptIn: helpers.noop
 };
@@ -264,7 +247,7 @@ const mapDispatchToProps = dispatch => ({
  * @param {object} state
  * @returns {object}
  */
-const mapStateToProps = ({ user }) => ({ ...user.optin, session: user.session });
+const mapStateToProps = ({ user }) => ({ ...user.optin });
 
 const ConnectedOptinView = connectTranslate(mapStateToProps, mapDispatchToProps)(OptinView);
 


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(authentication,optinView): issues/240 optin for all users 
   * authentication, remove admin session checks
   * optinView, remove admin session checks
   * locale, strings updated

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- Removes the org-admin checks. All users should now see the same thing
- A 403 from the RHSM API should trigger the "opt-in"
- A 401 from the RHSM API will trigger an unauthenticated view/message
- PR #247 Gives the original logic breakdown

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. navigate towards http://localhost:3000/optin
1. next, submit the form a confirmation screen similar to the below screenshot should appear
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screen Shot 2020-04-09 at 7 32 16 PM](https://user-images.githubusercontent.com/3761375/78949272-18083f00-7a99-11ea-83ac-eee2f6fdd375.png)

![Screen Shot 2020-04-09 at 7 32 25 PM](https://user-images.githubusercontent.com/3761375/78949282-1b9bc600-7a99-11ea-850d-5c659c511287.png)

![Screen Shot 2020-04-09 at 7 31 57 PM](https://user-images.githubusercontent.com/3761375/78949291-1f2f4d00-7a99-11ea-9c68-a368bef1a29f.png)

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
#240 