### PR TITLE
fix(graphCardHelpers): issues/273 tooltip date ranges

### DIFF
--- a/src/components/graphCard/__tests__/__snapshots__/graphCardHelpers.test.js.snap
+++ b/src/components/graphCard/__tests__/__snapshots__/graphCardHelpers.test.js.snap
@@ -13,8 +13,8 @@ exports[`GraphCardHelpers getTooltipDate should return a formatted date based on
 Object {
   "daily": "June 1",
   "monthly": "June 2019",
-  "quarterly": "June 2019",
-  "weekly": "June 1",
+  "quarterly": "Jun 2019 - Sep 2019",
+  "weekly": "Jun 1 - Jun 8 2019",
 }
 `;
 
@@ -25,9 +25,9 @@ t(curiosity-graph.dateLabel): June 1",
   "monthly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): t(curiosity-graph.noDataLabel)
 t(curiosity-graph.dateLabel): June 2019",
   "quarterly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): t(curiosity-graph.noDataLabel)
-t(curiosity-graph.dateLabel): June 2019",
+t(curiosity-graph.dateLabel): Jun 2019 - Sep 2019",
   "weekly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): t(curiosity-graph.noDataLabel)
-t(curiosity-graph.dateLabel): June 1",
+t(curiosity-graph.dateLabel): Jun 1 - Jun 8 2019",
 }
 `;
 
@@ -38,9 +38,9 @@ t(curiosity-graph.dateLabel): June 1",
   "monthly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): 50
 t(curiosity-graph.dateLabel): June 2019",
   "quarterly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): 50
-t(curiosity-graph.dateLabel): June 2019",
+t(curiosity-graph.dateLabel): Jun 2019 - Sep 2019",
   "weekly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): 50
-t(curiosity-graph.dateLabel): June 1",
+t(curiosity-graph.dateLabel): Jun 1 - Jun 8 2019",
 }
 `;
 
@@ -51,9 +51,9 @@ t(curiosity-graph.dateLabel): June 1",
   "monthly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): 50
 t(curiosity-graph.dateLabel): June 2019",
   "quarterly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): 50
-t(curiosity-graph.dateLabel): June 2019",
+t(curiosity-graph.dateLabel): Jun 2019 - Sep 2019",
   "weekly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): 50
-t(curiosity-graph.dateLabel): June 1",
+t(curiosity-graph.dateLabel): Jun 1 - Jun 8 2019",
 }
 `;
 
@@ -64,9 +64,9 @@ t(curiosity-graph.dateLabel): June 1",
   "monthly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): t(curiosity-graph.noDataLabel)
 t(curiosity-graph.dateLabel): June 2019",
   "quarterly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): t(curiosity-graph.noDataLabel)
-t(curiosity-graph.dateLabel): June 2019",
+t(curiosity-graph.dateLabel): Jun 2019 - Sep 2019",
   "weekly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): t(curiosity-graph.noDataLabel)
-t(curiosity-graph.dateLabel): June 1",
+t(curiosity-graph.dateLabel): Jun 1 - Jun 8 2019",
 }
 `;
 
@@ -77,9 +77,9 @@ t(curiosity-graph.dateLabel): June 1",
   "monthly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): 0
 t(curiosity-graph.dateLabel): June 2019",
   "quarterly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): 0
-t(curiosity-graph.dateLabel): June 2019",
+t(curiosity-graph.dateLabel): Jun 2019 - Sep 2019",
   "weekly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): 0
-t(curiosity-graph.dateLabel): June 1",
+t(curiosity-graph.dateLabel): Jun 1 - Jun 8 2019",
 }
 `;
 
@@ -90,9 +90,9 @@ t(curiosity-graph.dateLabel): June 1",
   "monthly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): 0
 t(curiosity-graph.dateLabel): June 2019",
   "quarterly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): 0
-t(curiosity-graph.dateLabel): June 2019",
+t(curiosity-graph.dateLabel): Jun 2019 - Sep 2019",
   "weekly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): 0
-t(curiosity-graph.dateLabel): June 1",
+t(curiosity-graph.dateLabel): Jun 1 - Jun 8 2019",
 }
 `;
 
