### PR TITLE
fix(authentication, routerTypes): revert nav clean up

### DIFF
--- a/src/components/authentication/__tests__/__snapshots__/authentication.test.js.snap
+++ b/src/components/authentication/__tests__/__snapshots__/authentication.test.js.snap
@@ -16,6 +16,53 @@ exports[`Authorization Component should render a non-connected component authori
     }
   }
   initializeChrome={[Function]}
+  navigation={
+    Array [
+      Object {
+        "default": true,
+        "id": "all",
+        "path": "/rhel-sw/all",
+        "pathId": "rhel-sw",
+        "pathParameter": "RHEL",
+        "title": "Red Hat Enterprise Linux",
+      },
+      Object {
+        "id": "arm",
+        "path": "/rhel-sw/arm",
+        "pathId": "rhel-sw",
+        "pathParameter": "RHEL for ARM",
+        "title": "ARM",
+      },
+      Object {
+        "id": "ibmpower",
+        "path": "/rhel-sw/ibmpower",
+        "pathId": "rhel-sw",
+        "pathParameter": "RHEL for IBM Power",
+        "title": "IBM Power",
+      },
+      Object {
+        "id": "ibmz",
+        "path": "/rhel-sw/ibmz",
+        "pathId": "rhel-sw",
+        "pathParameter": "RHEL for IBM z",
+        "title": "IBM Z systems",
+      },
+      Object {
+        "id": "x86",
+        "path": "/rhel-sw/x86",
+        "pathId": "rhel-sw",
+        "pathParameter": "RHEL for x86",
+        "title": "x86",
+      },
+      Object {
+        "id": "openshift-sw",
+        "path": "/openshift-sw",
+        "pathId": "openshift-sw",
+        "pathParameter": "OpenShift Container Platform",
+        "title": "Red Hat OpenShift",
+      },
+    ]
+  }
   onNavigation={[Function]}
   session={
     Object {
@@ -26,6 +73,7 @@ exports[`Authorization Component should render a non-connected component authori
     }
   }
   setAppName={[Function]}
+  setNavigation={[Function]}
   t={[Function]}
 >
   <span
@@ -46,6 +94,53 @@ exports[`Authorization Component should render a non-connected component error: 
     }
   }
   initializeChrome={[Function]}
+  navigation={
+    Array [
+      Object {
+        "default": true,
+        "id": "all",
+        "path": "/rhel-sw/all",
+        "pathId": "rhel-sw",
+        "pathParameter": "RHEL",
+        "title": "Red Hat Enterprise Linux",
+      },
+      Object {
+        "id": "arm",
+        "path": "/rhel-sw/arm",
+        "pathId": "rhel-sw",
+        "pathParameter": "RHEL for ARM",
+        "title": "ARM",
+      },
+      Object {
+        "id": "ibmpower",
+        "path": "/rhel-sw/ibmpower",
+        "pathId": "rhel-sw",
+        "pathParameter": "RHEL for IBM Power",
+        "title": "IBM Power",
+      },
+      Object {
+        "id": "ibmz",
+        "path": "/rhel-sw/ibmz",
+        "pathId": "rhel-sw",
+        "pathParameter": "RHEL for IBM z",
+        "title": "IBM Z systems",
+      },
+      Object {
+        "id": "x86",
+        "path": "/rhel-sw/x86",
+        "pathId": "rhel-sw",
+        "pathParameter": "RHEL for x86",
+        "title": "x86",
+      },
+      Object {
+        "id": "openshift-sw",
+        "path": "/openshift-sw",
+        "pathId": "openshift-sw",
+        "pathParameter": "OpenShift Container Platform",
+        "title": "Red Hat OpenShift",
+      },
+    ]
+  }
   onNavigation={[Function]}
   session={
     Object {
@@ -56,6 +151,7 @@ exports[`Authorization Component should render a non-connected component error: 
     }
   }
   setAppName={[Function]}
+  setNavigation={[Function]}
   t={[Function]}
 >
   <MessageView

