### PR TITLE
fix(build): issues/274 squash browsersync console messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "release": "standard-version",
     "start": "run-s dev:chrome; run-p -l api:dev start:js",
     "start:js": "react-scripts start",
-    "start:proxy": "sh -ac '. ./.env.proxy; open https://ci.foo.redhat.com:443/beta/subscriptions/; run-s api:proxy-hosts; run-p -l start:js api:proxy'",
+    "start:proxy": "sh -ac '. ./.env.proxy; open https://ci.foo.redhat.com/beta/subscriptions/; run-s api:proxy-hosts; run-p -l start:js api:proxy'",
     "start:standalone": "rm ./.env.development.local; run-p -l api:dev start:js",
     "test": "run-s test:lint test:ci",
     "test:ci": "export CI=true; react-scripts test --env=jsdom --roots=./src --coverage",

--- a/scripts/proxy.api.sh
+++ b/scripts/proxy.api.sh
@@ -144,7 +144,7 @@ runProxy()
       RUN_CONFIG="-e CUSTOM_CONF=true -v ${RUN_CONFIG}:/config/spandx.config.js"
     fi
 
-    docker run -d --rm -p $RUN_PORT:1337 $RUN_CONFIG -e PLATFORM -e PORT -e LOCAL_API -e SPANDX_HOST -e SPANDX_PORT --name $RUN_NAME $RUN_CONTAINER >/dev/null
+    docker run -d --rm -p $RUN_PORT:$RUN_PORT $RUN_CONFIG -e PLATFORM -e PORT -e LOCAL_API -e SPANDX_HOST -e SPANDX_PORT=$RUN_PORT --name $RUN_NAME $RUN_CONTAINER >/dev/null
   fi
 
   checkContainerRunning $RUN_NAME


### PR DESCRIPTION


## What's included
<!-- Summary of changes/additions -->
- fix(build): issues/274 squash browsersync console messages
   * build, proxy run port updated

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- This commit should be squashed with the prior PR #276 
- Appears the spandx port needed to be updated as well, this squashes the browsersync messages that appear in dev console
![Screen Shot 2020-05-08 at 11 00 40 AM](https://user-images.githubusercontent.com/3761375/81419469-4458bf00-911c-11ea-8c8f-a1f6b2311158.png)


## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
### Proxy run check
1. make sure Docker is running, plus on network, then
1. **BEFORE YOU START** do NOT sync with this PR, sync with the upstream CI branch
   - update the NPM packages with `$ yarn`
   - run `$ yarn start:proxy`
   - Confirm the above screenshot matches the browser dev console messaging you're seeing
1. next, stop the proxy
1. **NOW SYNC** with this PR,
   - update the NPM packages with `$ yarn`
   - `$ yarn start:proxy`
   - Confirm the console messaging for browsersync no longer clutters the browser dev console


<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
- Relates to PR #276 
- #274 