@@ -103,9 +103,9 @@ t(curiosity-graph.dateLabel): June 1",
   "monthly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): t(curiosity-graph.noDataLabel)
 t(curiosity-graph.dateLabel): June 2019",
   "quarterly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): t(curiosity-graph.noDataLabel)
-t(curiosity-graph.dateLabel): June 2019",
+t(curiosity-graph.dateLabel): Jun 2019 - Sep 2019",
   "weekly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): t(curiosity-graph.noDataLabel)
-t(curiosity-graph.dateLabel): June 1",
+t(curiosity-graph.dateLabel): Jun 1 - Jun 8 2019",
 }
 `;
 
@@ -116,9 +116,9 @@ t(curiosity-graph.dateLabel): June 1",
   "monthly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): 0
 t(curiosity-graph.dateLabel): June 2019",
   "quarterly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): 0
-t(curiosity-graph.dateLabel): June 2019",
+t(curiosity-graph.dateLabel): Jun 2019 - Sep 2019",
   "weekly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): 0
-t(curiosity-graph.dateLabel): June 1",
+t(curiosity-graph.dateLabel): Jun 1 - Jun 8 2019",
 }
 `;
 
@@ -129,9 +129,9 @@ t(curiosity-graph.dateLabel): June 1",
   "monthly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): 0
 t(curiosity-graph.dateLabel): June 2019",
   "quarterly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): 0
-t(curiosity-graph.dateLabel): June 2019",
+t(curiosity-graph.dateLabel): Jun 2019 - Sep 2019",
   "weekly": "t(curiosity-graph.hypervisorSocketsLabel, [object Object]): 0
-t(curiosity-graph.dateLabel): June 1",
+t(curiosity-graph.dateLabel): Jun 1 - Jun 8 2019",
 }
 `;
 
@@ -151,9 +151,9 @@ t(curiosity-graph.dateLabel): June 1",
   "monthly": "t(curiosity-graph.thresholdLabel): 100
 t(curiosity-graph.dateLabel): June 2019",
   "quarterly": "t(curiosity-graph.thresholdLabel): 100
-t(curiosity-graph.dateLabel): June 2019",
+t(curiosity-graph.dateLabel): Jun 2019 - Sep 2019",
   "weekly": "t(curiosity-graph.thresholdLabel): 100
-t(curiosity-graph.dateLabel): June 1",
+t(curiosity-graph.dateLabel): Jun 1 - Jun 8 2019",
 }
 `;
 
@@ -164,9 +164,9 @@ t(curiosity-graph.dateLabel): June 1",
   "monthly": "t(curiosity-graph.thresholdLabel): 100
 t(curiosity-graph.dateLabel): June 2019",
   "quarterly": "t(curiosity-graph.thresholdLabel): 100
-t(curiosity-graph.dateLabel): June 2019",
+t(curiosity-graph.dateLabel): Jun 2019 - Sep 2019",
   "weekly": "t(curiosity-graph.thresholdLabel): 100
-t(curiosity-graph.dateLabel): June 1",
+t(curiosity-graph.dateLabel): Jun 1 - Jun 8 2019",
 }
 `;
 
@@ -177,9 +177,9 @@ t(curiosity-graph.dateLabel): June 1",
   "monthly": "t(curiosity-graph.thresholdLabel): t(curiosity-graph.infiniteThresholdLabel)
 t(curiosity-graph.dateLabel): June 2019",
   "quarterly": "t(curiosity-graph.thresholdLabel): t(curiosity-graph.infiniteThresholdLabel)
-t(curiosity-graph.dateLabel): June 2019",
+t(curiosity-graph.dateLabel): Jun 2019 - Sep 2019",
   "weekly": "t(curiosity-graph.thresholdLabel): t(curiosity-graph.infiniteThresholdLabel)
-t(curiosity-graph.dateLabel): June 1",
+t(curiosity-graph.dateLabel): Jun 1 - Jun 8 2019",
 }
 `;
 
@@ -190,9 +190,9 @@ t(curiosity-graph.dateLabel): June 1",
   "monthly": "t(curiosity-graph.thresholdLabel): t(curiosity-graph.noDataLabel)
 t(curiosity-graph.dateLabel): June 2019",
   "quarterly": "t(curiosity-graph.thresholdLabel): t(curiosity-graph.noDataLabel)
