### PR TITLE
chore(build): local run dev chrome, hide broken nav icon

### DIFF
--- a/scripts/dev.chrome.sh
+++ b/scripts/dev.chrome.sh
@@ -94,7 +94,7 @@ buildChrome()
 
   printf "${YELLOW}dotenv includes ...${NOCOLOR}"
 
-  HEADER_CONTENT=$(node -pe "require('fs').readFileSync('${SNIPPET_HEAD}').toString().replace(/\n/g, '').concat('<style>.pf-c-page__sidebar .ins-c-skeleton{display:none}</style>')")
+  HEADER_CONTENT=$(node -pe "require('fs').readFileSync('${SNIPPET_HEAD}').toString().replace(/\n/g, '').concat('<style>.pf-c-page__sidebar .ins-c-skeleton,.pf-c-page__sidebar .ins-c-navigation__header{display:none}</style>')")
   BODY_CONTENT=$(node -pe "require('fs').readFileSync('${SNIPPET_BODY}').toString().replace(/\n/g,'').replace(/Logging in\.\.\./i, 'Development')")
 
   if [[ ! -z "$HEADER_CONTENT" ]] && [[ ! -z "$BODY_CONTENT" ]]; then


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- chore(build): local run dev chrome, hide broken nav icon

<!-- ### Notes -->
<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
Hides broken left nav icon
#### Before
<img width="1390" alt="Screen Shot 2020-05-19 at 3 16 42 AM" src="https://user-images.githubusercontent.com/3761375/82296439-335f4780-997f-11ea-83e1-260bb47402bd.png">


#### After
<img width="1158" alt="Screen Shot 2020-05-19 at 3 14 44 AM" src="https://user-images.githubusercontent.com/3761375/82296384-1dea1d80-997f-11ea-8ed8-3d8ff1292cd5.png">



## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Ongoing