--- a/src/components/authentication/authentication.js
+++ b/src/components/authentication/authentication.js
@@ -17,7 +17,16 @@ class Authentication extends Component {
   removeListeners = helpers.noop;
 
   componentDidMount() {
-    const { authorizeUser, history, initializeChrome, onNavigation, setAppName, session } = this.props;
+    const {
+      authorizeUser,
+      history,
+      initializeChrome,
+      navigation,
+      onNavigation,
+      setAppName,
+      setNavigation,
+      session
+    } = this.props;
 
     if (helpers.PROD_MODE || helpers.REVIEW_MODE) {
       initializeChrome();
@@ -28,8 +37,11 @@ class Authentication extends Component {
         history.push(path);
       });
 
+      const buildNav = history.listen(() => setNavigation(navigation));
+
       this.removeListeners = () => {
         appNav();
+        buildNav();
       };
     }
 
@@ -92,6 +104,12 @@ Authentication.propTypes = {
   initializeChrome: PropTypes.func,
   onNavigation: PropTypes.func,
   setAppName: PropTypes.func,
+  setNavigation: PropTypes.func,
+  navigation: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string
+    })
+  ),
   session: PropTypes.shape({
     authorized: PropTypes.bool,
     error: PropTypes.bool,
@@ -114,6 +132,8 @@ Authentication.defaultProps = {
   initializeChrome: helpers.noop,
   onNavigation: helpers.noop,
   setAppName: helpers.noop,
+  setNavigation: helpers.noop,
+  navigation: routerTypes.navigation,
   session: {
     authorized: false,
     error: false,
@@ -134,7 +154,8 @@ const mapDispatchToProps = dispatch => ({
   authorizeUser: () => dispatch(reduxActions.user.authorizeUser()),
   initializeChrome: () => dispatch(reduxActions.platform.initializeChrome()),
   onNavigation: callback => dispatch(reduxActions.platform.onNavigation(callback)),
-  setAppName: name => dispatch(reduxActions.platform.setAppName(name))
+  setAppName: name => dispatch(reduxActions.platform.setAppName(name)),
+  setNavigation: data => dispatch(reduxActions.platform.setNavigation(data))
 });
 
 /**

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -16,7 +16,7 @@ exports[`I18n Component should generate a predictable pot output snapshot: pot o
 msgstr \\"\\"
 \\"Content-Type: text/plain; charset=UTF-8\\\\n\\"
 
-#: src/components/authentication/authentication.js:70
+#: src/components/authentication/authentication.js:82
 msgid \\"curiosity-auth.authorizedTitle\\"
 msgstr \\"\\"
 
@@ -209,12 +209,12 @@ msgstr \\"\\"
 msgid \\"curiosity-view.rhel\\"
 msgstr \\"\\"
 
-#: src/components/authentication/authentication.js:71
+#: src/components/authentication/authentication.js:83
 msgctxt \\"...\\"
 msgid \\"curiosity-auth.authorizedCopy\\"
 msgstr \\"\\"
 
-#: src/components/authentication/authentication.js:58
+#: src/components/authentication/authentication.js:70
 msgctxt \\"...\\"
 msgid \\"curiosity-auth.pending\\"
 msgstr \\"\\"

--- a/src/components/router/__tests__/__snapshots__/routerHelpers.test.js.snap
+++ b/src/components/router/__tests__/__snapshots__/routerHelpers.test.js.snap
@@ -40,6 +40,7 @@ Object {
     "path": "/rhel-sw/all",
     "pathId": "rhel-sw",
     "pathParameter": "RHEL",
+    "title": "Red Hat Enterprise Linux",
   },
   "navRoute": Object {
     "component": Object {
@@ -58,6 +59,7 @@ Object {
     "pathParameter": "RHEL",
     "redirect": true,
     "render": true,
+    "title": "Red Hat Enterprise Linux",
     "to": "/rhel-sw/all",
   },
   "route": Object {
@@ -85,6 +87,7 @@ Object {
     "path": "/rhel-sw/all",
     "pathId": "rhel-sw",
     "pathParameter": "RHEL",
+    "title": "Red Hat Enterprise Linux",
   },
   "navRoute": Object {
     "component": Object {
@@ -103,6 +106,7 @@ Object {
     "pathParameter": "RHEL",
     "redirect": true,
     "render": true,
+    "title": "Red Hat Enterprise Linux",
     "to": "/rhel-sw/all",
   },
   "route": Object {
@@ -138,6 +142,7 @@ Object {
     "path": "/rhel-sw/all",
     "pathId": "rhel-sw",
     "pathParameter": "RHEL",
+    "title": "Red Hat Enterprise Linux",
   },
   "navRoute": Object {
     "component": Object {
@@ -156,6 +161,7 @@ Object {
     "pathParameter": "RHEL",
     "redirect": true,
     "render": true,
+    "title": "Red Hat Enterprise Linux",
     "to": "/rhel-sw/all",
   },
   "route": Object {},
@@ -177,6 +183,7 @@ Object {
     "path": "/rhel-sw/arm",
     "pathId": "rhel-sw",
     "pathParameter": "RHEL for ARM",
+    "title": "ARM",
   },
   "navRoute": Object {
     "component": Object {
@@ -193,6 +200,7 @@ Object {
     "pathId": "rhel-sw",
     "pathParameter": "RHEL for ARM",
     "render": true,
+    "title": "ARM",
     "to": "/rhel-sw/:variant",
   },
   "route": Object {},

--- a/src/components/router/__tests__/__snapshots__/routerTypes.test.js.snap
+++ b/src/components/router/__tests__/__snapshots__/routerTypes.test.js.snap
@@ -10,36 +10,42 @@ Array [
     "path": "/rhel-sw/all",
     "pathId": "rhel-sw",
     "pathParameter": "RHEL",
+    "title": "Red Hat Enterprise Linux",
   },
   Object {
     "id": "arm",
     "path": "/rhel-sw/arm",
     "pathId": "rhel-sw",
     "pathParameter": "RHEL for ARM",
+    "title": "ARM",
   },
   Object {
     "id": "ibmpower",
     "path": "/rhel-sw/ibmpower",
     "pathId": "rhel-sw",
     "pathParameter": "RHEL for IBM Power",
+    "title": "IBM Power",
   },
   Object {
     "id": "ibmz",
     "path": "/rhel-sw/ibmz",
     "pathId": "rhel-sw",
     "pathParameter": "RHEL for IBM z",
+    "title": "IBM Z systems",
   },
   Object {
     "id": "x86",
     "path": "/rhel-sw/x86",
     "pathId": "rhel-sw",
     "pathParameter": "RHEL for x86",
+    "title": "x86",
   },
   Object {
     "id": "openshift-sw",
     "path": "/openshift-sw",
     "pathId": "openshift-sw",
     "pathParameter": "OpenShift Container Platform",
+    "title": "Red Hat OpenShift",
   },
 ]
 `;

--- a/src/components/router/routerTypes.js
+++ b/src/components/router/routerTypes.js
@@ -83,6 +83,7 @@ const routes = [
  */
 const navigation = [
   {
+    title: 'Red Hat Enterprise Linux',
     id: 'all',
     path: '/rhel-sw/all',
     pathId: 'rhel-sw',
@@ -90,30 +91,35 @@ const navigation = [
     default: true
   },
   {
+    title: 'ARM',
     id: 'arm',
     path: '/rhel-sw/arm',
     pathId: 'rhel-sw',
     pathParameter: RHSM_API_PATH_ID_TYPES.RHEL_ARM
   },
   {
+    title: 'IBM Power',
     id: 'ibmpower',
     path: '/rhel-sw/ibmpower',
     pathId: 'rhel-sw',
     pathParameter: RHSM_API_PATH_ID_TYPES.RHEL_IBM_POWER
   },
   {
+    title: 'IBM Z systems',
     id: 'ibmz',
     path: '/rhel-sw/ibmz',
     pathId: 'rhel-sw',
     pathParameter: RHSM_API_PATH_ID_TYPES.RHEL_IBM_Z
   },
   {
+    title: 'x86',
     id: 'x86',
     path: '/rhel-sw/x86',
     pathId: 'rhel-sw',
     pathParameter: RHSM_API_PATH_ID_TYPES.RHEL_X86
   },
   {
+    title: 'Red Hat OpenShift',
     id: 'openshift-sw',
     path: '/openshift-sw',
     pathId: 'openshift-sw',


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(authentication, routerTypes): revert nav clean up
   * authentication, restore part of #245 setNavigation clean up
   * routerTypes, restore navigation titles for setNavigation

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- Reverts parts of the clean up for navigation from #245 


## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. once the browser is loaded open a blank tab/window and enter the following url, `https://cloud.redhat.com/beta/subscriptions/` upon navigating the browser should redirect to `https://cloud.redhat.com/beta/subscriptions/rhel-sw/all` and the left nav should expand
   - this behavior will apply to the stable path once deployed

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
updates #262 