-t(curiosity-graph.dateLabel): June 2019",
+t(curiosity-graph.dateLabel): Jun 2019 - Sep 2019",
   "weekly": "t(curiosity-graph.thresholdLabel): t(curiosity-graph.noDataLabel)
-t(curiosity-graph.dateLabel): June 1",
+t(curiosity-graph.dateLabel): Jun 1 - Jun 8 2019",
 }
 `;
 
@@ -203,9 +203,9 @@ t(curiosity-graph.dateLabel): June 1",
   "monthly": "t(curiosity-graph.thresholdLabel): t(curiosity-graph.noDataLabel)
 t(curiosity-graph.dateLabel): June 2019",
   "quarterly": "t(curiosity-graph.thresholdLabel): t(curiosity-graph.noDataLabel)
-t(curiosity-graph.dateLabel): June 2019",
+t(curiosity-graph.dateLabel): Jun 2019 - Sep 2019",
   "weekly": "t(curiosity-graph.thresholdLabel): t(curiosity-graph.noDataLabel)
-t(curiosity-graph.dateLabel): June 1",
+t(curiosity-graph.dateLabel): Jun 1 - Jun 8 2019",
 }
 `;
 
@@ -216,9 +216,9 @@ t(curiosity-graph.dateLabel): June 1",
   "monthly": "t(curiosity-graph.thresholdLabel): t(curiosity-graph.infiniteThresholdLabel)
 t(curiosity-graph.dateLabel): June 2019",
   "quarterly": "t(curiosity-graph.thresholdLabel): t(curiosity-graph.infiniteThresholdLabel)
-t(curiosity-graph.dateLabel): June 2019",
+t(curiosity-graph.dateLabel): Jun 2019 - Sep 2019",
   "weekly": "t(curiosity-graph.thresholdLabel): t(curiosity-graph.infiniteThresholdLabel)
-t(curiosity-graph.dateLabel): June 1",
+t(curiosity-graph.dateLabel): Jun 1 - Jun 8 2019",
 }
 `;
 
@@ -229,9 +229,9 @@ t(curiosity-graph.dateLabel): June 1",
   "monthly": "t(curiosity-graph.thresholdLabel): 0
 t(curiosity-graph.dateLabel): June 2019",
   "quarterly": "t(curiosity-graph.thresholdLabel): 0
-t(curiosity-graph.dateLabel): June 2019",
+t(curiosity-graph.dateLabel): Jun 2019 - Sep 2019",
   "weekly": "t(curiosity-graph.thresholdLabel): 0
-t(curiosity-graph.dateLabel): June 1",
+t(curiosity-graph.dateLabel): Jun 1 - Jun 8 2019",
 }
 `;
 
@@ -242,9 +242,9 @@ t(curiosity-graph.dateLabel): June 1",
   "monthly": "t(curiosity-graph.thresholdLabel): 0
 t(curiosity-graph.dateLabel): June 2019",
   "quarterly": "t(curiosity-graph.thresholdLabel): 0
-t(curiosity-graph.dateLabel): June 2019",
+t(curiosity-graph.dateLabel): Jun 2019 - Sep 2019",
   "weekly": "t(curiosity-graph.thresholdLabel): 0
-t(curiosity-graph.dateLabel): June 1",
+t(curiosity-graph.dateLabel): Jun 1 - Jun 8 2019",
 }
 `;
 
@@ -255,9 +255,9 @@ t(curiosity-graph.dateLabel): June 1",
   "monthly": "t(curiosity-graph.thresholdLabel): t(curiosity-graph.infiniteThresholdLabel)
 t(curiosity-graph.dateLabel): June 2019",
   "quarterly": "t(curiosity-graph.thresholdLabel): t(curiosity-graph.infiniteThresholdLabel)
-t(curiosity-graph.dateLabel): June 2019",
+t(curiosity-graph.dateLabel): Jun 2019 - Sep 2019",
   "weekly": "t(curiosity-graph.thresholdLabel): t(curiosity-graph.infiniteThresholdLabel)
-t(curiosity-graph.dateLabel): June 1",
+t(curiosity-graph.dateLabel): Jun 1 - Jun 8 2019",
 }
 `;
 

