### PR TITLE
feat(c3Chart): issues/283 add base c3 component 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -92,6 +92,7 @@
       }
     ],
     "react/forbid-prop-types": 0,
+    "react/jsx-curly-newline": 0,
     "react/jsx-filename-extension": 0,
     "react/jsx-fragments": [ 1, "element" ],
     "react/jsx-props-no-spreading": 0,

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@redhat-cloud-services/frontend-components-notifications": "1.0.3",
     "@redhat-cloud-services/frontend-components-utilities": "1.0.3",
     "axios": "^0.19.2",
+    "c3": "^0.7.15",
     "classnames": "^2.2.6",
     "i18next": "^19.4.4",
     "i18next-xhr-backend": "^3.2.2",

--- a/public/locales/en-US.json
+++ b/public/locales/en-US.json
@@ -18,13 +18,21 @@
     "noDataErrorLabel": "No data",
     "dateLabel": "Date",
     "coresLabel": "Cores",
+    "coresLegendTooltip": "Lorem ipsum dolor sit, cores.",
     "socketsLabel": "Sockets",
+    "socketsLegendTooltip": "Lorem ipsum dolor sit, sockets.",
     "cloudSocketsLabel": "Public cloud",
+    "cloudSocketsLegendTooltip": "Lorem ipsum dolor sit, cloudSockets.",
     "hypervisorCoresLabel": "Virtualized cores",
+    "hypervisorCoresLegendTooltip": "Lorem ipsum dolor sit, hypervisorCores.",
     "hypervisorSocketsLabel": "Virtualized {{product}}",
+    "hypervisorSocketsLegendTooltip": "Lorem ipsum dolor sit, hypervisorSockets.",
     "physicalCoresLabel": "Physical cores",
+    "physicalCoresLegendTooltip": "Lorem ipsum dolor sit, physicalCores.",
     "physicalSocketsLabel": "Physical {{product}}",
-    "thresholdLabel": "Subscription threshold"
+    "physicalSocketsLegendTooltip": "Lorem ipsum dolor sit, physicalSockets.",
+    "thresholdLabel": "Subscription threshold",
+    "thresholdLegendTooltip": "Lorem ipsum dolor sit, threshold."
   },
   "curiosity-toolbar": {
     "slaCategory": "SLA",

--- a/src/components/c3Chart/__tests__/__snapshots__/c3Chart.test.js.snap
+++ b/src/components/c3Chart/__tests__/__snapshots__/c3Chart.test.js.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`C3Chart Component should pass child components: child components 1`] = `
+<div
+  className="curiosity-c3chart null"
+  style={Object {}}
+>
+  <div
+    className="curiosity-c3chart-container"
+  />
+  <div
+    className="curiosity-c3chart-description"
+  >
+    lorem 
+    <span>
+      ipsum
+    </span>
+  </div>
+</div>
+`;
+
+exports[`C3Chart Component should render a basic component: basic 1`] = `
+<div
+  className="curiosity-c3chart null"
+  style={Object {}}
+>
+  <div
+    className="curiosity-c3chart-container"
+  />
+  <div
+    className="curiosity-c3chart-description"
+  />
+</div>
+`;
+
+exports[`C3Chart Component should return a chart and config reference: references 1`] = `
+<div
+  className="curiosity-c3chart null"
+  style={Object {}}
+>
+  <div
+    className="curiosity-c3chart-container"
+  />
+  <div
+    className="curiosity-c3chart-description"
+  >
+    <span>
+      <Component />
+       and 
+      {"data":{"columns":[]}}
+    </span>
+  </div>
+</div>
+`;

--- a/src/components/c3Chart/__tests__/c3Chart.test.js
+++ b/src/components/c3Chart/__tests__/c3Chart.test.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+import { C3Chart } from '../c3Chart';
+
+describe('C3Chart Component', () => {
+  it('should render a basic component', () => {
+    const props = {};
+    const component = shallow(<C3Chart {...props} />);
+
+    expect(component).toMatchSnapshot('basic');
+  });
+
+  it('should run componentWillUnmount method successfully', () => {
+    const component = mount(<C3Chart />);
+    const componentWillUnmount = jest.spyOn(component.instance(), 'componentWillUnmount');
+    component.unmount();
+    expect(componentWillUnmount).toHaveBeenCalled();
+  });
+
+  it('should pass child components', () => {
+    const props = {};
+    const component = shallow(
+      <C3Chart {...props}>
+        lorem <span>ipsum</span>
+      </C3Chart>
+    );
+
+    expect(component).toMatchSnapshot('child components');
+  });
+
+  it('should return a chart and config reference', () => {
+    const props = {
+      config: {
+        data: {
+          columns: []
+        }
+      }
+    };
+    const component = shallow(
+      <C3Chart {...props}>
+        {({ chart, config }) => (
+          <span>
+            {chart} and {JSON.stringify(config)}
+          </span>
+        )}
+      </C3Chart>
+    );
+
+    expect(component).toMatchSnapshot('references');
+  });
+});

--- a/src/components/c3Chart/c3Chart.js
+++ b/src/components/c3Chart/c3Chart.js
@@ -1,0 +1,110 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import c3 from 'c3';
+import _isEqual from 'lodash/isEqual';
+import 'c3/c3.min.css';
+import { helpers } from '../../common';
+
+/**
+ * C3 wrapper.
+ * Uses aspects from https://github.com/bcbcarl/react-c3js and https://github.com/wuct/react-c3-component
+ *
+ * @augments React.Component
+ */
+class C3Chart extends React.Component {
+  state = { chart: null };
+
+  node = React.createRef();
+
+  componentDidMount() {
+    this.generateChart();
+  }
+
+  componentDidUpdate(prevProps) {
+    const { config } = this.props;
+
+    if (!_isEqual(prevProps.config.data, config.data)) {
+      this.generateChart();
+    }
+  }
+
+  componentWillUnmount() {
+    const { chart } = this.state;
+    if (chart) {
+      chart.destroy();
+    }
+    this.setState({ chart: null });
+  }
+
+  generateChart() {
+    const { chart } = this.state;
+    const { config, onComplete } = this.props;
+
+    let updatedChart = chart;
+    if (!updatedChart) {
+      updatedChart = c3.generate({ bindto: this.node.current, ...config });
+    }
+
+    updatedChart.load({
+      ...config.data,
+      unload: config.unloadBeforeLoad || false,
+      done: () => {
+        this.setState({ chart: updatedChart }, () => {
+          if (config.done) {
+            config.done({ chart: updatedChart, config });
+          } else {
+            onComplete({ chart: updatedChart, config });
+          }
+        });
+      }
+    });
+  }
+
+  render() {
+    const { chart } = this.state;
+    const { className, children, config, style } = this.props;
+
+    return (
+      <div className={`curiosity-c3chart ${className}`} style={style}>
+        <div ref={this.node} className="curiosity-c3chart-container" />
+        {chart && (
+          <div className="curiosity-c3chart-description">
+            {(typeof children === 'function' && children({ chart, config })) || children}
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+/**
+ * Prop types.
+ *
+ * @type {{children: Node|Function, onComplete: Function, className: string, style: object, config}}
+ */
+C3Chart.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+  className: PropTypes.string,
+  config: PropTypes.shape({
+    unloadBeforeLoad: PropTypes.bool,
+    data: PropTypes.object,
+    done: PropTypes.func
+  }),
+  onComplete: PropTypes.func,
+  style: PropTypes.object
+};
+
+/**
+ * Default props.
+ *
+ * @type {{children: null, onComplete: Function, className: null, style: {}, config: {}}}
+ */
+C3Chart.defaultProps = {
+  children: null,
+  className: null,
+  config: {},
+  onComplete: helpers.noop,
+  style: {}
+};
+
+export { C3Chart as default, C3Chart };

--- a/src/components/c3GraphCard/c3GraphCard.js
+++ b/src/components/c3GraphCard/c3GraphCard.js
@@ -1,0 +1,287 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Card, CardHead, CardActions, CardBody } from '@patternfly/react-core';
+import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components/components/Skeleton';
+import _isEqual from 'lodash/isEqual';
+import { Select } from '../form/select';
+import { connectTranslate, reduxActions, reduxSelectors, reduxTypes, store } from '../../redux';
+import { helpers, dateHelpers } from '../../common';
+import { rhsmApiTypes, RHSM_API_QUERY_GRANULARITY_TYPES as GRANULARITY_TYPES } from '../../types/rhsmApiTypes';
+import { c3GraphCardHelpers } from './c3GraphCardHelpers';
+import { C3GraphCardLegendItem } from './c3GraphCardLegendItem';
+import { graphCardTypes } from '../graphCard/graphCardTypes';
+import { C3Chart } from '../c3Chart/c3Chart';
+
+/**
+ * A chart/graph card.
+ *
+ * @augments React.Component
+ * @fires onUpdateGraphData
+ * @fires onGranularitySelect
+ */
+class C3GraphCard extends React.Component {
+  state = {};
+
+  componentDidMount() {
+    this.onUpdateGraphData();
+  }
+
+  componentDidUpdate(prevProps) {
+    const { graphQuery, productId } = this.props;
+
+    if (productId !== prevProps.productId || !_isEqual(graphQuery, prevProps.graphQuery)) {
+      this.onUpdateGraphData();
+    }
+  }
+
+  /**
+   * Call the RHSM APIs, apply filters.
+   *
+   * @event onUpdateGraphData
+   */
+  onUpdateGraphData = () => {
+    const { getGraphReportsCapacity, graphQuery, isDisabled, productId } = this.props;
+    const graphGranularity = graphQuery && graphQuery[rhsmApiTypes.RHSM_API_QUERY_GRANULARITY];
+
+    if (!isDisabled && graphGranularity && productId) {
+      const { startDate, endDate } = dateHelpers.getRangedDateTime(graphGranularity);
+      const query = {
+        [rhsmApiTypes.RHSM_API_QUERY_START_DATE]: startDate.toISOString(),
+        [rhsmApiTypes.RHSM_API_QUERY_END_DATE]: endDate.toISOString(),
+        ...graphQuery
+      };
+
+      getGraphReportsCapacity(productId, query);
+    }
+  };
+
+  /**
+   * On granularity select, dispatch granularity type.
+   *
+   * @event onGranularitySelect
+   * @param {object} event
+   */
+  onGranularitySelect = (event = {}) => {
+    const { value } = event;
+    const { viewId } = this.props;
+
+    store.dispatch({
+      type: reduxTypes.rhsm.SET_GRAPH_GRANULARITY_RHSM,
+      viewId,
+      [rhsmApiTypes.RHSM_API_QUERY_GRANULARITY]: value
+    });
+  };
+
+  /**
+   * Apply a custom legend.
+   *
+   * @param {object} options
+   * @property {Function} chart
+   * @property {Array} filteredData
+   * @property {string} granularity
+   * @property {Array} hiddenDataFacets
+   * @returns {Array}
+   */
+  renderLegend({ chart, filteredData = [], granularity, hiddenDataFacets = [] }) {
+    const { state } = this;
+    const { productId, productShortLabel, t } = this.props;
+
+    return filteredData.map(({ id }) => {
+      const isThreshold = /^threshold/.test(id);
+      const isDataHidden = hiddenDataFacets.includes(id);
+      const tooltipContent = (
+        <p>{(isThreshold && t(`curiosity-graph.thresholdLegendTooltip`)) || t(`curiosity-graph.${id}LegendTooltip`)}</p>
+      );
+
+      const getToggle = ({ isToggled }) => this.setState({ [`${productId}-${granularity}-${id}`]: isToggled });
+      const isToggled = state[`${productId}-${granularity}-${id}`] || false;
+
+      return (
+        <C3GraphCardLegendItem
+          key={`legend-${productId}-${granularity}-${id}`}
+          chart={chart}
+          chartId={id}
+          tooltipContent={tooltipContent}
+          isDisabled={isDataHidden}
+          isThreshold={isThreshold}
+          isToggled={isToggled}
+          getToggle={getToggle}
+        >
+          {(isThreshold && t(`curiosity-graph.thresholdLabel`)) ||
+            t(`curiosity-graph.${id}Label`, { product: productShortLabel })}
+        </C3GraphCardLegendItem>
+      );
+    });
+  }
+
+  /**
+   * Apply props to chart/graph.
+   *
+   * @returns {Node}
+   */
+  renderChart() {
+    const { filterGraphData, graphData, graphQuery, selectOptionsType, productId, productShortLabel } = this.props;
+
+    const graphGranularity = graphQuery && graphQuery[rhsmApiTypes.RHSM_API_QUERY_GRANULARITY];
+    const { selected } = graphCardTypes.getGranularityOptions(selectOptionsType);
+    const updatedGranularity = graphGranularity || selected;
+
+    if (!graphData || !Object.values(graphData).length) {
+      return null;
+    }
+
+    const filtered = [];
+
+    if (filterGraphData.length) {
+      filterGraphData.forEach(filteredValue => {
+        if (graphData[filteredValue.id]) {
+          filtered.push({ ...filteredValue, data: [...graphData[filteredValue.id]] });
+        }
+      });
+    } else {
+      Object.keys(graphData).forEach(id => {
+        filtered.push({ id, data: [...graphData[id]] });
+      });
+    }
+
+    const { configuration = {}, hiddenDataFacets = [] } = c3GraphCardHelpers.c3Config({
+      data: filtered,
+      granularity: updatedGranularity,
+      productShortLabel
+    });
+
+    return (
+      <C3Chart key={`chart-${productId}-${updatedGranularity}`} config={configuration}>
+        {({ chart }) =>
+          this.renderLegend({
+            chart,
+            filteredData: filtered,
+            granularity: updatedGranularity,
+            hiddenDataFacets
+          })
+        }
+      </C3Chart>
+    );
+  }
+
+  /**
+   * Render a chart/graph card with chart/graph.
+   *
+   * @returns {Node}
+   */
+  render() {
+    const { cardTitle, children, error, graphQuery, isDisabled, selectOptionsType, pending, t } = this.props;
+
+    if (isDisabled) {
+      return null;
+    }
+
+    const { options } = graphCardTypes.getGranularityOptions(selectOptionsType);
+    const graphGranularity = graphQuery && graphQuery[rhsmApiTypes.RHSM_API_QUERY_GRANULARITY];
+
+    return (
+      <Card className="curiosity-usage-graph fadein">
+        <CardHead>
+          <h2>{cardTitle}</h2>
+          <CardActions>
+            {children}
+            <Select
+              aria-label={t('curiosity-graph.dropdownPlaceholder')}
+              onSelect={this.onGranularitySelect}
+              options={options}
+              selectedOptions={graphGranularity}
+              placeholder={t('curiosity-graph.dropdownPlaceholder')}
+            />
+          </CardActions>
+        </CardHead>
+        <CardBody>
+          <div className={`curiosity-skeleton-container ${(error && 'blur') || ''}`}>
+            {pending && (
+              <React.Fragment>
+                <Skeleton size={SkeletonSize.xs} />
+                <Skeleton size={SkeletonSize.sm} />
+                <Skeleton size={SkeletonSize.md} />
+                <Skeleton size={SkeletonSize.lg} />
+              </React.Fragment>
+            )}
+            {!pending && this.renderChart()}
+          </div>
+        </CardBody>
+      </Card>
+    );
+  }
+}
+
+/**
+ * Prop types.
+ *
+ * @type {{productId: string, pending: boolean, error: boolean, graphQuery: object, cardTitle: string,
+ *     filterGraphData: Array, getGraphReportsCapacity: Function, productShortLabel: string, selectOptionsType: string,
+ *     viewId: string, t: Function, children: Node, graphData: object, isDisabled: boolean}}
+ */
+C3GraphCard.propTypes = {
+  cardTitle: PropTypes.string,
+  children: PropTypes.node,
+  error: PropTypes.bool,
+  filterGraphData: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      color: PropTypes.string
+    })
+  ),
+  getGraphReportsCapacity: PropTypes.func,
+  graphData: PropTypes.object,
+  graphQuery: PropTypes.shape({
+    [rhsmApiTypes.RHSM_API_QUERY_GRANULARITY]: PropTypes.oneOf([...Object.values(GRANULARITY_TYPES)]).isRequired
+  }).isRequired,
+  isDisabled: PropTypes.bool,
+  pending: PropTypes.bool,
+  productId: PropTypes.string.isRequired,
+  selectOptionsType: PropTypes.oneOf(['default']),
+  t: PropTypes.func,
+  productShortLabel: PropTypes.string,
+  viewId: PropTypes.string
+};
+
+/**
+ * Default props.
+ *
+ * @type {{getGraphReportsCapacity: Function, productShortLabel: string, selectOptionsType: string,
+ *     viewId: string, t: Function, children: null, pending: boolean, graphData: object,
+ *     isDisabled: boolean, error: boolean, cardTitle: null, filterGraphData: Array}}
+ */
+C3GraphCard.defaultProps = {
+  cardTitle: null,
+  children: null,
+  error: false,
+  filterGraphData: [],
+  getGraphReportsCapacity: helpers.noop,
+  graphData: {},
+  isDisabled: helpers.UI_DISABLED_GRAPH,
+  pending: false,
+  selectOptionsType: 'default',
+  t: helpers.noopTranslate,
+  productShortLabel: '',
+  viewId: 'graphCard'
+};
+
+/**
+ * Create a selector from applied state, props.
+ *
+ * @type {Function}
+ */
+const makeMapStateToProps = reduxSelectors.graphCard.makeGraphCard();
+
+/**
+ * Apply actions to props.
+ *
+ * @param {Function} dispatch
+ * @returns {object}
+ */
+const mapDispatchToProps = dispatch => ({
+  getGraphReportsCapacity: (id, query) => dispatch(reduxActions.rhsm.getGraphReportsCapacity(id, query))
+});
+
+const ConnectedGraphCard = connectTranslate(makeMapStateToProps, mapDispatchToProps)(C3GraphCard);
+
+export { ConnectedGraphCard as default, ConnectedGraphCard, C3GraphCard };

