### PR TITLE
fix(optinView): issues/240 assume opt-in is activated

### DIFF
--- a/src/components/optinView/__tests__/__snapshots__/optinView.test.js.snap
+++ b/src/components/optinView/__tests__/__snapshots__/optinView.test.js.snap
@@ -411,6 +411,21 @@ exports[`OptinView Component should render an API state driven view: initial vie
 </PageLayout>
 `;
 
+exports[`OptinView Component should render an API state driven view: null or undefined status view 1`] = `
+<CardFooter>
+  <Form>
+    <ActionGroup>
+      <Component
+        isDisabled={true}
+        variant="primary"
+      >
+        t(curiosity-optin.buttonIsActive, [object Object])
+      </Component>
+    </ActionGroup>
+  </Form>
+</CardFooter>
+`;
+
 exports[`OptinView Component should render an API state driven view: pending view 1`] = `
 <CardFooter>
   <Form>

--- a/src/components/optinView/__tests__/optinView.test.js
+++ b/src/components/optinView/__tests__/optinView.test.js
@@ -52,6 +52,13 @@ describe('OptinView Component', () => {
     expect(component.find('CardFooter').first()).toMatchSnapshot('500 view');
 
     component.setProps({
+      session: {
+        status: null
+      }
+    });
+    expect(component.find('CardFooter').first()).toMatchSnapshot('null or undefined status view');
+
+    component.setProps({
       pending: true,
       session: {}
     });

--- a/src/components/optinView/optinView.js
+++ b/src/components/optinView/optinView.js
@@ -49,7 +49,7 @@ class OptinView extends React.Component {
    */
   renderOptinForm() {
     const { error, fulfilled, pending, session, t } = this.props;
-    const disableButton = !session.status || session.status !== 403;
+    const disableButton = session.status !== 403;
 
     if (pending) {
       return (
@@ -253,7 +253,7 @@ const mapDispatchToProps = dispatch => ({
  * @param {object} state
  * @returns {object}
  */
-const mapStateToProps = ({ user }) => ({ ...user.optin });
+const mapStateToProps = ({ user }) => ({ ...user.optin, session: user.session });
 
 const ConnectedOptinView = connectTranslate(mapStateToProps, mapDispatchToProps)(OptinView);
 


### PR DESCRIPTION

## What's included
<!-- Summary of changes/additions -->
fix(optinView): issues/240 assume opt-in is activated
   * optinView, simplify check for 403 status

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- minor logic simplify
- missing state ref

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`

<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Relates #240 