--- a/src/components/graphCard/graphCardHelpers.js
+++ b/src/components/graphCard/graphCardHelpers.js
@@ -33,23 +33,25 @@ const getChartXAxisLabelIncrement = granularity => {
  */
 const getTooltipDate = ({ date, granularity }) => {
   const momentDate = moment.utc(date);
-  let formattedDateTooltip;
 
   switch (granularity) {
     case GRANULARITY_TYPES.QUARTERLY:
-      formattedDateTooltip = dateHelpers.timestampQuarterFormats.yearLong;
-      break;
+      return `${momentDate.format(dateHelpers.timestampQuarterFormats.yearShort)} - ${momentDate
+        .add(1, 'quarter')
+        .format(dateHelpers.timestampQuarterFormats.yearShort)}`;
+
     case GRANULARITY_TYPES.MONTHLY:
-      formattedDateTooltip = dateHelpers.timestampMonthFormats.yearLong;
-      break;
+      return momentDate.format(dateHelpers.timestampMonthFormats.yearLong);
+
     case GRANULARITY_TYPES.WEEKLY:
+      return `${momentDate.format(dateHelpers.timestampDayFormats.short)} - ${momentDate
+        .add(1, 'week')
+        .format(dateHelpers.timestampDayFormats.yearShort)}`;
+
     case GRANULARITY_TYPES.DAILY:
     default:
-      formattedDateTooltip = dateHelpers.timestampDayFormats.long;
-      break;
+      return momentDate.format(dateHelpers.timestampDayFormats.long);
   }
-
-  return momentDate.format(formattedDateTooltip);
 };
 
 /**

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -24,7 +24,7 @@ msgstr \\"\\"
 msgid \\"curiosity-graph.cardHeading\\"
 msgstr \\"\\"
 
-#: src/components/graphCard/graphCardHelpers.js:75
+#: src/components/graphCard/graphCardHelpers.js:77
 msgid \\"curiosity-graph.dateLabel\\"
 msgstr \\"\\"
 
@@ -49,16 +49,16 @@ msgstr \\"\\"
 msgid \\"curiosity-graph.dropdownWeekly\\"
 msgstr \\"\\"
 
-#: src/components/graphCard/graphCardHelpers.js:83
+#: src/components/graphCard/graphCardHelpers.js:85
 msgid \\"curiosity-graph.infiniteThresholdLabel\\"
 msgstr \\"\\"
 
-#: src/components/graphCard/graphCardHelpers.js:97
+#: src/components/graphCard/graphCardHelpers.js:99
 msgid \\"curiosity-graph.noDataErrorLabel\\"
 msgstr \\"\\"
 
-#: src/components/graphCard/graphCardHelpers.js:84
-#: src/components/graphCard/graphCardHelpers.js:89
+#: src/components/graphCard/graphCardHelpers.js:86
+#: src/components/graphCard/graphCardHelpers.js:91
 msgid \\"curiosity-graph.noDataLabel\\"
 msgstr \\"\\"
 
@@ -67,7 +67,7 @@ msgid \\"curiosity-graph.socketsHeading\\"
 msgstr \\"\\"
 
 #: src/components/graphCard/graphCard.js:134
-#: src/components/graphCard/graphCardHelpers.js:86
+#: src/components/graphCard/graphCardHelpers.js:88
 msgid \\"curiosity-graph.thresholdLabel\\"
 msgstr \\"\\"
 


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(graphCardHelpers): issues/273 tooltip date ranges
   * graphCardHelpers, tooltip date ranges for week, quarter granularity

<!-- ### Notes -->
<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. select the weekly or quarterly granularity, then hover over the graph to view the date ranges

<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
### Weekly
![Screen Shot 2020-05-18 at 11 33 28 PM (2)](https://user-images.githubusercontent.com/3761375/82281742-18c9a600-9960-11ea-9daa-c5865d4455a6.png)

### Quarterly
 
![Screen Shot 2020-05-18 at 11 30 16 PM (2)](https://user-images.githubusercontent.com/3761375/82281806-46165400-9960-11ea-9c76-1eaa45c01cba.png)




## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
#273 

@rblackbu