--- a/src/components/c3GraphCard/c3GraphCardHelpers.js
+++ b/src/components/c3GraphCard/c3GraphCardHelpers.js
@@ -1,0 +1,255 @@
+import moment from 'moment';
+import numbro from 'numbro';
+import { chart_color_green_300 as chartColorGreenDark } from '@patternfly/react-tokens';
+import { translate } from '../i18n/i18n';
+import { RHSM_API_QUERY_GRANULARITY_TYPES as GRANULARITY_TYPES } from '../../types/rhsmApiTypes';
+import { dateHelpers, helpers } from '../../common';
+
+/**
+ * Return a formatted date string.
+ *
+ * @param {object} params
+ * @property {Date} date
+ * @property {string} granularity See enum of RHSM_API_QUERY_GRANULARITY_TYPES
+ * @returns {string}
+ */
+const getTooltipDate = ({ date, granularity }) => {
+  const momentDate = moment.utc(date);
+
+  switch (granularity) {
+    case GRANULARITY_TYPES.QUARTERLY:
+      return `${momentDate.format(dateHelpers.timestampQuarterFormats.yearShort)} - ${momentDate
+        .add(1, 'quarter')
+        .format(dateHelpers.timestampQuarterFormats.yearShort)}`;
+
+    case GRANULARITY_TYPES.MONTHLY:
+      return momentDate.format(dateHelpers.timestampMonthFormats.yearLong);
+
+    case GRANULARITY_TYPES.WEEKLY:
+      return `${momentDate.format(dateHelpers.timestampDayFormats.short)} - ${momentDate
+        .add(1, 'week')
+        .format(dateHelpers.timestampDayFormats.yearShort)}`;
+
+    case GRANULARITY_TYPES.DAILY:
+    default:
+      return momentDate.format(dateHelpers.timestampDayFormats.long);
+  }
+};
+
+/**
+ * Format x axis ticks.
+ *
+ * @param {object} params
+ * @property {Date} date
+ * @property {string} granularity See enum of RHSM_API_QUERY_GRANULARITY_TYPES
+ * @property {number|string} tick
+ * @property {Date} previousDate
+ * @returns {string|undefined}
+ */
+const xAxisTickFormat = ({ date, granularity, tick, previousDate }) => {
+  if (!date || !granularity) {
+    return undefined;
+  }
+
+  const momentDate = moment.utc(date);
+  const isNewYear =
+    tick !== 0 && Number.parseInt(momentDate.year(), 10) !== Number.parseInt(moment.utc(previousDate).year(), 10);
+  let formattedDate;
+
+  switch (granularity) {
+    case GRANULARITY_TYPES.QUARTERLY:
+      formattedDate = isNewYear
+        ? momentDate.format(dateHelpers.timestampQuarterFormats.yearShort)
+        : momentDate.format(dateHelpers.timestampQuarterFormats.short);
+
+      formattedDate = formattedDate.replace(/\s/, '\n');
+      break;
+    case GRANULARITY_TYPES.MONTHLY:
+      formattedDate = isNewYear
+        ? momentDate.format(dateHelpers.timestampMonthFormats.yearShort)
+        : momentDate.format(dateHelpers.timestampMonthFormats.short);
+
+      formattedDate = formattedDate.replace(/\s/, '\n');
+      break;
+    case GRANULARITY_TYPES.WEEKLY:
+    case GRANULARITY_TYPES.DAILY:
+    default:
+      formattedDate = isNewYear
+        ? momentDate.format(dateHelpers.timestampDayFormats.yearShort)
+        : momentDate.format(dateHelpers.timestampDayFormats.short);
+
+      formattedDate = formattedDate.replace(/\s(\d{4})$/, '\n$1');
+      break;
+  }
+
+  return formattedDate;
+};
+
+/**
+ * Format y axis ticks.
+ *
+ * @param {object} params
+ * @property {number|string} tick
+ * @returns {string}
+ */
+const yAxisTickFormat = ({ tick }) => numbro(tick).format({ average: true, mantissa: 1, optionalMantissa: true });
+
+/**
+ * Convert data into a C3 configuration object.
+ *
+ * @param {object} options
+ * @property {Array} data
+ * @property {string} granularity
+ * @property {string} productShortLabel
+ * @returns {{configuration: {padding: {top: number, left: number, bottom: number, right: number},
+ *     data: {types: {}, names: {}, columns: [], x: string, groups: [[]], colors: {}},
+ *     legend: {show: boolean}, grid: {y: {show: boolean}}, tooltip: {format: {title: (function(*): string),
+ *     value: (function(*, *, *=, *): *)}, order: (function(*, *): number)}, unloadBeforeLoad: boolean,
+ *     spline: {interpolation: {type: string}}, axis: {x: {padding: number,
+ *     tick: {format: (function(*=): string)}, type: string}, y: {padding: {bottom: number},
+ *     default: number[], min: number, tick: {show: boolean, outer: boolean,
+ *     format: (function(*): string)}}}, point: {show: boolean}}, hiddenDataFacets: []}}
+ */
+const c3Config = ({ data = [], granularity, productShortLabel }) => {
+  const hiddenDataFacets = [];
+  const converted = {
+    x: 'x',
+    colors: {},
+    columns: [],
+    groups: [[]],
+    names: {},
+    types: {}
+  };
+
+  const convertTimeSeriesDate = value => {
+    const dateStr = (helpers.TEST_MODE && moment.utc(value)) || moment.utc(value).local();
+    return dateStr.format('YYYY-MM-DD');
+  };
+
+  data.forEach(value => {
+    if (/^threshold/.test(value.id)) {
+      converted.colors[value.id] = value.color || chartColorGreenDark.value;
+      converted.types[value.id] = 'step';
+      converted.names[value.id] = translate(`curiosity-graph.thresholdLabel`);
+    } else {
+      converted.colors[value.id] = value.color;
+      converted.types[value.id] = 'area-spline';
+      converted.groups[0].push(value.id);
+      converted.names[value.id] = translate(`curiosity-graph.${value.id}Label`, { product: productShortLabel });
+    }
+
+    converted.columns[0] = ['x'];
+    converted.columns.push([value.id]);
+
+    let totalData = 0;
+
+    value.data.forEach(filteredValue => {
+      converted.columns[0].push(convertTimeSeriesDate(filteredValue.date));
+      converted.columns[converted.columns.length - 1].push(filteredValue.y);
+      totalData += filteredValue.y || 0;
+    });
+
+    // ToDo: need to check for infinite threshold, possibly has data
+    if (totalData <= 0) {
+      converted.columns.pop();
+      hiddenDataFacets.push(value.id);
+    }
+  });
+
+  return {
+    hiddenDataFacets,
+    configuration: {
+      tooltip: {
+        order: (a, b) => converted.columns.indexOf(a.id) - converted.columns.indexOf(b.id),
+        format: {
+          title: date =>
+            getTooltipDate({
+              date,
+              granularity
+            }),
+          value: (value, ratio, id, index) => {
+            const dataItem = data.find(dataValue => id === dataValue.id)?.data[index];
+            let updatedValue;
+
+            if (/^threshold/.test(id)) {
+              updatedValue =
+                (dataItem?.hasInfinite && translate('curiosity-graph.infiniteThresholdLabel')) ||
+                (dataItem?.y ?? translate('curiosity-graph.noDataLabel'));
+            } else {
+              updatedValue =
+                (dataItem?.hasData === false && translate('curiosity-graph.noDataLabel')) || dataItem?.y || 0;
+            }
+
+            return updatedValue;
+          }
+        }
+      },
+      unloadBeforeLoad: true,
+      padding: { left: 40, right: 40, top: 10, bottom: 10 },
+      legend: { show: false },
+      spline: {
+        interpolation: {
+          type: 'monotone'
+        }
+      },
+      data: {
+        ...converted
+      },
+      point: {
+        show: false
+      },
+      grid: {
+        y: {
+          show: true
+        }
+      },
+      axis: {
+        x: {
+          type: 'timeseries',
+          tick: {
+            format: tick => {
+              const xAxisTicks = converted.columns[0].slice(1);
+              const formattedDate = convertTimeSeriesDate(tick);
+              const dateIndex = xAxisTicks.indexOf(formattedDate);
+              const previousDate = dateIndex > -1 && xAxisTicks[dateIndex - 1];
+
+              return xAxisTickFormat({
+                tick: dateIndex,
+                date: formattedDate,
+                previousDate,
+                granularity
+              });
+            }
+          },
+          padding: 0
+        },
+        y: {
+          default: [0, 50],
+          padding: { bottom: 0 },
+          min: 0,
+          tick: {
+            show: false,
+            outer: false,
+            format: tick => (tick === 0 ? '' : yAxisTickFormat({ tick }))
+          }
+        }
+      }
+    }
+  };
+};
+
+const c3GraphCardHelpers = {
+  c3Config,
+  getTooltipDate,
+  xAxisTickFormat,
+  yAxisTickFormat
+};
+
+export {
+  c3GraphCardHelpers as default,
+  c3GraphCardHelpers,
+  c3Config,
+  getTooltipDate,
+  xAxisTickFormat,
+  yAxisTickFormat
+};

--- a/src/components/c3GraphCard/c3GraphCardLegendItem.js
+++ b/src/components/c3GraphCard/c3GraphCardLegendItem.js
@@ -1,0 +1,201 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { EyeSlashIcon } from '@patternfly/react-icons';
+import { helpers } from '../../common';
+
+/**
+ * A chart/graph legend button.
+ *
+ * @augments React.Component
+ * @fires onFocus
+ * @fires onRevert
+ * @fires onToggle
+ */
+class C3GraphCardLegendItem extends React.Component {
+  state = { updatedIsToggled: null };
+
+  /**
+   * C3 chart display focus.
+   *
+   * @event onFocus
+   */
+  onFocus = () => {
+    const { updatedIsToggled } = this.state;
+    const { chart, chartId, getToggle, isToggled } = this.props;
+
+    if ((typeof getToggle === 'function' && !isToggled) || !updatedIsToggled) {
+      chart.focus(chartId);
+    }
+  };
+
+  /**
+   * C3 chart display revert.
+   *
+   * @event onRevert
+   */
+  onRevert = () => {
+    const { updatedIsToggled } = this.state;
+    const { chart, getToggle, isToggled } = this.props;
+
+    if ((typeof getToggle === 'function' && !isToggled) || !updatedIsToggled) {
+      chart.revert();
+    }
+  };
+
+  /**
+   * C3 chart display toggle.
+   *
+   * @event onToggle
+   */
+  onToggle = () => {
+    const { updatedIsToggled } = this.state;
+    const { chart, chartId, getToggle, isToggled } = this.props;
+
+    chart.toggle(chartId);
+
+    if (typeof getToggle === 'function') {
+      getToggle({ isToggled: !isToggled });
+    } else {
+      this.setState({
+        updatedIsToggled: !updatedIsToggled
+      });
+    }
+
+    this.onRevert();
+  };
+
+  /**
+   * C3 chart display config color.
+   *
+   * @returns {string}
+   */
+  getColor = () => {
+    const { chart, chartId } = this.props;
+    return chart.color(chartId);
+  };
+
+  /**
+   * ToDO: evaluate using nullish coalescing operator for checkIsToggled
+   */
+  /**
+   * Render a chart legend item.
+   *
+   * @returns {Node}
+   */
+  render() {
+    const { updatedIsToggled } = this.state;
+    const { children, chart, chartId, isDisabled, isThreshold, isToggled, tooltipContent } = this.props;
+    const checkIsToggled =
+      (updatedIsToggled === null && typeof isToggled === 'boolean' && isToggled) || updatedIsToggled || false;
+
+    if (checkIsToggled) {
+      chart.hide(chartId);
+    }
+
+    const button = (
+      <Button
+        tabIndex={0}
+        key={`curiosity-button-${chartId}`}
+        variant="link"
+        onClick={this.onToggle}
+        onFocus={this.onFocus}
+        onMouseOver={this.onFocus}
+        onBlur={this.onRevert}
+        onMouseOut={this.onRevert}
+        onKeyPress={this.onToggle}
+        component="a"
+        isDisabled={isDisabled}
+        icon={
+          ((isDisabled || checkIsToggled) && <EyeSlashIcon />) ||
+          (isThreshold && (
+            <hr
+              aria-hidden
+              className="threshold-legend-icon"
+              style={{
+                visibility: (isDisabled && 'hidden') || (checkIsToggled && 'hidden') || 'visible',
+                borderTopColor: this.getColor()
+              }}
+            />
+          )) || (
+            <div
+              aria-hidden
+              className="legend-icon"
+              style={{
+                visibility: (isDisabled && 'hidden') || (checkIsToggled && 'hidden') || 'visible',
+                backgroundColor: this.getColor()
+              }}
+            />
+          )
+        }
+      >
+        {children}
+      </Button>
+    );
+
+    if (tooltipContent) {
+      return (
+        <Tooltip
+          key={`curiosity-tooltip-${chartId}`}
+          content={tooltipContent}
+          position={TooltipPosition.top}
+          distance={-10}
+          entryDelay={100}
+          exitDelay={0}
+        >
+          {button}
+        </Tooltip>
+      );
+    }
+
+    return button;
+  }
+}
+
+/**
+ * Prop types.
+ *
+ * @type {{chartId: string, children: Node, isDisabled: boolean, tooltipContent: Node, chart: object,
+ *    isThreshold: boolean, isToggled: boolean, getToggle: Function}}
+ */
+C3GraphCardLegendItem.propTypes = {
+  chart: PropTypes.shape({
+    color: PropTypes.func,
+    focus: PropTypes.func,
+    hide: PropTypes.func,
+    revert: PropTypes.func,
+    toggle: PropTypes.func
+  }),
+  chartId: PropTypes.string.isRequired,
+  children: PropTypes.node,
+  isDisabled: PropTypes.bool,
+  isThreshold: PropTypes.bool,
+  isToggled: PropTypes.bool,
+  tooltipContent: PropTypes.node,
+  getToggle: PropTypes.func
+};
+
+/**
+ * Default props.
+ *
+ * @type {{children: null, isDisabled: boolean, tooltipContent: null, chart: {hide: Function,
+ *    color: Function, focus: Function, revert: Function, toggle: Function}, isThreshold: boolean,
+ *    isToggled: boolean, getToggle: Function}}
+ */
+C3GraphCardLegendItem.defaultProps = {
+  chart: {
+    color: helpers.noop,
+    focus: helpers.noop,
+    hide: helpers.noop,
+    revert: helpers.noop,
+    toggle: helpers.noop
+  },
+  children: null,
+  isDisabled: false,
+  isThreshold: false,
+  isToggled: false,
+  tooltipContent: null,
+  getToggle: null
+};
+
+export { C3GraphCardLegendItem as default, C3GraphCardLegendItem };

--- a/src/components/c3GraphCard/tests/__snapshots__/c3GraphCard.test.js.snap
+++ b/src/components/c3GraphCard/tests/__snapshots__/c3GraphCard.test.js.snap
@@ -1,0 +1,400 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`C3GraphCard Component should filter result sets: filtered config 1`] = `
+Object {
+  "colors": Object {
+    "loremIpsumSockets": undefined,
+    "thresholdLoremIpsumSockets": "#4cb140",
+  },
+  "columns": Array [
+    Array [
+      "x",
+      "2019-06-01",
+      "2019-06-08",
+      "2019-06-25",
+    ],
+    Array [
+      "loremIpsumSockets",
+      10,
+      12,
+      3,
+    ],
+    Array [
+      "thresholdLoremIpsumSockets",
+      10,
+      12,
+      3,
+    ],
+  ],
+  "groups": Array [
+    Array [
+      "loremIpsumSockets",
+    ],
+  ],
+  "names": Object {
+    "loremIpsumSockets": "t(curiosity-graph.loremIpsumSocketsLabel, [object Object])",
+    "thresholdLoremIpsumSockets": "t(curiosity-graph.thresholdLabel)",
+  },
+  "types": Object {
+    "loremIpsumSockets": "area-spline",
+    "thresholdLoremIpsumSockets": "step",
+  },
+  "x": "x",
+}
+`;
+
+exports[`C3GraphCard Component should render a custom legend: empty legend 1`] = `Array []`;
+
+exports[`C3GraphCard Component should render a custom legend: legend 1`] = `
+Array [
+  <C3GraphCardLegendItem
+    chart={
+      Object {
+        "color": [Function],
+        "focus": [Function],
+        "hide": [Function],
+        "revert": [Function],
+        "toggle": [Function],
+      }
+    }
+    chartId="lorem"
+    getToggle={[Function]}
+    isDisabled={false}
+    isThreshold={false}
+    isToggled={false}
+    tooltipContent={
+      <p>
+        t(curiosity-graph.loremLegendTooltip)
+      </p>
+    }
+  >
+    t(curiosity-graph.loremLabel, [object Object])
+  </C3GraphCardLegendItem>,
+  <C3GraphCardLegendItem
+    chart={
+      Object {
+        "color": [Function],
+        "focus": [Function],
+        "hide": [Function],
+        "revert": [Function],
+        "toggle": [Function],
+      }
+    }
+    chartId="thresholdIpsum"
+    getToggle={[Function]}
+    isDisabled={false}
+    isThreshold={true}
+    isToggled={false}
+    tooltipContent={
+      <p>
+        t(curiosity-graph.thresholdLegendTooltip)
+      </p>
+    }
+  >
+    t(curiosity-graph.thresholdLabel)
+  </C3GraphCardLegendItem>,
+]
+`;
+
+exports[`C3GraphCard Component should render a non-connected component: non-connected 1`] = `
+<Card
+  className="curiosity-usage-graph fadein"
+>
+  <CardHead>
+    <h2 />
+    <CardActions>
+      <Select
+        aria-label="t(curiosity-graph.dropdownPlaceholder)"
+        ariaLabel="Select option"
+        className=""
+        id="generatedid-"
+        isDisabled={false}
+        name={null}
+        onSelect={[Function]}
+        options={
+          Array [
+            Object {
+              "selected": true,
+              "title": "t(curiosity-graph.dropdownDaily)",
+              "value": "daily",
+            },
+            Object {
+              "title": "t(curiosity-graph.dropdownWeekly)",
+              "value": "weekly",
+            },
+            Object {
+              "title": "t(curiosity-graph.dropdownMonthly)",
+              "value": "monthly",
+            },
+            Object {
+              "title": "t(curiosity-graph.dropdownQuarterly)",
+              "value": "quarterly",
+            },
+          ]
+        }
+        placeholder="t(curiosity-graph.dropdownPlaceholder)"
+        selectedOptions="daily"
+        variant="single"
+      />
+    </CardActions>
+  </CardHead>
+  <CardBody>
+    <div
+      className="curiosity-skeleton-container "
+    />
+  </CardBody>
+</Card>
+`;
+
+exports[`C3GraphCard Component should render multiple states: error passes values 1`] = `
+Object {
+  "chartBarData": Object {
+    "colors": Object {
+      "physicalSockets": undefined,
+    },
+    "columns": Array [
+      Array [
+        "x",
+        "2019-06-01",
+        "2019-06-08",
+        "2019-06-25",
+      ],
+      Array [
+        "physicalSockets",
+        10,
+        12,
+        3,
+      ],
+    ],
+    "groups": Array [
+      Array [
+        "physicalSockets",
+      ],
+    ],
+    "names": Object {
+      "physicalSockets": "t(curiosity-graph.physicalSocketsLabel, [object Object])",
+    },
+    "types": Object {
+      "physicalSockets": "area-spline",
+    },
+    "x": "x",
+  },
+}
+`;
+
+exports[`C3GraphCard Component should render multiple states: fulfilled 1`] = `
+<Card
+  className="curiosity-usage-graph fadein"
+>
+  <CardHead>
+    <h2 />
+    <CardActions>
+      <Select
+        aria-label="t(curiosity-graph.dropdownPlaceholder)"
+        ariaLabel="Select option"
+        className=""
+        id="generatedid-"
+        isDisabled={false}
+        name={null}
+        onSelect={[Function]}
+        options={
+          Array [
+            Object {
+              "selected": true,
+              "title": "t(curiosity-graph.dropdownDaily)",
+              "value": "daily",
+            },
+            Object {
+              "title": "t(curiosity-graph.dropdownWeekly)",
+              "value": "weekly",
+            },
+            Object {
+              "title": "t(curiosity-graph.dropdownMonthly)",
+              "value": "monthly",
+            },
+            Object {
+              "title": "t(curiosity-graph.dropdownQuarterly)",
+              "value": "quarterly",
+            },
+          ]
+        }
+        placeholder="t(curiosity-graph.dropdownPlaceholder)"
+        selectedOptions="daily"
+        variant="single"
+      />
+    </CardActions>
+  </CardHead>
+  <CardBody>
+    <div
+      className="curiosity-skeleton-container "
+    >
+      <C3Chart
+        className={null}
+        config={
+          Object {
+            "axis": Object {
+              "x": Object {
+                "padding": 0,
+                "tick": Object {
+                  "format": [Function],
+                },
+                "type": "timeseries",
+              },
+              "y": Object {
+                "default": Array [
+                  0,
+                  50,
+                ],
+                "min": 0,
+                "padding": Object {
+                  "bottom": 0,
+                },
+                "tick": Object {
+                  "format": [Function],
+                  "outer": false,
+                  "show": false,
+                },
+              },
+            },
+            "data": Object {
+              "colors": Object {
+                "physicalSockets": undefined,
+              },
+              "columns": Array [
+                Array [
+                  "x",
+                  "2019-06-01",
+                  "2019-06-08",
+                  "2019-06-25",
+                ],
+                Array [
+                  "physicalSockets",
+                  10,
+                  12,
+                  3,
+                ],
+              ],
+              "groups": Array [
+                Array [
+                  "physicalSockets",
+                ],
+              ],
+              "names": Object {
+                "physicalSockets": "t(curiosity-graph.physicalSocketsLabel, [object Object])",
+              },
+              "types": Object {
+                "physicalSockets": "area-spline",
+              },
+              "x": "x",
+            },
+            "grid": Object {
+              "y": Object {
+                "show": true,
+              },
+            },
+            "legend": Object {
+              "show": false,
+            },
+            "padding": Object {
+              "bottom": 10,
+              "left": 40,
+              "right": 40,
+              "top": 10,
+            },
+            "point": Object {
+              "show": false,
+            },
+            "spline": Object {
+              "interpolation": Object {
+                "type": "monotone",
+              },
+            },
+            "tooltip": Object {
+              "format": Object {
+                "title": [Function],
+                "value": [Function],
+              },
+              "order": [Function],
+            },
+            "unloadBeforeLoad": true,
+          }
+        }
+        key="chart-lorem-daily"
+        onComplete={[Function]}
+        style={Object {}}
+      >
+        <Component />
+      </C3Chart>
+    </div>
+  </CardBody>
+</Card>
+`;
+
+exports[`C3GraphCard Component should render multiple states: pending 1`] = `
+<Card
+  className="curiosity-usage-graph fadein"
+>
+  <CardHead>
+    <h2 />
+    <CardActions>
+      <Select
+        aria-label="t(curiosity-graph.dropdownPlaceholder)"
+        ariaLabel="Select option"
+        className=""
+        id="generatedid-"
+        isDisabled={false}
+        name={null}
+        onSelect={[Function]}
+        options={
+          Array [
+            Object {
+              "selected": true,
+              "title": "t(curiosity-graph.dropdownDaily)",
+              "value": "daily",
+            },
+            Object {
+              "title": "t(curiosity-graph.dropdownWeekly)",
+              "value": "weekly",
+            },
+            Object {
+              "title": "t(curiosity-graph.dropdownMonthly)",
+              "value": "monthly",
+            },
+            Object {
+              "title": "t(curiosity-graph.dropdownQuarterly)",
+              "value": "quarterly",
+            },
+          ]
+        }
+        placeholder="t(curiosity-graph.dropdownPlaceholder)"
+        selectedOptions="daily"
+        variant="single"
+      />
+    </CardActions>
+  </CardHead>
+  <CardBody>
+    <div
+      className="curiosity-skeleton-container "
+    >
+      <Skeleton
+        isDark={false}
+        size="xs"
+      />
+      <Skeleton
+        isDark={false}
+        size="sm"
+      />
+      <Skeleton
+        isDark={false}
+        size="md"
+      />
+      <Skeleton
+        isDark={false}
+        size="lg"
+      />
+    </div>
+  </CardBody>
+</Card>
+`;
+
+exports[`C3GraphCard Component should return an empty render when disabled: disabled component 1`] = `""`;

--- a/src/components/c3GraphCard/tests/__snapshots__/c3GraphCardHelpers.test.js.snap
+++ b/src/components/c3GraphCard/tests/__snapshots__/c3GraphCardHelpers.test.js.snap
@@ -1,0 +1,266 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`C3GraphCardHelpers c3Config should return a c3 configuration object: chart configuration 1`] = `
+Object {
+  "configuration": Object {
+    "configuration": Object {
+      "axis": Object {
+        "x": Object {
+          "padding": 0,
+          "tick": Object {
+            "format": [Function],
+          },
+          "type": "timeseries",
+        },
+        "y": Object {
+          "default": Array [
+            0,
+            50,
+          ],
+          "min": 0,
+          "padding": Object {
+            "bottom": 0,
+          },
+          "tick": Object {
+            "format": [Function],
+            "outer": false,
+            "show": false,
+          },
+        },
+      },
+      "data": Object {
+        "colors": Object {
+          "dolor": "red",
+          "ipsum": "red",
+          "lorem": "red",
+          "sit": "red",
+        },
+        "columns": Array [
+          Array [
+            "x",
+            "2019-06-08",
+          ],
+          Array [
+            "lorem",
+            1,
+          ],
+          Array [
+            "ipsum",
+            1,
+          ],
+          Array [
+            "dolor",
+            1,
+          ],
+          Array [
+            "sit",
+            1,
+          ],
+        ],
+        "groups": Array [
+          Array [
+            "lorem",
+            "ipsum",
+            "dolor",
+            "sit",
+          ],
+        ],
+        "names": Object {
+          "dolor": "t(curiosity-graph.dolorLabel, [object Object])",
+          "ipsum": "t(curiosity-graph.ipsumLabel, [object Object])",
+          "lorem": "t(curiosity-graph.loremLabel, [object Object])",
+          "sit": "t(curiosity-graph.sitLabel, [object Object])",
+        },
+        "types": Object {
+          "dolor": "area-spline",
+          "ipsum": "area-spline",
+          "lorem": "area-spline",
+          "sit": "area-spline",
+        },
+        "x": "x",
+      },
+      "grid": Object {
+        "y": Object {
+          "show": true,
+        },
+      },
+      "legend": Object {
+        "show": false,
+      },
+      "padding": Object {
+        "bottom": 10,
+        "left": 40,
+        "right": 40,
+        "top": 10,
+      },
+      "point": Object {
+        "show": false,
+      },
+      "spline": Object {
+        "interpolation": Object {
+          "type": "monotone",
+        },
+      },
+      "tooltip": Object {
+        "format": Object {
+          "title": [Function],
+          "value": [Function],
+        },
+        "order": [Function],
+      },
+      "unloadBeforeLoad": true,
+    },
+    "hiddenDataFacets": Array [],
+  },
+}
+`;
+
+exports[`C3GraphCardHelpers getTooltipDate should return a formatted date based on granularity: granularity based date 1`] = `
+Object {
+  "daily": "June 1",
+  "monthly": "June 2019",
+  "quarterly": "Jun 2019 - Sep 2019",
+  "weekly": "Jun 1 - Jun 8 2019",
+}
+`;
+
+exports[`C3GraphCardHelpers should have specific functions: graphCardHelpers 1`] = `
+Object {
+  "c3Config": [Function],
+  "getTooltipDate": [Function],
+  "xAxisTickFormat": [Function],
+  "yAxisTickFormat": [Function],
+}
+`;
+
+exports[`C3GraphCardHelpers xAxisTickFormat should produce consistent x axis tick values: x axis should be undefined if date or granularity are missing 1`] = `
+Object {
+  "missingDate": undefined,
+  "missingGranularity": undefined,
+}
+`;
+
+exports[`C3GraphCardHelpers xAxisTickFormat should produce consistent x axis tick values: x axis tick values 1`] = `
+Object {
+  "daily": Array [
+    "Jun 20",
+    "Jun 21",
+    "Jun 22",
+    "Jun 23",
+    "Jun 24",
+    "Jun 25",
+    "Jun 26",
+    "Jun 27",
+    "Jun 28",
+    "Jun 29",
+    "Jun 30",
+    "Jul 1",
+    "Jul 2",
+    "Jul 3",
+    "Jul 4",
+    "Jul 5",
+    "Jul 6",
+    "Jul 7",
+    "Jul 8",
+    "Jul 9",
+    "Jul 10",
+    "Jul 11",
+    "Jul 12",
+    "Jul 13",
+    "Jul 14",
+    "Jul 15",
+    "Jul 16",
+    "Jul 17",
+    "Jul 18",
+    "Jul 19",
+    "Jul 20",
+  ],
+  "monthly": Array [
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+    "Jan
+2019",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+  ],
+  "quarterly": Array [
+    "Jul",
+    "Oct",
+    "Jan
+2017",
+    "Apr",
+    "Jul",
+    "Oct",
+    "Jan
+2018",
+    "Apr",
+    "Jul",
+    "Oct",
+    "Jan
+2019",
+    "Apr",
+    "Jul",
+  ],
+  "weekly": Array [
+    "Apr 21",
+    "Apr 28",
+    "May 5",
+    "May 12",
+    "May 19",
+    "May 26",
+    "Jun 2",
+    "Jun 9",
+    "Jun 16",
+    "Jun 23",
+    "Jun 30",
+    "Jul 7",
+    "Jul 14",
+  ],
+}
+`;
+
+exports[`C3GraphCardHelpers yAxisTickFormat should produce consistent y axis tick values: y axis tick values 1`] = `
+Object {
+  "1": "1",
+  "10": "10",
+  "100": "100",
+  "1000": "1k",
+  "10000": "10k",
+  "100000": "100k",
+  "1000000": "1m",
+  "10000000": "10m",
+  "100000000": "100m",
+  "1000000000": "1b",
+  "10000000000": "10b",
+  "13": "13",
+  "130": "130",
+  "1300": "1.3k",
+  "13000": "13k",
+  "130000": "130k",
+  "1300000": "1.3m",
+  "13000000": "13m",
+  "130000000": "130m",
+  "1300000000": "1.3b",
+  "13000000000": "13b",
+  "130000000000": "130b",
+  "15": "15",
+  "150": "150",
+  "1500": "1.5k",
+  "15000": "15k",
+  "150000": "150k",
+  "1500000": "1.5m",
+  "15000000": "15m",
+  "150000000": "150m",
+  "1500000000": "1.5b",
+  "15000000000": "15b",
+  "150000000000": "150b",
+}
+`;

--- a/src/components/c3GraphCard/tests/__snapshots__/c3GraphCardLegendItem.test.js.snap
+++ b/src/components/c3GraphCard/tests/__snapshots__/c3GraphCardLegendItem.test.js.snap
@@ -1,0 +1,160 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`C3GraphCardLegendItem Component should be able to display both threshold and disabling icons: disabled 1`] = `
+<Component
+  component="a"
+  icon={
+    <EyeSlashIcon
+      color="currentColor"
+      noVerticalAlign={false}
+      size="sm"
+      title={null}
+    />
+  }
+  isDisabled={true}
+  key="curiosity-button-lorem"
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyPress={[Function]}
+  onMouseOut={[Function]}
+  onMouseOver={[Function]}
+  tabIndex={0}
+  variant="link"
+/>
+`;
+
+exports[`C3GraphCardLegendItem Component should be able to display both threshold and disabling icons: threshold 1`] = `
+<Component
+  component="a"
+  icon={
+    <hr
+      aria-hidden={true}
+      className="threshold-legend-icon"
+      style={
+        Object {
+          "borderTopColor": undefined,
+          "visibility": "visible",
+        }
+      }
+    />
+  }
+  isDisabled={false}
+  key="curiosity-button-lorem"
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyPress={[Function]}
+  onMouseOut={[Function]}
+  onMouseOver={[Function]}
+  tabIndex={0}
+  variant="link"
+/>
+`;
+
+exports[`C3GraphCardLegendItem Component should handle focus, revert, and toggle chart events while reading and updating state: toggle OFF 1`] = `
+Object {
+  "updatedIsToggled": false,
+}
+`;
+
+exports[`C3GraphCardLegendItem Component should handle focus, revert, and toggle chart events while reading and updating state: toggle ON 1`] = `
+Object {
+  "updatedIsToggled": true,
+}
+`;
+
+exports[`C3GraphCardLegendItem Component should render a non-connected component: non-connected 1`] = `
+<Component
+  component="a"
+  icon={
+    <div
+      aria-hidden={true}
+      className="legend-icon"
+      style={
+        Object {
+          "backgroundColor": undefined,
+          "visibility": "visible",
+        }
+      }
+    />
+  }
+  isDisabled={false}
+  key="curiosity-button-lorem"
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyPress={[Function]}
+  onMouseOut={[Function]}
+  onMouseOver={[Function]}
+  tabIndex={0}
+  variant="link"
+>
+  lorem ipsum
+</Component>
+`;
+
+exports[`C3GraphCardLegendItem Component should render a tooltip with button: tooltip 1`] = `
+<Tooltip
+  appendTo={[Function]}
+  aria="describedby"
+  boundary="window"
+  className=""
+  content={
+    <div>
+      lorem ipsum
+    </div>
+  }
+  distance={-10}
+  enableFlip={true}
+  entryDelay={100}
+  exitDelay={0}
+  flipBehavior={
+    Array [
+      "top",
+      "right",
+      "bottom",
+      "left",
+      "top",
+      "right",
+      "bottom",
+    ]
+  }
+  id=""
+  isAppLauncher={false}
+  isContentLeftAligned={false}
+  isVisible={false}
+  key="curiosity-tooltip-lorem"
+  maxWidth="18.75rem"
+  position="top"
+  tippyProps={Object {}}
+  trigger="mouseenter focus"
+  zIndex={9999}
+>
+  <Component
+    component="a"
+    icon={
+      <div
+        aria-hidden={true}
+        className="legend-icon"
+        style={
+          Object {
+            "backgroundColor": undefined,
+            "visibility": "visible",
+          }
+        }
+      />
+    }
+    isDisabled={false}
+    key="curiosity-button-lorem"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyPress={[Function]}
+    onMouseOut={[Function]}
+    onMouseOver={[Function]}
+    tabIndex={0}
+    variant="link"
+  />
+</Tooltip>
+`;

--- a/src/components/c3GraphCard/tests/c3GraphCard.test.js
+++ b/src/components/c3GraphCard/tests/c3GraphCard.test.js
@@ -1,0 +1,182 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { C3Chart } from '../../c3Chart/c3Chart';
+import { C3GraphCard } from '../c3GraphCard';
+import { RHSM_API_QUERY_GRANULARITY_TYPES as GRANULARITY_TYPES, rhsmApiTypes } from '../../../types/rhsmApiTypes';
+
+describe('C3GraphCard Component', () => {
+  it('should render a non-connected component', () => {
+    const props = {
+      graphQuery: { [rhsmApiTypes.RHSM_API_QUERY_GRANULARITY]: GRANULARITY_TYPES.DAILY },
+      productId: 'lorem'
+    };
+    const component = shallow(<C3GraphCard {...props} />);
+
+    expect(component).toMatchSnapshot('non-connected');
+  });
+
+  it('should render multiple states', () => {
+    const props = {
+      graphQuery: { [rhsmApiTypes.RHSM_API_QUERY_GRANULARITY]: GRANULARITY_TYPES.DAILY },
+      productId: 'lorem',
+      graphData: {
+        physicalSockets: [
+          {
+            date: new Date('2019-06-01T00:00:00Z'),
+            y: 10,
+            x: 0
+          },
+          {
+            date: new Date('2019-06-08T00:00:00Z'),
+            y: 12,
+            x: 1
+          },
+          {
+            date: new Date('2019-06-25T00:00:00Z'),
+            y: 3,
+            x: 2
+          }
+        ]
+      }
+    };
+
+    const component = shallow(<C3GraphCard {...props} />);
+
+    component.setProps({
+      error: true
+    });
+
+    expect({
+      chartBarData: component.find(C3Chart).prop('config').data
+    }).toMatchSnapshot('error passes values');
+
+    component.setProps({
+      status: 403
+    });
+
+    expect(component.find('.curiosity-skeleton-container').hasClass('blur')).toBe(true);
+
+    component.setProps({
+      status: 500
+    });
+
+    expect(component.find('.curiosity-skeleton-container').hasClass('blur')).toBe(true);
+
+    component.setProps({
+      error: false,
+      pending: true
+    });
+
+    expect(component).toMatchSnapshot('pending');
+
+    component.setProps({
+      error: false,
+      pending: false,
+      fulfilled: true
+    });
+
+    expect(component).toMatchSnapshot('fulfilled');
+  });
+
+  it('should filter result sets', () => {
+    const props = {
+      filterGraphData: [
+        {
+          id: 'loremIpsumSockets'
+        },
+        {
+          id: 'thresholdLoremIpsumSockets'
+        }
+      ],
+      graphQuery: { [rhsmApiTypes.RHSM_API_QUERY_GRANULARITY]: GRANULARITY_TYPES.DAILY },
+      productId: 'lorem',
+      graphData: {
+        loremIpsumSockets: [
+          {
+            date: new Date('2019-06-01T00:00:00Z'),
+            y: 10,
+            x: 0
+          },
+          {
+            date: new Date('2019-06-08T00:00:00Z'),
+            y: 12,
+            x: 1
+          },
+          {
+            date: new Date('2019-06-25T00:00:00Z'),
+            y: 3,
+            x: 2
+          }
+        ],
+        dolorSitSockets: [
+          {
+            date: new Date('2019-06-01T00:00:00Z'),
+            y: 10,
+            x: 0
+          },
+          {
+            date: new Date('2019-06-08T00:00:00Z'),
+            y: 12,
+            x: 1
+          },
+          {
+            date: new Date('2019-06-25T00:00:00Z'),
+            y: 3,
+            x: 2
+          }
+        ],
+        thresholdLoremIpsumSockets: [
+          {
+            date: new Date('2019-06-01T00:00:00Z'),
+            y: 10,
+            x: 0
+          },
+          {
+            date: new Date('2019-06-08T00:00:00Z'),
+            y: 12,
+            x: 1
+          },
+          {
+            date: new Date('2019-06-25T00:00:00Z'),
+            y: 3,
+            x: 2
+          }
+        ]
+      }
+    };
+
+    const component = shallow(<C3GraphCard {...props} />);
+    expect(component.find(C3Chart).prop('config').data).toMatchSnapshot('filtered config');
+  });
+
+  it('should render a custom legend', () => {
+    const props = {
+      graphQuery: { [rhsmApiTypes.RHSM_API_QUERY_GRANULARITY]: GRANULARITY_TYPES.DAILY },
+      productId: 'lorem'
+    };
+
+    const component = shallow(<C3GraphCard {...props} />);
+    const componentInstance = component.instance();
+
+    expect(componentInstance.renderLegend({})).toMatchSnapshot('empty legend');
+
+    expect(
+      componentInstance.renderLegend({
+        filteredData: [{ id: 'lorem' }, { id: 'thresholdIpsum' }],
+        granularity: 'dolor',
+        hiddenDataFacets: []
+      })
+    ).toMatchSnapshot('legend');
+  });
+
+  it('should return an empty render when disabled', () => {
+    const props = {
+      graphQuery: { [rhsmApiTypes.RHSM_API_QUERY_GRANULARITY]: GRANULARITY_TYPES.DAILY },
+      isDisabled: true,
+      productId: 'lorem'
+    };
+    const component = shallow(<C3GraphCard {...props} />);
+
+    expect(component).toMatchSnapshot('disabled component');
+  });
+});

--- a/src/components/c3GraphCard/tests/c3GraphCardHelpers.test.js
+++ b/src/components/c3GraphCard/tests/c3GraphCardHelpers.test.js
@@ -1,0 +1,115 @@
+import moment from 'moment';
+import { c3GraphCardHelpers, c3Config, getTooltipDate, xAxisTickFormat, yAxisTickFormat } from '../c3GraphCardHelpers';
+import { dateHelpers } from '../../../common';
+import { RHSM_API_QUERY_GRANULARITY_TYPES as GRANULARITY_TYPES } from '../../../types/rhsmApiTypes';
+
+describe('C3GraphCardHelpers', () => {
+  it('should have specific functions', () => {
+    expect(c3GraphCardHelpers).toMatchSnapshot('graphCardHelpers');
+  });
+
+  it('c3Config should return a c3 configuration object', () => {
+    const configuration = c3Config({
+      data: [
+        {
+          id: 'lorem',
+          data: [{ date: '2019-06-08T00:00:00Z', x: 0, y: 1, hasData: false, isInfinite: false }],
+          color: 'red'
+        },
+        {
+          id: 'ipsum',
+          data: [{ date: '2019-06-08T00:00:00Z', x: 0, y: 1, hasData: true, isInfinite: false }],
+          color: 'red'
+        },
+        {
+          id: 'dolor',
+          data: [{ date: '2019-06-08T00:00:00Z', x: 0, y: 1, hasData: false, isInfinite: true }],
+          color: 'red'
+        },
+        {
+          id: 'sit',
+          data: [{ date: '2019-06-08T00:00:00Z', x: 0, y: 1, hasData: true, isInfinite: true }],
+          color: 'red'
+        }
+      ],
+      granularity: GRANULARITY_TYPES.DAILY,
+      productShortLabel: 'lorem'
+    });
+    expect({ configuration }).toMatchSnapshot('chart configuration');
+  });
+
+  it('getTooltipDate should return a formatted date based on granularity', () => {
+    const daily = getTooltipDate({ granularity: GRANULARITY_TYPES.DAILY, date: '2019-06-01T00:00:00Z' });
+    const weekly = getTooltipDate({ granularity: GRANULARITY_TYPES.WEEKLY, date: '2019-06-01T00:00:00Z' });
+    const monthly = getTooltipDate({ granularity: GRANULARITY_TYPES.MONTHLY, date: '2019-06-01T00:00:00Z' });
+    const quarterly = getTooltipDate({ granularity: GRANULARITY_TYPES.QUARTERLY, date: '2019-06-01T00:00:00Z' });
+
+    expect({ daily, weekly, monthly, quarterly }).toMatchSnapshot('granularity based date');
+  });
+
+  /**
+   * Previously we handled the "discreet" filler dates, the API handles this now.
+   * Now we emulate an API like response with "generateTicks".
+   */
+  it('xAxisTickFormat should produce consistent x axis tick values', () => {
+    const generateTicks = ({ startDate, endDate, granularity, momentGranularity }) => {
+      const endDateStartDateDiff = moment(endDate).diff(startDate, momentGranularity);
+      const generatedTicks = [];
+
+      for (let i = 0; i <= endDateStartDateDiff; i++) {
+        const date = moment.utc(startDate).add(i, momentGranularity).startOf(momentGranularity);
+        const previousDate = moment(date).subtract(1, momentGranularity).startOf(momentGranularity);
+
+        generatedTicks.push(
+          xAxisTickFormat({ date: date.toISOString(), granularity, tick: i, previousDate: previousDate.toISOString() })
+        );
+      }
+
+      return generatedTicks;
+    };
+
+    const daily = generateTicks({
+      ...dateHelpers.defaultDateTime,
+      granularity: GRANULARITY_TYPES.DAILY,
+      momentGranularity: 'days'
+    });
+    const weekly = generateTicks({
+      ...dateHelpers.weeklyDateTime,
+      granularity: GRANULARITY_TYPES.WEEKLY,
+      momentGranularity: 'weeks'
+    });
+    const monthly = generateTicks({
+      ...dateHelpers.monthlyDateTime,
+      granularity: GRANULARITY_TYPES.MONTHLY,
+      momentGranularity: 'months'
+    });
+    const quarterly = generateTicks({
+      ...dateHelpers.quarterlyDateTime,
+      granularity: GRANULARITY_TYPES.QUARTERLY,
+      momentGranularity: 'quarters'
+    });
+
+    expect({ daily, weekly, monthly, quarterly }).toMatchSnapshot('x axis tick values');
+
+    expect({
+      missingDate: xAxisTickFormat({ granularity: GRANULARITY_TYPES.DAILY, tick: 0 }),
+      missingGranularity: xAxisTickFormat({ date: dateHelpers.defaultDateTime.startDate, tick: 0 })
+    }).toMatchSnapshot('x axis should be undefined if date or granularity are missing');
+  });
+
+  it('yAxisTickFormat should produce consistent y axis tick values', () => {
+    const ticks = {};
+
+    for (let i = 0; i < 11; i++) {
+      const multiplier = Math.pow(10, i);
+      const thirteenMultiplier = 13 * multiplier;
+      const fifteenMultiplier = 15 * multiplier;
+
+      ticks[multiplier] = yAxisTickFormat({ tick: multiplier });
+      ticks[thirteenMultiplier] = yAxisTickFormat({ tick: thirteenMultiplier });
+      ticks[fifteenMultiplier] = yAxisTickFormat({ tick: fifteenMultiplier });
+    }
+
+    expect(ticks).toMatchSnapshot('y axis tick values');
+  });
+});

--- a/src/components/c3GraphCard/tests/c3GraphCardLegendItem.test.js
+++ b/src/components/c3GraphCard/tests/c3GraphCardLegendItem.test.js
@@ -1,0 +1,102 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Button } from '@patternfly/react-core';
+import { C3GraphCardLegendItem } from '../c3GraphCardLegendItem';
+
+describe('C3GraphCardLegendItem Component', () => {
+  it('should render a non-connected component', () => {
+    const props = {
+      chartId: 'lorem'
+    };
+    const component = shallow(<C3GraphCardLegendItem {...props}>lorem ipsum</C3GraphCardLegendItem>);
+
+    expect(component).toMatchSnapshot('non-connected');
+  });
+
+  it('should render a tooltip with button', () => {
+    const props = {
+      chartId: 'lorem',
+      tooltipContent: <div>lorem ipsum</div>
+    };
+    const component = shallow(<C3GraphCardLegendItem {...props} />);
+
+    expect(component).toMatchSnapshot('tooltip');
+  });
+
+  it('should be able to display both threshold and disabling icons', () => {
+    const props = {
+      chartId: 'lorem',
+      isThreshold: true
+    };
+    const component = shallow(<C3GraphCardLegendItem {...props} />);
+    expect(component).toMatchSnapshot('threshold');
+
+    component.setProps({
+      isThreshold: false,
+      isDisabled: true
+    });
+    expect(component).toMatchSnapshot('disabled');
+  });
+
+  it('should handle focus, revert, and toggle chart events while reading and updating state', () => {
+    const props = {
+      chartId: 'lorem',
+      chart: {
+        color: jest.fn(),
+        focus: jest.fn().mockReturnValue('focus'),
+        hide: jest.fn(),
+        revert: jest.fn(),
+        toggle: jest.fn()
+      }
+    };
+    const component = shallow(<C3GraphCardLegendItem {...props} />);
+    const componentInstance = component.instance();
+
+    componentInstance.onToggle();
+    expect(component.state()).toMatchSnapshot('toggle ON');
+
+    componentInstance.onFocus();
+    expect(props.chart.focus).toHaveBeenCalledTimes(0);
+
+    componentInstance.onRevert();
+    expect(props.chart.revert).toHaveBeenCalledTimes(0);
+
+    componentInstance.onToggle();
+    expect(component.state()).toMatchSnapshot('toggle OFF');
+
+    componentInstance.onFocus();
+    expect(props.chart.focus).toHaveBeenCalledTimes(1);
+
+    componentInstance.onRevert();
+    expect(props.chart.revert).toHaveBeenCalledTimes(2);
+  });
+
+  it('should handle hiding the chart legend item', () => {
+    const props = {
+      chartId: 'lorem',
+      chart: {
+        color: jest.fn(),
+        focus: jest.fn(),
+        hide: jest.fn(),
+        revert: jest.fn(),
+        toggle: jest.fn()
+      },
+      isToggled: true
+    };
+
+    shallow(<C3GraphCardLegendItem {...props} />);
+    expect(props.chart.hide).toHaveBeenCalledTimes(1);
+  });
+
+  it('should offset internal state towards the parent component', () => {
+    const props = {
+      chartId: 'lorem',
+      getToggle: jest.fn(),
+      isToggled: false
+    };
+
+    const component = shallow(<C3GraphCardLegendItem {...props} />);
+    component.find(Button).simulate('click');
+    expect(props.getToggle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/graphCard/__tests__/__snapshots__/graphCard.test.js.snap
+++ b/src/components/graphCard/__tests__/__snapshots__/graphCard.test.js.snap
@@ -1,5 +1,72 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`GraphCard Component should filter result sets: filtered dataSets 1`] = `
+Array [
+  Object {
+    "animate": Object {
+      "duration": 250,
+      "onLoad": Object {
+        "duration": 250,
+      },
+    },
+    "data": Array [
+      Object {
+        "date": 2019-06-01T00:00:00.000Z,
+        "x": 0,
+        "y": 10,
+      },
+      Object {
+        "date": 2019-06-08T00:00:00.000Z,
+        "x": 1,
+        "y": 12,
+      },
+      Object {
+        "date": 2019-06-25T00:00:00.000Z,
+        "x": 2,
+        "y": 3,
+      },
+    ],
+    "id": "loremIpsumSockets",
+    "isStacked": true,
+    "isThreshold": false,
+    "legendLabel": "t(curiosity-graph.loremIpsumSocketsLabel, [object Object])",
+  },
+  Object {
+    "animate": Object {
+      "duration": 100,
+      "onLoad": Object {
+        "duration": 100,
+      },
+    },
+    "data": Array [
+      Object {
+        "date": 2019-06-01T00:00:00.000Z,
+        "x": 0,
+        "y": 10,
+      },
+      Object {
+        "date": 2019-06-08T00:00:00.000Z,
+        "x": 1,
+        "y": 12,
+      },
+      Object {
+        "date": 2019-06-25T00:00:00.000Z,
+        "x": 2,
+        "y": 3,
+      },
+    ],
+    "id": "thresholdLoremIpsumSockets",
+    "isStacked": false,
+    "isThreshold": true,
+    "legendLabel": "t(curiosity-graph.thresholdLabel)",
+    "legendSymbolType": "dash",
+    "stroke": "#4cb140",
+    "strokeDasharray": "4,3",
+    "strokeWidth": 2.5,
+  },
+]
+`;
+
 exports[`GraphCard Component should render a non-connected component: non-connected 1`] = `
 <Card
   className="curiosity-usage-graph fadein"

--- a/src/components/graphCard/__tests__/graphCard.test.js
+++ b/src/components/graphCard/__tests__/graphCard.test.js
@@ -78,6 +78,78 @@ describe('GraphCard Component', () => {
     expect(component).toMatchSnapshot('fulfilled');
   });
 
+  it('should filter result sets', () => {
+    const props = {
+      filterGraphData: [
+        {
+          id: 'loremIpsumSockets'
+        },
+        {
+          id: 'thresholdLoremIpsumSockets'
+        }
+      ],
+      graphQuery: { [rhsmApiTypes.RHSM_API_QUERY_GRANULARITY]: GRANULARITY_TYPES.DAILY },
+      productId: 'lorem',
+      graphData: {
+        loremIpsumSockets: [
+          {
+            date: new Date('2019-06-01T00:00:00Z'),
+            y: 10,
+            x: 0
+          },
+          {
+            date: new Date('2019-06-08T00:00:00Z'),
+            y: 12,
+            x: 1
+          },
+          {
+            date: new Date('2019-06-25T00:00:00Z'),
+            y: 3,
+            x: 2
+          }
+        ],
+        dolorSitSockets: [
+          {
+            date: new Date('2019-06-01T00:00:00Z'),
+            y: 10,
+            x: 0
+          },
+          {
+            date: new Date('2019-06-08T00:00:00Z'),
+            y: 12,
+            x: 1
+          },
+          {
+            date: new Date('2019-06-25T00:00:00Z'),
+            y: 3,
+            x: 2
+          }
+        ],
+        thresholdLoremIpsumSockets: [
+          {
+            date: new Date('2019-06-01T00:00:00Z'),
+            y: 10,
+            x: 0
+          },
+          {
+            date: new Date('2019-06-08T00:00:00Z'),
+            y: 12,
+            x: 1
+          },
+          {
+            date: new Date('2019-06-25T00:00:00Z'),
+            y: 3,
+            x: 2
+          }
+        ]
+      }
+    };
+
+    const component = shallow(<GraphCard {...props} />);
+
+    expect(component.find(ChartArea).prop('dataSets')).toMatchSnapshot('filtered dataSets');
+  });
+
   it('should return an empty render when disabled', () => {
     const props = {
       graphQuery: { [rhsmApiTypes.RHSM_API_QUERY_GRANULARITY]: GRANULARITY_TYPES.DAILY },

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -20,7 +20,8 @@ msgstr \\"\\"
 msgid \\"curiosity-auth.authorizedTitle\\"
 msgstr \\"\\"
 
-#: src/components/openshiftView/openshiftView.js:90
+#: src/components/openshiftView/openshiftView.js:105
+#: src/components/openshiftView/openshiftView.js:93
 msgid \\"curiosity-graph.cardHeading\\"
 msgstr \\"\\"
 
@@ -67,7 +68,8 @@ msgstr \\"\\"
 msgid \\"curiosity-graph.noDataLabel\\"
 msgstr \\"\\"
 
-#: src/components/rhelView/rhelView.js:47
+#: src/components/rhelView/rhelView.js:50
+#: src/components/rhelView/rhelView.js:60
 msgid \\"curiosity-graph.socketsHeading\\"
 msgstr \\"\\"
 
@@ -221,11 +223,11 @@ msgstr \\"\\"
 msgid \\"curiosity-tour.emptyStateTitle\\"
 msgstr \\"\\"
 
-#: src/components/openshiftView/openshiftView.js:79
+#: src/components/openshiftView/openshiftView.js:81
 msgid \\"curiosity-view.openshift\\"
 msgstr \\"\\"
 
-#: src/components/rhelView/rhelView.js:36
+#: src/components/rhelView/rhelView.js:38
 msgid \\"curiosity-view.rhel\\"
 msgstr \\"\\"
 

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -36,6 +36,8 @@ msgstr \\"\\"
 msgid \\"curiosity-graph.dropdownMonthly\\"
 msgstr \\"\\"
 
+#: src/components/c3GraphCard/c3GraphCard.js:189
+#: src/components/c3GraphCard/c3GraphCard.js:193
 #: src/components/graphCard/graphCard.js:174
 #: src/components/graphCard/graphCard.js:178
 msgid \\"curiosity-graph.dropdownPlaceholder\\"
@@ -49,6 +51,7 @@ msgstr \\"\\"
 msgid \\"curiosity-graph.dropdownWeekly\\"
 msgstr \\"\\"
 
+#: src/components/c3GraphCard/c3GraphCardHelpers.js:176
 #: src/components/graphCard/graphCardHelpers.js:85
 msgid \\"curiosity-graph.infiniteThresholdLabel\\"
 msgstr \\"\\"
@@ -57,6 +60,8 @@ msgstr \\"\\"
 msgid \\"curiosity-graph.noDataErrorLabel\\"
 msgstr \\"\\"
 
+#: src/components/c3GraphCard/c3GraphCardHelpers.js:177
+#: src/components/c3GraphCard/c3GraphCardHelpers.js:180
 #: src/components/graphCard/graphCardHelpers.js:86
 #: src/components/graphCard/graphCardHelpers.js:91
 msgid \\"curiosity-graph.noDataLabel\\"
@@ -66,9 +71,15 @@ msgstr \\"\\"
 msgid \\"curiosity-graph.socketsHeading\\"
 msgstr \\"\\"
 
+#: src/components/c3GraphCard/c3GraphCard.js:110
+#: src/components/c3GraphCard/c3GraphCardHelpers.js:133
 #: src/components/graphCard/graphCard.js:134
 #: src/components/graphCard/graphCardHelpers.js:88
 msgid \\"curiosity-graph.thresholdLabel\\"
+msgstr \\"\\"
+
+#: src/components/c3GraphCard/c3GraphCard.js:93
+msgid \\"curiosity-graph.thresholdLegendTooltip\\"
 msgstr \\"\\"
 
 #: src/components/optinView/optinView.js:59

--- a/src/components/openshiftView/__tests__/__snapshots__/openshiftView.test.js.snap
+++ b/src/components/openshiftView/__tests__/__snapshots__/openshiftView.test.js.snap
@@ -1,5 +1,74 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`OpenshiftView Component should display an alternate graph on query-string update: alternate graph 1`] = `
+<PageLayout>
+  <PageHeader>
+    t(curiosity-view.openshift, Subscription Watch)
+  </PageHeader>
+  <PageToolbar>
+    <withI18nextTranslation(Toolbar)
+      graphQuery={
+        Object {
+          "granularity": "daily",
+        }
+      }
+      viewId="OpenShift"
+    />
+  </PageToolbar>
+  <PageSection>
+    <Connect(C3GraphCard)
+      cardTitle="t(curiosity-graph.cardHeading)"
+      filterGraphData={
+        Array [
+          Object {
+            "color": "#06c",
+            "fill": "#8bc1f7",
+            "id": "cores",
+            "stroke": "#06c",
+          },
+          Object {
+            "id": "thresholdCores",
+          },
+        ]
+      }
+      graphQuery={
+        Object {
+          "granularity": "daily",
+        }
+      }
+      key="lorem ipsum"
+      productId="lorem ipsum"
+      productShortLabel="OpenShift"
+      viewId="OpenShift"
+    >
+      <Select
+        ariaLabel="Select option"
+        className=""
+        id="generatedid-"
+        isDisabled={false}
+        name={null}
+        onSelect={[Function]}
+        options={
+          Array [
+            Object {
+              "title": "Cores",
+              "value": "cores",
+            },
+            Object {
+              "title": "Sockets",
+              "value": "sockets",
+            },
+          ]
+        }
+        placeholder="Select option"
+        selectedOptions="cores"
+        variant="single"
+      />
+    </Connect(C3GraphCard)>
+  </PageSection>
+</PageLayout>
+`;
+
 exports[`OpenshiftView Component should have a fallback title: title 1`] = `
 <PageLayout>
   <PageHeader>
@@ -21,6 +90,7 @@ exports[`OpenshiftView Component should have a fallback title: title 1`] = `
       filterGraphData={
         Array [
           Object {
+            "color": "#06c",
             "fill": "#8bc1f7",
             "id": "cores",
             "stroke": "#06c",
@@ -89,6 +159,7 @@ exports[`OpenshiftView Component should render a non-connected component: non-co
       filterGraphData={
         Array [
           Object {
+            "color": "#06c",
             "fill": "#8bc1f7",
             "id": "cores",
             "stroke": "#06c",

--- a/src/components/openshiftView/__tests__/openshiftView.test.js
+++ b/src/components/openshiftView/__tests__/openshiftView.test.js
@@ -5,6 +5,7 @@ import { OpenshiftView } from '../openshiftView';
 describe('OpenshiftView Component', () => {
   it('should render a non-connected component', () => {
     const props = {
+      location: {},
       routeDetail: {
         pathId: 'test_id',
         pathParameter: 'lorem ipsum',
@@ -20,6 +21,7 @@ describe('OpenshiftView Component', () => {
 
   it('should have a fallback title', () => {
     const props = {
+      location: {},
       routeDetail: {
         pathId: 'test_id',
         pathParameter: 'lorem ipsum'
@@ -28,5 +30,20 @@ describe('OpenshiftView Component', () => {
 
     const component = shallow(<OpenshiftView {...props} />);
     expect(component).toMatchSnapshot('title');
+  });
+
+  it('should display an alternate graph on query-string update', () => {
+    const props = {
+      location: {
+        parsedSearch: { c3: '' }
+      },
+      routeDetail: {
+        pathId: 'test_id',
+        pathParameter: 'lorem ipsum'
+      }
+    };
+
+    const component = shallow(<OpenshiftView {...props} />);
+    expect(component).toMatchSnapshot('alternate graph');
   });
 });

--- a/src/components/openshiftView/openshiftView.js
+++ b/src/components/openshiftView/openshiftView.js
@@ -8,6 +8,7 @@ import { PageLayout, PageHeader, PageSection, PageToolbar } from '../pageLayout/
 import { RHSM_API_QUERY_GRANULARITY_TYPES as GRANULARITY_TYPES, rhsmApiTypes } from '../../types/rhsmApiTypes';
 import { connectTranslate, reduxSelectors } from '../../redux';
 import GraphCard from '../graphCard/graphCard';
+import C3GraphCard from '../c3GraphCard/c3GraphCard';
 import { Select } from '../form/select';
 import Toolbar from '../toolbar/toolbar';
 import { helpers } from '../../common';
@@ -72,7 +73,8 @@ class OpenshiftView extends React.Component {
    */
   render() {
     const { filters } = this.state;
-    const { graphQuery, routeDetail, t, viewId } = this.props;
+    const { graphQuery, location, routeDetail, t, viewId } = this.props;
+    const isC3 = location?.parsedSearch?.c3 === '';
 
     return (
       <PageLayout>
@@ -81,17 +83,31 @@ class OpenshiftView extends React.Component {
           <Toolbar graphQuery={graphQuery} viewId={viewId} />
         </PageToolbar>
         <PageSection>
-          <GraphCard
-            key={routeDetail.pathParameter}
-            filterGraphData={filters}
-            graphQuery={graphQuery}
-            productId={routeDetail.pathParameter}
-            viewId={viewId}
-            cardTitle={t('curiosity-graph.cardHeading')}
-            productShortLabel={viewId}
-          >
-            {this.renderSelect()}
-          </GraphCard>
+          {(isC3 && (
+            <C3GraphCard
+              key={routeDetail.pathParameter}
+              filterGraphData={filters}
+              graphQuery={graphQuery}
+              productId={routeDetail.pathParameter}
+              viewId={viewId}
+              cardTitle={t('curiosity-graph.cardHeading')}
+              productShortLabel={viewId}
+            >
+              {this.renderSelect()}
+            </C3GraphCard>
+          )) || (
+            <GraphCard
+              key={routeDetail.pathParameter}
+              filterGraphData={filters}
+              graphQuery={graphQuery}
+              productId={routeDetail.pathParameter}
+              viewId={viewId}
+              cardTitle={t('curiosity-graph.cardHeading')}
+              productShortLabel={viewId}
+            >
+              {this.renderSelect()}
+            </GraphCard>
+          )}
         </PageSection>
       </PageLayout>
     );
@@ -101,7 +117,8 @@ class OpenshiftView extends React.Component {
 /**
  * Prop types.
  *
- * @type {{initialFilters: Array, initialOption: string, viewId: string, t: Function, routeDetail: object, graphQuery: object}}
+ * @type {{initialFilters: Array, initialOption: string, viewId: string, t: Function, routeDetail: object,
+ *     location: object, graphQuery: object}}
  */
 OpenshiftView.propTypes = {
   graphQuery: PropTypes.shape({
@@ -109,6 +126,9 @@ OpenshiftView.propTypes = {
   }),
   initialOption: PropTypes.oneOf(['cores', 'sockets']),
   initialFilters: PropTypes.array,
+  location: PropTypes.shape({
+    parsedSearch: PropTypes.objectOf(PropTypes.string)
+  }).isRequired,
   routeDetail: PropTypes.shape({
     pathParameter: PropTypes.string.isRequired,
     pathId: PropTypes.string.isRequired,
@@ -131,8 +151,13 @@ OpenshiftView.defaultProps = {
   },
   initialOption: 'cores',
   initialFilters: [
-    { id: 'cores', fill: chartColorBlueLight.value, stroke: chartColorBlueDark.value },
-    { id: 'sockets', fill: chartColorBlueLight.value, stroke: chartColorBlueDark.value },
+    { id: 'cores', fill: chartColorBlueLight.value, stroke: chartColorBlueDark.value, color: chartColorBlueDark.value },
+    {
+      id: 'sockets',
+      fill: chartColorBlueLight.value,
+      stroke: chartColorBlueDark.value,
+      color: chartColorBlueDark.value
+    },
     { id: 'thresholdSockets' },
     { id: 'thresholdCores' }
   ],

--- a/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
+++ b/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
@@ -1,5 +1,62 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`RhelView Component should display an alternate graph on query-string update: alternate graph 1`] = `
+<PageLayout>
+  <PageHeader>
+    t(curiosity-view.rhel, Subscription Watch)
+  </PageHeader>
+  <PageToolbar>
+    <withI18nextTranslation(Toolbar)
+      graphQuery={
+        Object {
+          "granularity": "daily",
+        }
+      }
+      viewId="RHEL"
+    />
+  </PageToolbar>
+  <PageSection>
+    <Connect(C3GraphCard)
+      cardTitle="t(curiosity-graph.socketsHeading)"
+      filterGraphData={
+        Array [
+          Object {
+            "color": "#06c",
+            "fill": "#8bc1f7",
+            "id": "physicalSockets",
+            "stroke": "#06c",
+          },
+          Object {
+            "color": "#009596",
+            "fill": "#a2d9d9",
+            "id": "hypervisorSockets",
+            "stroke": "#009596",
+          },
+          Object {
+            "color": "#5752d1",
+            "fill": "#b2b0ea",
+            "id": "cloudSockets",
+            "stroke": "#5752d1",
+          },
+          Object {
+            "id": "thresholdSockets",
+          },
+        ]
+      }
+      graphQuery={
+        Object {
+          "granularity": "daily",
+        }
+      }
+      key="lorem ipsum"
+      productId="lorem ipsum"
+      productShortLabel="RHEL"
+      viewId="RHEL"
+    />
+  </PageSection>
+</PageLayout>
+`;
+
 exports[`RhelView Component should have a fallback title: title 1`] = `
 <PageLayout>
   <PageHeader>
@@ -21,16 +78,19 @@ exports[`RhelView Component should have a fallback title: title 1`] = `
       filterGraphData={
         Array [
           Object {
+            "color": "#06c",
             "fill": "#8bc1f7",
             "id": "physicalSockets",
             "stroke": "#06c",
           },
           Object {
+            "color": "#009596",
             "fill": "#a2d9d9",
             "id": "hypervisorSockets",
             "stroke": "#009596",
           },
           Object {
+            "color": "#5752d1",
             "fill": "#b2b0ea",
             "id": "cloudSockets",
             "stroke": "#5752d1",
@@ -75,16 +135,19 @@ exports[`RhelView Component should render a non-connected component: non-connect
       filterGraphData={
         Array [
           Object {
+            "color": "#06c",
             "fill": "#8bc1f7",
             "id": "physicalSockets",
             "stroke": "#06c",
           },
           Object {
+            "color": "#009596",
             "fill": "#a2d9d9",
             "id": "hypervisorSockets",
             "stroke": "#009596",
           },
           Object {
+            "color": "#5752d1",
             "fill": "#b2b0ea",
             "id": "cloudSockets",
             "stroke": "#5752d1",

--- a/src/components/rhelView/__tests__/rhelView.test.js
+++ b/src/components/rhelView/__tests__/rhelView.test.js
@@ -5,6 +5,7 @@ import { RhelView } from '../rhelView';
 describe('RhelView Component', () => {
   it('should render a non-connected component', () => {
     const props = {
+      location: {},
       routeDetail: {
         pathId: 'test_id',
         pathParameter: 'lorem ipsum',
@@ -20,6 +21,7 @@ describe('RhelView Component', () => {
 
   it('should have a fallback title', () => {
     const props = {
+      location: {},
       routeDetail: {
         pathId: 'test_id',
         pathParameter: 'lorem ipsum'
@@ -28,5 +30,20 @@ describe('RhelView Component', () => {
 
     const component = shallow(<RhelView {...props} />);
     expect(component).toMatchSnapshot('title');
+  });
+
+  it('should display an alternate graph on query-string update', () => {
+    const props = {
+      location: {
+        parsedSearch: { c3: '' }
+      },
+      routeDetail: {
+        pathId: 'test_id',
+        pathParameter: 'lorem ipsum'
+      }
+    };
+
+    const component = shallow(<RhelView {...props} />);
+    expect(component).toMatchSnapshot('alternate graph');
   });
 });

--- a/src/components/rhelView/rhelView.js
+++ b/src/components/rhelView/rhelView.js
@@ -12,6 +12,7 @@ import { PageLayout, PageHeader, PageSection, PageToolbar } from '../pageLayout/
 import { RHSM_API_QUERY_GRANULARITY_TYPES as GRANULARITY_TYPES, rhsmApiTypes } from '../../types/rhsmApiTypes';
 import { connectTranslate, reduxSelectors } from '../../redux';
 import GraphCard from '../graphCard/graphCard';
+import C3GraphCard from '../c3GraphCard/c3GraphCard';
 import Toolbar from '../toolbar/toolbar';
 import { helpers } from '../../common';
 
@@ -29,7 +30,8 @@ class RhelView extends React.Component {
    * @returns {Node}
    */
   render() {
-    const { graphQuery, initialFilters, routeDetail, t, viewId } = this.props;
+    const { graphQuery, initialFilters, location, routeDetail, t, viewId } = this.props;
+    const isC3 = location?.parsedSearch?.c3 === '';
 
     return (
       <PageLayout>
@@ -38,15 +40,27 @@ class RhelView extends React.Component {
           <Toolbar graphQuery={graphQuery} viewId={viewId} />
         </PageToolbar>
         <PageSection>
-          <GraphCard
-            key={routeDetail.pathParameter}
-            filterGraphData={initialFilters}
-            graphQuery={graphQuery}
-            productId={routeDetail.pathParameter}
-            viewId={viewId}
-            cardTitle={t('curiosity-graph.socketsHeading')}
-            productShortLabel={viewId}
-          />
+          {(isC3 && (
+            <C3GraphCard
+              key={routeDetail.pathParameter}
+              filterGraphData={initialFilters}
+              graphQuery={graphQuery}
+              productId={routeDetail.pathParameter}
+              viewId={viewId}
+              cardTitle={t('curiosity-graph.socketsHeading')}
+              productShortLabel={viewId}
+            />
+          )) || (
+            <GraphCard
+              key={routeDetail.pathParameter}
+              filterGraphData={initialFilters}
+              graphQuery={graphQuery}
+              productId={routeDetail.pathParameter}
+              viewId={viewId}
+              cardTitle={t('curiosity-graph.socketsHeading')}
+              productShortLabel={viewId}
+            />
+          )}
         </PageSection>
       </PageLayout>
     );
@@ -56,13 +70,17 @@ class RhelView extends React.Component {
 /**
  * Prop types.
  *
- * @type {{initialFilters: Array, viewId: string, t: Function, routeDetail: object, graphQuery: object}}
+ * @type {{initialFilters: Array, viewId: string, t: Function, routeDetail: object, location: object,
+ *     graphQuery: object}}
  */
 RhelView.propTypes = {
   graphQuery: PropTypes.shape({
     [rhsmApiTypes.RHSM_API_QUERY_GRANULARITY]: PropTypes.oneOf([...Object.values(GRANULARITY_TYPES)])
   }),
   initialFilters: PropTypes.array,
+  location: PropTypes.shape({
+    parsedSearch: PropTypes.objectOf(PropTypes.string)
+  }).isRequired,
   routeDetail: PropTypes.shape({
     pathParameter: PropTypes.string.isRequired,
     pathId: PropTypes.string.isRequired,
@@ -84,9 +102,24 @@ RhelView.defaultProps = {
     [rhsmApiTypes.RHSM_API_QUERY_GRANULARITY]: GRANULARITY_TYPES.DAILY
   },
   initialFilters: [
-    { id: 'physicalSockets', fill: chartColorBlueLight.value, stroke: chartColorBlueDark.value },
-    { id: 'hypervisorSockets', fill: chartColorCyanLight.value, stroke: chartColorCyanDark.value },
-    { id: 'cloudSockets', fill: chartColorPurpleLight.value, stroke: chartColorPurpleDark.value },
+    {
+      id: 'physicalSockets',
+      fill: chartColorBlueLight.value,
+      stroke: chartColorBlueDark.value,
+      color: chartColorBlueDark.value
+    },
+    {
+      id: 'hypervisorSockets',
+      fill: chartColorCyanLight.value,
+      stroke: chartColorCyanDark.value,
+      color: chartColorCyanDark.value
+    },
+    {
+      id: 'cloudSockets',
+      fill: chartColorPurpleLight.value,
+      stroke: chartColorPurpleDark.value,
+      color: chartColorPurpleDark.value
+    },
     { id: 'thresholdSockets' }
   ],
   t: helpers.noopTranslate,

--- a/src/services/rhsmServices.js
+++ b/src/services/rhsmServices.js
@@ -46,7 +46,7 @@ const getApiVersion = () =>
 
 /**
  * @apiMock {DelayResponse} 2000
- * @apiMock {ForceStatus} 200
+ * @apiMock {RandomSuccess}
  * @api {get} /api/rhsm-subscriptions/v1/tally/products/:product_id Get RHSM graph data
  * @apiDescription Retrieve graph data.
  *
@@ -84,7 +84,143 @@ const getApiVersion = () =>
  *     {
  *       "data": [
  *         {
- *           "date": "2018-07-19T00:00:00Z",
+ *           "date": "2019-07-01T00:00:00Z",
+ *           "sockets": 50,
+ *           "physical_sockets": 50,
+ *           "hypervisor_sockets": 0,
+ *           "has_data": true,
+ *           "cloud_sockets": 80
+ *         },
+ *         {
+ *           "date": "2019-07-02T00:00:00Z",
+ *           "sockets": 50,
+ *           "physical_sockets": 50,
+ *           "hypervisor_sockets": 0,
+ *           "has_data": true,
+ *           "cloud_sockets": 80
+ *         },
+ *         {
+ *           "date": "2019-07-03T00:00:00Z",
+ *           "sockets": 50,
+ *           "physical_sockets": 50,
+ *           "hypervisor_sockets": 0,
+ *           "has_data": true,
+ *           "cloud_sockets": 80
+ *         },
+ *         {
+ *           "date": "2019-07-04T00:00:00Z",
+ *           "sockets": 50,
+ *           "physical_sockets": 50,
+ *           "hypervisor_sockets": 0,
+ *           "has_data": true,
+ *           "cloud_sockets": 80
+ *         },
+ *         {
+ *           "date": "2019-07-05T00:00:00Z",
+ *           "sockets": 50,
+ *           "physical_sockets": 50,
+ *           "hypervisor_sockets": 0,
+ *           "has_data": false,
+ *           "cloud_sockets": 20
+ *         },
+ *         {
+ *           "date": "2019-07-06T00:00:00Z",
+ *           "sockets": 50,
+ *           "physical_sockets": 50,
+ *           "hypervisor_sockets": 0,
+ *           "has_data": false,
+ *           "cloud_sockets": 20
+ *         },
+ *         {
+ *           "date": "2019-07-07T00:00:00Z",
+ *           "sockets": 50,
+ *           "physical_sockets": 50,
+ *           "hypervisor_sockets": 0,
+ *           "has_data": false,
+ *           "cloud_sockets": 20
+ *         },
+ *         {
+ *           "date": "2019-07-08T00:00:00Z",
+ *           "sockets": 50,
+ *           "physical_sockets": 50,
+ *           "hypervisor_sockets": 0,
+ *           "has_data": false,
+ *           "cloud_sockets": 20
+ *         },
+ *         {
+ *           "date": "2019-07-09T00:00:00Z",
+ *           "sockets": 50,
+ *           "physical_sockets": 50,
+ *           "hypervisor_sockets": 0,
+ *           "has_data": false,
+ *           "cloud_sockets": 20
+ *         },
+ *         {
+ *           "date": "2019-07-10T00:00:00Z",
+ *           "sockets": 50,
+ *           "physical_sockets": 50,
+ *           "hypervisor_sockets": 0,
+ *           "has_data": false,
+ *           "cloud_sockets": 20
+ *         },
+ *         {
+ *           "date": "2019-07-11T00:00:00Z",
+ *           "sockets": 50,
+ *           "physical_sockets": 50,
+ *           "hypervisor_sockets": 0,
+ *           "has_data": false,
+ *           "cloud_sockets": 20
+ *         },
+ *         {
+ *           "date": "2019-07-12T00:00:00Z",
+ *           "sockets": 50,
+ *           "physical_sockets": 50,
+ *           "hypervisor_sockets": 0,
+ *           "has_data": false,
+ *           "cloud_sockets": 20
+ *         },
+ *         {
+ *           "date": "2019-07-13T00:00:00Z",
+ *           "sockets": 50,
+ *           "physical_sockets": 50,
+ *           "hypervisor_sockets": 0,
+ *           "has_data": false,
+ *           "cloud_sockets": 20
+ *         },
+ *         {
+ *           "date": "2019-07-14T00:00:00Z",
+ *           "sockets": 50,
+ *           "physical_sockets": 50,
+ *           "hypervisor_sockets": 0,
+ *           "has_data": false,
+ *           "cloud_sockets": 20
+ *         },
+ *         {
+ *           "date": "2019-07-15T00:00:00Z",
+ *           "sockets": 50,
+ *           "physical_sockets": 50,
+ *           "hypervisor_sockets": 0,
+ *           "has_data": false,
+ *           "cloud_sockets": 20
+ *         },
+ *         {
+ *           "date": "2019-07-16T00:00:00Z",
+ *           "sockets": 50,
+ *           "physical_sockets": 50,
+ *           "hypervisor_sockets": 0,
+ *           "has_data": false,
+ *           "cloud_sockets": 20
+ *         },
+ *         {
+ *           "date": "2019-07-17T00:00:00Z",
+ *           "sockets": 50,
+ *           "physical_sockets": 50,
+ *           "hypervisor_sockets": 0,
+ *           "has_data": false,
+ *           "cloud_sockets": 20
+ *         },
+ *         {
+ *           "date": "2019-07-18T00:00:00Z",
  *           "sockets": 50,
  *           "physical_sockets": 50,
  *           "hypervisor_sockets": 0,
@@ -92,7 +228,7 @@ const getApiVersion = () =>
  *           "cloud_sockets": 20
  *         },
  *         {
- *           "date": "2018-07-20T00:00:00Z",
+ *           "date": "2019-07-19T00:00:00Z",
  *           "sockets": 50,
  *           "physical_sockets": 50,
  *           "hypervisor_sockets": 0,
@@ -208,78 +344,104 @@ const getApiVersion = () =>
  *     }
  *
  * @apiSuccessExample {json} WEEKLY, Success-Response:
- *     HTTP/1.1 201 OK
+ *     HTTP/1.1 200 OK
  *     {
  *       "data": [
  *         {
+ *           "date": "2019-05-19T00:00:00Z",
+ *           "sockets": 86,
+ *           "physical_sockets": 56,
+ *           "hypervisor_sockets": 30,
+ *           "has_data": true,
+ *           "cloud_sockets": 60
+ *         },
+ *         {
  *           "date": "2019-05-26T00:00:00Z",
- *           "instance_count": 16,
- *           "cores": 32,
- *           "hypervisor": 50,
- *           "sockets": 32
+ *           "sockets": 86,
+ *           "physical_sockets": 56,
+ *           "hypervisor_sockets": 30,
+ *           "has_data": true,
+ *           "cloud_sockets": 60
  *         },
  *         {
  *           "date": "2019-06-02T00:00:00Z",
- *           "instance_count": 6,
- *           "cores": 12,
- *           "hypervisor": 20,
- *           "sockets": 12
+ *           "sockets": 86,
+ *           "physical_sockets": 56,
+ *           "hypervisor_sockets": 30,
+ *           "has_data": true,
+ *           "cloud_sockets": 60
  *         },
  *         {
  *           "date": "2019-06-09T00:00:00Z",
- *           "instance_count": 6,
- *           "cores": 12,
- *           "hypervisor": 20,
- *           "sockets": 12
+ *           "sockets": 86,
+ *           "physical_sockets": 56,
+ *           "hypervisor_sockets": 30,
+ *           "has_data": true,
+ *           "cloud_sockets": 60
  *         },
  *         {
  *           "date": "2019-06-16T00:00:00Z",
- *           "instance_count": 6,
- *           "cores": 12,
- *           "hypervisor": 20,
- *           "sockets": 12
+ *           "sockets": 86,
+ *           "physical_sockets": 56,
+ *           "hypervisor_sockets": 30,
+ *           "has_data": true,
+ *           "cloud_sockets": 60
  *         },
  *         {
  *           "date": "2019-06-23T00:00:00Z",
- *           "instance_count": 6,
- *           "cores": 12,
- *           "hypervisor": 20,
- *           "sockets": 12
+ *           "sockets": 86,
+ *           "physical_sockets": 56,
+ *           "hypervisor_sockets": 30,
+ *           "has_data": true,
+ *           "cloud_sockets": 60
  *         },
  *         {
  *           "date": "2019-06-30T00:00:00Z",
- *           "instance_count": 6,
- *           "cores": 12,
- *           "hypervisor": 20,
- *           "sockets": 12
+ *           "sockets": 86,
+ *           "physical_sockets": 56,
+ *           "hypervisor_sockets": 30,
+ *           "has_data": true,
+ *           "cloud_sockets": 60
  *         },
  *         {
  *           "date": "2019-07-07T00:00:00Z",
- *           "instance_count": 5,
- *           "cores": 10,
- *           "hypervisor": 0,
- *           "sockets": 10
+ *           "sockets": 86,
+ *           "physical_sockets": 56,
+ *           "hypervisor_sockets": 30,
+ *           "has_data": true,
+ *           "cloud_sockets": 60
  *         },
  *         {
  *           "date": "2019-07-14T00:00:00Z",
- *           "instance_count": 5,
- *           "cores": 10,
- *           "hypervisor": 0,
- *           "sockets": 10
+ *           "sockets": 86,
+ *           "physical_sockets": 56,
+ *           "hypervisor_sockets": 30,
+ *           "has_data": true,
+ *           "cloud_sockets": 60
  *         },
  *         {
  *           "date": "2019-07-21T00:00:00Z",
- *           "instance_count": 5,
- *           "cores": 10,
- *           "hypervisor": 0,
- *           "sockets": 10
+ *           "sockets": 86,
+ *           "physical_sockets": 56,
+ *           "hypervisor_sockets": 30,
+ *           "has_data": true,
+ *           "cloud_sockets": 60
  *         },
  *         {
  *           "date": "2019-07-28T00:00:00Z",
- *           "instance_count": 6,
- *           "cores": 12,
- *           "hypervisor": 20,
- *           "sockets": 12
+ *           "sockets": 86,
+ *           "physical_sockets": 56,
+ *           "hypervisor_sockets": 30,
+ *           "has_data": true,
+ *           "cloud_sockets": 60
+ *         },
+ *         {
+ *           "date": "2019-08-04T00:00:00Z",
+ *           "sockets": 86,
+ *           "physical_sockets": 56,
+ *           "hypervisor_sockets": 30,
+ *           "has_data": true,
+ *           "cloud_sockets": 60
  *         }
  *       ],
  *       "links": {
@@ -294,50 +456,112 @@ const getApiVersion = () =>
  *     }
  *
  * @apiSuccessExample {json} MONTHLY, Success-Response:
- *     HTTP/1.1 201 OK
+ *     HTTP/1.1 200 OK
  *     {
  *       "data": [
  *         {
+ *           "date": "2018-08-01T00:00:00Z",
+ *           "sockets": 100,
+ *           "physical_sockets": 25,
+ *           "hypervisor_sockets": 50,
+ *           "has_data": true,
+ *           "cloud_sockets": 25
+ *         },
+ *         {
+ *           "date": "2018-09-01T00:00:00Z",
+ *           "sockets": 100,
+ *           "physical_sockets": 25,
+ *           "hypervisor_sockets": 50,
+ *           "has_data": true,
+ *           "cloud_sockets": 25
+ *         },
+ *         {
+ *           "date": "2018-10-01T00:00:00Z",
+ *           "sockets": 100,
+ *           "physical_sockets": 25,
+ *           "hypervisor_sockets": 50,
+ *           "has_data": true,
+ *           "cloud_sockets": 25
+ *         },
+ *         {
+ *           "date": "2018-11-01T00:00:00Z",
+ *           "sockets": 0,
+ *           "physical_sockets": 0,
+ *           "hypervisor_sockets": null,
+ *           "has_data": false,
+ *           "cloud_sockets": 0
+ *         },
+ *         {
+ *           "date": "2018-12-01T00:00:00Z",
+ *           "sockets": 0,
+ *           "physical_sockets": 0,
+ *           "hypervisor_sockets": null,
+ *           "has_data": false,
+ *           "cloud_sockets": 0
+ *         },
+ *         {
  *           "date": "2019-01-01T00:00:00Z",
- *           "instance_count": 16,
- *           "cores": 32,
- *           "hypervisor": 50,
- *           "sockets": 32
+ *           "sockets": 0,
+ *           "physical_sockets": 0,
+ *           "hypervisor_sockets": null,
+ *           "has_data": false,
+ *           "cloud_sockets": 0
  *         },
  *         {
  *           "date": "2019-02-01T00:00:00Z",
- *           "instance_count": 8,
- *           "cores": 16,
- *           "hypervisor": 20,
- *           "sockets": 16
+ *           "sockets": 0,
+ *           "physical_sockets": 0,
+ *           "hypervisor_sockets": null,
+ *           "has_data": false,
+ *           "cloud_sockets": 0
  *         },
  *         {
  *           "date": "2019-03-01T00:00:00Z",
- *           "instance_count": 0,
- *           "cores": 0,
- *           "hypervisor": 0,
- *           "sockets": 0
+ *           "sockets": 3000,
+ *           "physical_sockets": 500,
+ *           "hypervisor_sockets": 2000,
+ *           "has_data": true,
+ *           "cloud_sockets": 500
  *         },
  *         {
  *           "date": "2019-04-01T00:00:00Z",
- *           "instance_count": 8,
- *           "cores": 16,
- *           "hypervisor": 20,
- *           "sockets": 16
+ *           "sockets": 2600,
+ *           "physical_sockets": 100,
+ *           "hypervisor_sockets": 2000,
+ *           "has_data": true,
+ *           "cloud_sockets": 500
  *         },
  *         {
  *           "date": "2019-05-01T00:00:00Z",
- *           "instance_count": 16,
- *           "cores": 32,
- *           "hypervisor": 50,
- *           "sockets": 32
+ *           "sockets": 3000,
+ *           "physical_sockets": 500,
+ *           "hypervisor_sockets": 2000,
+ *           "has_data": true,
+ *           "cloud_sockets": 500
  *         },
  *         {
  *           "date": "2019-06-01T00:00:00Z",
- *           "instance_count": 24,
- *           "cores": 48,
- *           "hypervisor": 50,
- *           "sockets": 48
+ *           "sockets": 3000,
+ *           "physical_sockets": 500,
+ *           "hypervisor_sockets": 2000,
+ *           "has_data": true,
+ *           "cloud_sockets": 500
+ *         },
+ *         {
+ *           "date": "2019-07-01T00:00:00Z",
+ *           "sockets": 3000,
+ *           "physical_sockets": 500,
+ *           "hypervisor_sockets": 2000,
+ *           "has_data": true,
+ *           "cloud_sockets": 500
+ *         },
+ *         {
+ *           "date": "2019-08-01T00:00:00Z",
+ *           "sockets": 2600,
+ *           "physical_sockets": 100,
+ *           "hypervisor_sockets": 2000,
+ *           "has_data": true,
+ *           "cloud_sockets": 500
  *         }
  *       ],
  *       "links": {
@@ -351,49 +575,6 @@ const getApiVersion = () =>
  *       }
  *     }
  *
- * @apiSuccessExample {json} QUARTERLY, Success-Response:
- *     HTTP/1.1 201 OK
- *     {
- *       "data": [
- *         {
- *           "date": "2018-01-01T00:00:00Z",
- *           "instance_count": 24,
- *           "cores": 48,
- *           "hypervisor": 50,
- *           "sockets": 48
- *         },
- *         {
- *           "date": "2018-04-01T00:00:00Z",
- *           "instance_count": 16,
- *           "cores": 32,
- *           "hypervisor": 50,
- *           "sockets": 32
- *         },
- *         {
- *           "date": "2018-07-01T00:00:00Z",
- *           "instance_count": 8,
- *           "cores": 16,
- *           "hypervisor": 20,
- *           "sockets": 16
- *         },
- *         {
- *           "date": "2018-10-01T00:00:00Z",
- *           "instance_count": 0,
- *           "cores": 0,
- *           "hypervisor": 10,
- *           "sockets": 0
- *         }
- *       ],
- *       "links": {
- *         "first": "/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=quarterly&beginning=2015-01-01T00:00:00.000Z&ending=2019-08-19T23:59:59.999Z&offset=0",
- *         "last": "/api/rhsm-subscriptions/v1/tally/products/RHEL?granularity=quarterly&beginning=2015-01-01T00:00:00.000Z&ending=2019-08-19T23:59:59.999Z&offset=0"
- *       },
- *       "meta": {
- *         "count": 4,
- *         "product": "RHEL",
- *         "granularity": "quarterly"
- *       }
- *     }
  *
  * @apiError {Array} errors
  * @apiErrorExample {json} Error-Response:
@@ -460,14 +641,140 @@ const getGraphReports = (id, params = {}) =>
  *     {
  *       "data": [
  *         {
- *           "date": "2018-07-19T00:00:00Z",
+ *           "date": "2019-07-01T00:00:00Z",
+ *           "sockets": 0,
+ *           "physical_sockets": 0,
+ *           "hypervisor_sockets": 0,
+ *           "has_infinite_quantity": false
+ *         },
+ *         {
+ *           "date": "2019-07-02T00:00:00Z",
+ *           "sockets": 0,
+ *           "physical_sockets": 0,
+ *           "hypervisor_sockets": 0,
+ *           "has_infinite_quantity": false
+ *         },
+ *         {
+ *           "date": "2019-07-03T00:00:00Z",
+ *           "sockets": 0,
+ *           "physical_sockets": 0,
+ *           "hypervisor_sockets": 0,
+ *           "has_infinite_quantity": false
+ *         },
+ *         {
+ *           "date": "2019-07-04T00:00:00Z",
+ *           "sockets": 0,
+ *           "physical_sockets": 0,
+ *           "hypervisor_sockets": 0,
+ *           "has_infinite_quantity": true
+ *         },
+ *         {
+ *           "date": "2019-07-05T00:00:00Z",
+ *           "sockets": 0,
+ *           "physical_sockets": 0,
+ *           "hypervisor_sockets": 0,
+ *           "has_infinite_quantity": true
+ *         },
+ *         {
+ *           "date": "2019-07-06T00:00:00Z",
+ *           "sockets": 0,
+ *           "physical_sockets": 0,
+ *           "hypervisor_sockets": 0,
+ *           "has_infinite_quantity": true
+ *         },
+ *         {
+ *           "date": "2019-07-07T00:00:00Z",
+ *           "sockets": 0,
+ *           "physical_sockets": 0,
+ *           "hypervisor_sockets": 0,
+ *           "has_infinite_quantity": true
+ *         },
+ *         {
+ *           "date": "2019-07-08T00:00:00Z",
+ *           "sockets": 0,
+ *           "physical_sockets": 0,
+ *           "hypervisor_sockets": 0,
+ *           "has_infinite_quantity": true
+ *         },
+ *         {
+ *           "date": "2019-07-09T00:00:00Z",
+ *           "sockets": 0,
+ *           "physical_sockets": 0,
+ *           "hypervisor_sockets": 0,
+ *           "has_infinite_quantity": true
+ *         },
+ *         {
+ *           "date": "2019-07-10T00:00:00Z",
+ *           "sockets": 0,
+ *           "physical_sockets": 0,
+ *           "hypervisor_sockets": 0,
+ *           "has_infinite_quantity": true
+ *         },
+ *         {
+ *           "date": "2019-07-11T00:00:00Z",
  *           "sockets": 50,
  *           "physical_sockets": 50,
  *           "hypervisor_sockets": 0,
  *           "has_infinite_quantity": false
  *         },
  *         {
- *           "date": "2018-07-20T00:00:00Z",
+ *           "date": "2019-07-12T00:00:00Z",
+ *           "sockets": 50,
+ *           "physical_sockets": 50,
+ *           "hypervisor_sockets": 0,
+ *           "has_infinite_quantity": false
+ *         },
+ *         {
+ *           "date": "2019-07-13T00:00:00Z",
+ *           "sockets": 50,
+ *           "physical_sockets": 50,
+ *           "hypervisor_sockets": 0,
+ *           "has_infinite_quantity": false
+ *         },
+ *         {
+ *           "date": "2019-07-14T00:00:00Z",
+ *           "sockets": 50,
+ *           "physical_sockets": 50,
+ *           "hypervisor_sockets": 0,
+ *           "has_infinite_quantity": false
+ *         },
+ *         {
+ *           "date": "2019-07-15T00:00:00Z",
+ *           "sockets": 50,
+ *           "physical_sockets": 50,
+ *           "hypervisor_sockets": 0,
+ *           "has_infinite_quantity": false
+ *         },
+ *         {
+ *           "date": "2019-07-16T00:00:00Z",
+ *           "sockets": 50,
+ *           "physical_sockets": 50,
+ *           "hypervisor_sockets": 0,
+ *           "has_infinite_quantity": false
+ *         },
+ *         {
+ *           "date": "2019-07-17T00:00:00Z",
+ *           "sockets": 50,
+ *           "physical_sockets": 50,
+ *           "hypervisor_sockets": 0,
+ *           "has_infinite_quantity": false
+ *         },
+ *         {
+ *           "date": "2019-07-18T00:00:00Z",
+ *           "sockets": 50,
+ *           "physical_sockets": 50,
+ *           "hypervisor_sockets": 0,
+ *           "has_infinite_quantity": false
+ *         },
+ *         {
+ *           "date": "2019-07-18T00:00:00Z",
+ *           "sockets": 50,
+ *           "physical_sockets": 50,
+ *           "hypervisor_sockets": 0,
+ *           "has_infinite_quantity": false
+ *         },
+ *         {
+ *           "date": "2019-07-19T00:00:00Z",
  *           "sockets": 50,
  *           "physical_sockets": 50,
  *           "hypervisor_sockets": 0,
@@ -499,13 +806,13 @@ const getGraphReports = (id, params = {}) =>
  *           "sockets": null,
  *           "physical_sockets": null,
  *           "hypervisor_sockets": null,
- *           "has_infinite_quantity": true
+ *           "has_infinite_quantity": false
  *         },
  *         {
  *           "date": "2019-07-24T00:00:00Z",
- *           "sockets": 100,
- *           "physical_sockets": 75,
- *           "hypervisor_sockets": 25,
+ *           "sockets": null,
+ *           "physical_sockets": null,
+ *           "hypervisor_sockets": null,
  *           "has_infinite_quantity": true
  *         },
  *         {
@@ -545,6 +852,13 @@ const getGraphReports = (id, params = {}) =>
  *         },
  *         {
  *           "date": "2019-07-30T00:00:00Z",
+ *           "sockets": 100,
+ *           "physical_sockets": 75,
+ *           "hypervisor_sockets": 25,
+ *           "has_infinite_quantity": true
+ *         },
+ *         {
+ *           "date": "2019-07-31T00:00:00Z",
  *           "sockets": 100,
  *           "physical_sockets": 75,
  *           "hypervisor_sockets": 25,

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,6 +3,17 @@ import Adapter from 'enzyme-adapter-react-16';
 
 configure({ adapter: new Adapter() });
 
+jest.mock('c3', () => ({
+  generate: () => ({
+    destroy: jest.fn(),
+    focus: jest.fn(),
+    hide: jest.fn(),
+    load: ({ done }) => done && done(),
+    revert: jest.fn(),
+    toggle: jest.fn()
+  })
+}));
+
 global.window.insights = {
   chrome: {
     auth: {

--- a/src/styles/_common.scss
+++ b/src/styles/_common.scss
@@ -3,6 +3,10 @@
     filter: blur(4px);
   }
 
+  .faded {
+    opacity: 0.3;
+  }
+
   .fadein {
     opacity:0;
     animation:fadein .25s ease-in forwards;
@@ -10,4 +14,12 @@
   }
 
   @keyframes fadein { 0%{opacity:0} 100%{opacity:1} }
+
+  .fadeout {
+    opacity:1;
+    animation:fadeout .25s ease-in forwards;
+    animation-delay:.25s;
+  }
+
+  @keyframes fadeout { 0%{opacity:1} 100%{opacity:0} }
 }

--- a/src/styles/_usage-graph.scss
+++ b/src/styles/_usage-graph.scss
@@ -4,4 +4,62 @@
       border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
     }
   }
+
+  .c3 svg {
+    font: 1em var(--pf-chart-global--FontFamily);
+    letter-spacing: var(--pf-chart-global--letter-spacing);
+  }
+
+  .c3-axis.c3-axis-x,
+  .c3-axis.c3-axis-y {
+    opacity: 0.5 !important;
+  }
+
+  .c3-shape.c3-line[class*="threshold"] {
+    stroke-dasharray: 5,5;
+    stroke-width: 3;
+  }
+
+  .threshold-legend-icon,
+  .legend-icon {
+    vertical-align: baseline;
+    width: 10px;
+    height: 10px;
+    display: inline-block;
+  }
+
+  .threshold-legend-icon {
+    height: auto;
+    vertical-align: middle;
+    width: 25px;
+    border-width: 0;
+    border-top-width: 3px;
+    border-style: dashed;
+    margin-left: 2px;
+    margin-right: 2px;
+  }
+
+  .c3-xgrid, .c3-ygrid {
+    stroke-dasharray: none;
+    opacity: 0.5;
+  }
+
+  // ToDo: apply pf color variables
+  table.c3-tooltip {
+    background-color: #333333;
+    color: #ffffff;
+
+    tr,th,td {
+      background-color: inherit;
+      color: inherit;
+      border: none;
+    }
+  }
+
+  .curiosity-c3chart {
+    .curiosity-c3chart-description {
+      padding-left: 20px;
+      padding-right: 20px;
+    }
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3121,6 +3121,13 @@ bytes@3.1.0:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
   integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
 
+c3@^0.7.15:
+  version "0.7.15"
+  resolved "https://registry.yarnpkg.com/c3/-/c3-0.7.15.tgz#d848051800386f0123a96841e2c2dddbf1534d29"
+  integrity sha512-4hck3Y0VSzPuIghKiSzl8WIIO9OLuKaYpkOV1WtIOPPSHsVUHB1iAXjlLVDdGRbqr2iGnQHoxucKmcOxgkq6gQ==
+  dependencies:
+    d3 "^5.8.0"
+
 cacache@^12.0.2:
   version "12.0.3"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-12.0.3.tgz#be99abba4e1bf5df461cd5a2c1071fc432573390"
@@ -3582,7 +3589,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.11.0, commander@^2.19.0, commander@^2.20.0, commander@~2.20.3:
+commander@2, commander@^2.11.0, commander@^2.19.0, commander@^2.20.0, commander@~2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -4302,10 +4309,34 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-d3-array@^1.2.0:
+d3-array@1, d3-array@^1.1.1, d3-array@^1.2.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
   integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
+
+d3-axis@1:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-1.0.12.tgz#cdf20ba210cfbb43795af33756886fb3638daac9"
+  integrity sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ==
+
+d3-brush@1:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-1.1.5.tgz#066b8e84d17b192986030446c97c0fba7e1bacdc"
+  integrity sha512-rEaJ5gHlgLxXugWjIkolTA0OyMvw8UWU1imYXy1v642XyyswmI1ybKOv05Ft+ewq+TFmdliD3VuK0pRp1VT/5A==
+  dependencies:
+    d3-dispatch "1"
+    d3-drag "1"
+    d3-interpolate "1"
+    d3-selection "1"
+    d3-transition "1"
+
+d3-chord@1:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-1.0.6.tgz#309157e3f2db2c752f0280fedd35f2067ccbb15f"
+  integrity sha512-JXA2Dro1Fxw9rJe33Uv+Ckr5IrAa74TlfDEhE/jfLOaXegMQFQTAgAw9WnZL8+HxVBRXaRGCkrNU7pJeylRIuA==
+  dependencies:
+    d3-array "1"
+    d3-path "1"
 
 d3-collection@1:
   version "1.0.7"
@@ -4317,15 +4348,73 @@ d3-color@1:
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.0.tgz#89c45a995ed773b13314f06460df26d60ba0ecaf"
   integrity sha512-TzNPeJy2+iEepfiL92LAAB7fvnp/dV2YwANPVHdDWmYMm23qIJBYww3qT8I8C1wXrmrg4UWs7BKc2tKIgyjzHg==
 
-d3-ease@^1.0.0:
+d3-contour@1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-1.3.2.tgz#652aacd500d2264cb3423cee10db69f6f59bead3"
+  integrity sha512-hoPp4K/rJCu0ladiH6zmJUEz6+u3lgR+GSm/QdM2BBvDraU39Vr7YdDCicJcxP1z8i9B/2dJLgDC1NcvlF8WCg==
+  dependencies:
+    d3-array "^1.1.1"
+
+d3-dispatch@1:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.6.tgz#00d37bcee4dd8cd97729dd893a0ac29caaba5d58"
+  integrity sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==
+
+d3-drag@1:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-1.2.5.tgz#2537f451acd39d31406677b7dc77c82f7d988f70"
+  integrity sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==
+  dependencies:
+    d3-dispatch "1"
+    d3-selection "1"
+
+d3-dsv@1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-1.2.0.tgz#9d5f75c3a5f8abd611f74d3f5847b0d4338b885c"
+  integrity sha512-9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==
+  dependencies:
+    commander "2"
+    iconv-lite "0.4"
+    rw "1"
+
+d3-ease@1, d3-ease@^1.0.0:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.6.tgz#ebdb6da22dfac0a22222f2d4da06f66c416a0ec0"
   integrity sha512-SZ/lVU7LRXafqp7XtIcBdxnWl8yyLpgOmzAk0mWBI9gXNzLDx5ybZgnRbH9dN/yY5tzVBqCQ9avltSnqVwessQ==
+
+d3-fetch@1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/d3-fetch/-/d3-fetch-1.1.2.tgz#957c8fbc6d4480599ba191b1b2518bf86b3e1be2"
+  integrity sha512-S2loaQCV/ZeyTyIF2oP8D1K9Z4QizUzW7cWeAOAS4U88qOt3Ucf6GsmgthuYSdyB2HyEm4CeGvkQxWsmInsIVA==
+  dependencies:
+    d3-dsv "1"
+
+d3-force@1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-1.2.1.tgz#fd29a5d1ff181c9e7f0669e4bd72bdb0e914ec0b"
+  integrity sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==
+  dependencies:
+    d3-collection "1"
+    d3-dispatch "1"
+    d3-quadtree "1"
+    d3-timer "1"
 
 d3-format@1:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.3.tgz#4e8eb4dff3fdcb891a8489ec6e698601c41b96f1"
   integrity sha512-mm/nE2Y9HgGyjP+rKIekeITVgBtX97o1nrvHCWX8F/yBYyevUTvu9vb5pUnKwrcSw7o7GuwMOWjS9gFDs4O+uQ==
+
+d3-geo@1:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-1.12.0.tgz#58ddbdf4d9db5f199db69d1b7c93dca6454a6f24"
+  integrity sha512-NalZVW+6/SpbKcnl+BCO67m8gX+nGeJdo6oGL9H6BRUGUL1e+AtPcP4vE4TwCQ/gl8y5KE7QvBzrLn+HsKIl+w==
+  dependencies:
+    d3-array "1"
+
+d3-hierarchy@1:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz#2f6bee24caaea43f8dc37545fa01628559647a83"
+  integrity sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ==
 
 d3-interpolate@1, d3-interpolate@^1.1.1:
   version "1.4.0"
@@ -4338,6 +4427,41 @@ d3-path@1:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.9.tgz#48c050bb1fe8c262493a8caf5524e3e9591701cf"
   integrity sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==
+
+d3-polygon@1:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-polygon/-/d3-polygon-1.0.6.tgz#0bf8cb8180a6dc107f518ddf7975e12abbfbd38e"
+  integrity sha512-k+RF7WvI08PC8reEoXa/w2nSg5AUMTi+peBD9cmFc+0ixHfbs4QmxxkarVal1IkVkgxVuk9JSHhJURHiyHKAuQ==
+
+d3-quadtree@1:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-1.0.7.tgz#ca8b84df7bb53763fe3c2f24bd435137f4e53135"
+  integrity sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA==
+
+d3-random@1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-1.1.2.tgz#2833be7c124360bf9e2d3fd4f33847cfe6cab291"
+  integrity sha512-6AK5BNpIFqP+cx/sreKzNjWbwZQCSUatxq+pPRmFIQaWuoD+NrbVWw7YWpHiXpCQ/NanKdtGDuB+VQcZDaEmYQ==
+
+d3-scale-chromatic@1:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-1.5.0.tgz#54e333fc78212f439b14641fb55801dd81135a98"
+  integrity sha512-ACcL46DYImpRFMBcpk9HhtIyC7bTBR4fNOPxwVSl0LfulDAwyiHyPOTqcDG1+t5d4P9W7t/2NAuWu59aKko/cg==
+  dependencies:
+    d3-color "1"
+    d3-interpolate "1"
+
+d3-scale@2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-2.2.2.tgz#4e880e0b2745acaaddd3ede26a9e908a9e17b81f"
+  integrity sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==
+  dependencies:
+    d3-array "^1.2.0"
+    d3-collection "1"
+    d3-format "1"
+    d3-interpolate "1"
+    d3-time "1"
+    d3-time-format "2"
 
 d3-scale@^1.0.0:
   version "1.0.7"
@@ -4352,7 +4476,12 @@ d3-scale@^1.0.0:
     d3-time "1"
     d3-time-format "2"
 
-d3-shape@^1.0.0, d3-shape@^1.2.0:
+d3-selection@1, d3-selection@^1.1.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.4.1.tgz#98eedbbe085fbda5bafa2f9e3f3a2f4d7d622a98"
+  integrity sha512-BTIbRjv/m5rcVTfBs4AMBLKs4x8XaaLkwm28KWu9S2vKNqXkXt2AH2Qf0sdPZHjFxcWg/YL53zcqAz+3g4/7PA==
+
+d3-shape@1, d3-shape@^1.0.0, d3-shape@^1.2.0:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.7.tgz#df63801be07bc986bc54f63789b4fe502992b5d7"
   integrity sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==
@@ -4371,15 +4500,75 @@ d3-time@1:
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.1.0.tgz#b1e19d307dae9c900b7e5b25ffc5dcc249a8a0f1"
   integrity sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==
 
-d3-timer@^1.0.0:
+d3-timer@1, d3-timer@^1.0.0:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.10.tgz#dfe76b8a91748831b13b6d9c793ffbd508dd9de5"
   integrity sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==
 
-d3-voronoi@^1.1.2:
+d3-transition@1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-1.3.2.tgz#a98ef2151be8d8600543434c1ca80140ae23b398"
+  integrity sha512-sc0gRU4PFqZ47lPVHloMn9tlPcv8jxgOQg+0zjhfZXMQuvppjG6YuwdMBE0TuqCZjeJkLecku/l9R0JPcRhaDA==
+  dependencies:
+    d3-color "1"
+    d3-dispatch "1"
+    d3-ease "1"
+    d3-interpolate "1"
+    d3-selection "^1.1.0"
+    d3-timer "1"
+
+d3-voronoi@1, d3-voronoi@^1.1.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/d3-voronoi/-/d3-voronoi-1.1.4.tgz#dd3c78d7653d2bb359284ae478645d95944c8297"
   integrity sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg==
+
+d3-zoom@1:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-1.8.3.tgz#b6a3dbe738c7763121cd05b8a7795ffe17f4fc0a"
+  integrity sha512-VoLXTK4wvy1a0JpH2Il+F2CiOhVu7VRXWF5M/LroMIh3/zBAC3WAt7QoIvPibOavVo20hN6/37vwAsdBejLyKQ==
+  dependencies:
+    d3-dispatch "1"
+    d3-drag "1"
+    d3-interpolate "1"
+    d3-selection "1"
+    d3-transition "1"
+
+d3@^5.8.0:
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/d3/-/d3-5.16.0.tgz#9c5e8d3b56403c79d4ed42fbd62f6113f199c877"
+  integrity sha512-4PL5hHaHwX4m7Zr1UapXW23apo6pexCgdetdJ5kTmADpG/7T9Gkxw0M0tf/pjoB63ezCCm0u5UaFYy2aMt0Mcw==
+  dependencies:
+    d3-array "1"
+    d3-axis "1"
+    d3-brush "1"
+    d3-chord "1"
+    d3-collection "1"
+    d3-color "1"
+    d3-contour "1"
+    d3-dispatch "1"
+    d3-drag "1"
+    d3-dsv "1"
+    d3-ease "1"
+    d3-fetch "1"
+    d3-force "1"
+    d3-format "1"
+    d3-geo "1"
+    d3-hierarchy "1"
+    d3-interpolate "1"
+    d3-path "1"
+    d3-polygon "1"
+    d3-quadtree "1"
+    d3-random "1"
+    d3-scale "2"
+    d3-scale-chromatic "1"
+    d3-selection "1"
+    d3-shape "1"
+    d3-time "1"
+    d3-time-format "2"
+    d3-timer "1"
+    d3-transition "1"
+    d3-voronoi "1"
+    d3-zoom "1"
 
 d@1, d@^1.0.1:
   version "1.0.1"
@@ -6594,7 +6783,7 @@ i18next@^19.4.4:
   dependencies:
     "@babel/runtime" "^7.3.1"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24:
+iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -11329,6 +11518,11 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   integrity sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=
   dependencies:
     aproba "^1.1.1"
+
+rw@1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
+  integrity sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=
 
 rxjs@^6.5.3:
   version "6.5.4"


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(graphCard): issues/283 expand unit tests
- feat(c3Chart): issues/283 add base c3 component 
   * c3Chart, adds a c3 wrapper component, initial tests
- feat(c3GraphCard): issues/283 add card, display data 
   * c3GraphCard, add card wrapper for c3, display api data
   * c3GraphCardHelpers, c3 config generator, maintain prior card helpers
   * c3GraphCardLegendItem, custom chart legend item
   * i18n, placeholder legend tooltip strings
   * rhsmServices, update API mocks for local dev, random response
   * styling, adjustments to match pf victory charts styling
- feat(rhelView,openshiftView): issues/283 activate c3
   * rhelView, c3 charting, tooltip enhancements via query-string
   * openshiftView, c3 charting, tooltip enhancements via query-string

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- The goal is performance and feature related testing within the `CI-beta` environment.
- The current PF4 victory based charts are still active. To use the `c3` based charts add the query-string `?c3` to the end of either the Openshift or Rhel product views like
   - https://ci.cloud.redhat.com/beta/subscriptions/rhel-sw/all?c3
   - https://ci.cloud.redhat.com/beta/subscriptions/openshift-sw?c3
   - Removing the `?c3` should restore the original PF4 victory based charts

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. navigate to either the Rhel or Openshift product views and add a `?c3` to the url, like
   - `/beta/subscriptions/openshift-sw?c3`
   - `/beta/subscriptions/rhel-sw/all?c3`
1. Removing the `?c3` should restore the original PF4 victory based charts


### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. navigate to either the Rhel or Openshift product views and add a `?c3` to the url, like
   - `/beta/subscriptions/openshift-sw?c3`
   - `/beta/subscriptions/rhel-sw/all?c3`
1. Removing the `?c3` should restore the original PF4 victory based charts

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
## Granularity selection and graph tooltips
![May-15-2020 18-28-07](https://user-images.githubusercontent.com/3761375/82101276-19510b00-96da-11ea-89bb-b4ff2cf861d0.gif)

## Tooltip and legend
![May-15-2020 18-32-24](https://user-images.githubusercontent.com/3761375/82101432-7baa0b80-96da-11ea-8a73-9b6336d784b1.gif)

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
- relates #257 #181 #158 #141 
- updates #283 

@rblackbu