### PR TITLE
feat(chartArea,graphCard): issues/283 interactive legend

### DIFF
--- a/src/components/chartArea/__tests__/__snapshots__/chartArea.test.js.snap
+++ b/src/components/chartArea/__tests__/__snapshots__/chartArea.test.js.snap
@@ -704,33 +704,64 @@ exports[`ChartArea Component should allow tick formatting: y tick format 1`] = `
 </div>
 `;
 
+exports[`ChartArea Component should handle custom chart legends: hide state 1`] = `
+Object {
+  "loremGraph": true,
+}
+`;
+
+exports[`ChartArea Component should handle custom chart legends: isToggled state 1`] = `
+Object {
+  "returnedToggleValue": true,
+  "state": Object {
+    "loremGraph": true,
+  },
+}
+`;
+
 exports[`ChartArea Component should handle custom chart legends: renderLegend: should return a custom legend 1`] = `
 Object {
-  "dataSets": Array [
-    Object {
-      "data": Array [
-        Object {
-          "x": 1,
-          "xAxisLabel": "1 x axis label",
-          "y": 0,
-        },
-      ],
-      "id": "loremGraph",
-      "interpolation": "natural",
-      "isStacked": true,
-    },
-    Object {
-      "data": Array [
-        Object {
-          "x": 1,
-          "xAxisLabel": "1 x axis label",
-          "y": 10,
-        },
-      ],
-      "id": "ipsumGraph",
-      "isThreshold": true,
-    },
-  ],
+  "chart": Object {
+    "hide": [Function],
+    "isToggled": [Function],
+    "revert": [Function],
+    "toggle": [Function],
+  },
+  "datum": Object {
+    "dataSets": Array [
+      Object {
+        "data": Array [
+          Object {
+            "x": 1,
+            "xAxisLabel": "1 x axis label",
+            "y": 0,
+          },
+        ],
+        "id": "loremGraph",
+        "interpolation": "natural",
+        "isStacked": true,
+      },
+      Object {
+        "data": Array [
+          Object {
+            "x": 1,
+            "xAxisLabel": "1 x axis label",
+            "y": 10,
+          },
+        ],
+        "id": "ipsumGraph",
+        "isThreshold": true,
+      },
+    ],
+  },
+}
+`;
+
+exports[`ChartArea Component should handle custom chart legends: revert state 1`] = `Object {}`;
+
+exports[`ChartArea Component should handle custom chart legends: toggle state 1`] = `
+Object {
+  "loremGraph": false,
 }
 `;
 
@@ -867,21 +898,13 @@ exports[`ChartArea Component should handle custom chart tooltips: renderTooltip:
       "y": -10,
     }
   }
-  labelComponent={
-    <VictoryPortal
-      groupComponent={<g />}
-    >
-      <ChartTooltip
-        flyoutComponent={<FlyoutComponent />}
-      />
-    </VictoryPortal>
-  }
+  labelComponent={<FlyoutComponent />}
   labels={[Function]}
   portalComponent={<Portal />}
   portalZIndex={99}
   responsive={true}
   voronoiDimension="x"
-  voronoiPadding={50}
+  voronoiPadding={60}
 />
 `;
 

--- a/src/components/chartArea/__tests__/chartArea.test.js
+++ b/src/components/chartArea/__tests__/chartArea.test.js
@@ -308,6 +308,7 @@ describe('ChartArea Component', () => {
   });
 
   it('should handle custom chart legends', () => {
+    let chartMethods = {};
     const props = {
       dataSets: [
         {
@@ -334,11 +335,26 @@ describe('ChartArea Component', () => {
           isThreshold: true
         }
       ],
-      chartLegend: propsObj => propsObj.datum
+      chartLegend: propsObj => {
+        chartMethods = propsObj.chart;
+        return propsObj;
+      }
     };
 
     const component = shallow(<ChartArea {...props} />);
     expect(component.instance().renderLegend()).toMatchSnapshot('renderLegend: should return a custom legend');
+
+    chartMethods.hide('loremGraph');
+    expect(component.instance().dataSetsToggle).toMatchSnapshot('hide state');
+
+    const returnedToggleValue = chartMethods.isToggled('loremGraph');
+    expect({ state: component.instance().dataSetsToggle, returnedToggleValue }).toMatchSnapshot('isToggled state');
+
+    chartMethods.toggle('loremGraph');
+    expect(component.instance().dataSetsToggle).toMatchSnapshot('toggle state');
+
+    chartMethods.revert();
+    expect(component.instance().dataSetsToggle).toMatchSnapshot('revert state');
   });
 
   it('should set initial width to zero and then resize', () => {

--- a/src/components/graphCard/__tests__/__snapshots__/graphCardChartLegend.test.js.snap
+++ b/src/components/graphCard/__tests__/__snapshots__/graphCardChartLegend.test.js.snap
@@ -1,5 +1,82 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`GraphCardChartLegend Component should handle a click event: click event post 1`] = `
+<Component
+  className="victory-legend-item"
+  component="a"
+  icon={
+    <div
+      aria-hidden={true}
+      className="legend-icon"
+      style={
+        Object {
+          "backgroundColor": "#000000",
+          "visibility": "visible",
+        }
+      }
+    />
+  }
+  isDisabled={false}
+  key="curiosity-button-loremIpsum"
+  onClick={[Function]}
+  onKeyPress={[Function]}
+  tabIndex={0}
+  variant="link"
+>
+  t(curiosity-graph.loremIpsumLabel, [object Object])
+</Component>
+`;
+
+exports[`GraphCardChartLegend Component should handle a click event: click event pre 1`] = `
+<Component
+  className="victory-legend-item"
+  component="a"
+  icon={
+    <div
+      aria-hidden={true}
+      className="legend-icon"
+      style={
+        Object {
+          "backgroundColor": "#000000",
+          "visibility": "visible",
+        }
+      }
+    />
+  }
+  isDisabled={false}
+  key="curiosity-button-loremIpsum"
+  onClick={[Function]}
+  onKeyPress={[Function]}
+  tabIndex={0}
+  variant="link"
+>
+  t(curiosity-graph.loremIpsumLabel, [object Object])
+</Component>
+`;
+
+exports[`GraphCardChartLegend Component should handle a click event: click event update 1`] = `
+<Component
+  className="victory-legend-item"
+  component="a"
+  icon={
+    <EyeSlashIcon
+      color="currentColor"
+      noVerticalAlign={false}
+      size="sm"
+      title={null}
+    />
+  }
+  isDisabled={false}
+  key="curiosity-button-loremIpsum"
+  onClick={[Function]}
+  onKeyPress={[Function]}
+  tabIndex={0}
+  variant="link"
+>
+  t(curiosity-graph.loremIpsumLabel, [object Object])
+</Component>
+`;
+
 exports[`GraphCardChartLegend Component should handle variations in data when returning legend items: legend item, MISSING tooltip content 1`] = `
 <Unknown
   className="victory-legend-item"
@@ -10,13 +87,15 @@ exports[`GraphCardChartLegend Component should handle variations in data when re
       className="legend-icon"
       style={
         Object {
-          "backgroundColor": "#ipsum",
+          "backgroundColor": "#000000",
           "visibility": "visible",
         }
       }
     />
   }
   isDisabled={false}
+  onClick={[Function]}
+  onKeyPress={[Function]}
   tabIndex={0}
   variant="link"
 >
@@ -69,13 +148,15 @@ exports[`GraphCardChartLegend Component should handle variations in data when re
         className="legend-icon"
         style={
           Object {
-            "backgroundColor": "#ipsum",
+            "backgroundColor": "#000000",
             "visibility": "visible",
           }
         }
       />
     }
     isDisabled={false}
+    onClick={[Function]}
+    onKeyPress={[Function]}
     tabIndex={0}
     variant="link"
   >
@@ -97,6 +178,8 @@ exports[`GraphCardChartLegend Component should handle variations in data when re
     />
   }
   isDisabled={true}
+  onClick={[Function]}
+  onKeyPress={[Function]}
   tabIndex={0}
   variant="link"
 >
@@ -159,6 +242,8 @@ exports[`GraphCardChartLegend Component should render a basic component: basic 1
       }
       isDisabled={false}
       key="curiosity-button-loremIpsum"
+      onClick={[Function]}
+      onKeyPress={[Function]}
       tabIndex={0}
       variant="link"
     >
@@ -223,6 +308,8 @@ exports[`GraphCardChartLegend Component should render basic data: data 1`] = `
       }
       isDisabled={false}
       key="curiosity-button-loremIpsum"
+      onClick={[Function]}
+      onKeyPress={[Function]}
       tabIndex={0}
       variant="link"
     >
@@ -278,6 +365,8 @@ exports[`GraphCardChartLegend Component should render basic data: data 1`] = `
       }
       isDisabled={true}
       key="curiosity-button-ametConsectetur"
+      onClick={[Function]}
+      onKeyPress={[Function]}
       tabIndex={0}
       variant="link"
     >
@@ -337,6 +426,8 @@ exports[`GraphCardChartLegend Component should render basic data: data 1`] = `
       }
       isDisabled={false}
       key="curiosity-button-dolorSit"
+      onClick={[Function]}
+      onKeyPress={[Function]}
       tabIndex={0}
       variant="link"
     >
@@ -396,6 +487,8 @@ exports[`GraphCardChartLegend Component should render basic data: data 1`] = `
       }
       isDisabled={false}
       key="curiosity-button-nonCursus"
+      onClick={[Function]}
+      onKeyPress={[Function]}
       tabIndex={0}
       variant="link"
     >

--- a/src/components/graphCard/__tests__/graphCardChartLegend.test.js
+++ b/src/components/graphCard/__tests__/graphCardChartLegend.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { Button } from '@patternfly/react-core';
 import { GraphCardChartLegend } from '../graphCardChartLegend';
 
 describe('GraphCardChartLegend Component', () => {
@@ -57,11 +58,76 @@ describe('GraphCardChartLegend Component', () => {
     expect(component).toMatchSnapshot('data');
   });
 
+  it('should handle a click event', () => {
+    const props = {
+      datum: {
+        dataSets: [
+          {
+            stroke: '#000000',
+            id: 'loremIpsum',
+            isThreshold: false,
+            data: [{ y: 0, hasData: true }]
+          },
+          {
+            stroke: '#ff0000',
+            id: 'dolorSit',
+            isThreshold: true,
+            data: [{ y: 0, isInfinite: false }]
+          }
+        ]
+      },
+      legend: {
+        'test-dolorSit': true
+      },
+      product: 'test',
+      viewId: 'test'
+    };
+
+    const component = shallow(<GraphCardChartLegend {...props} />);
+    expect(component.find(Button).first()).toMatchSnapshot('click event pre');
+
+    component.find(Button).first().simulate('click');
+    // emulate a Redux state update.
+    component.setProps({
+      legend: { ...props.legend, ...{ 'test-loremIpsum': true } }
+    });
+    expect(component.find(Button).first()).toMatchSnapshot('click event update');
+
+    component.find(Button).first().simulate('keyPress');
+    // emulate a Redux state update.
+    component.setProps({
+      legend: { ...props.legend, ...{ 'test-loremIpsum': false } }
+    });
+    expect(component.find(Button).first()).toMatchSnapshot('click event post');
+  });
+
   it('should handle variations in data when returning legend items', () => {
+    const props = {
+      datum: {
+        dataSets: [
+          {
+            stroke: '#000000',
+            id: 'loremIpsum',
+            isThreshold: false,
+            data: [{ y: 0, hasData: true }]
+          },
+          {
+            stroke: '#ff0000',
+            id: 'dolorSit',
+            isThreshold: true,
+            data: [{ y: 0, isInfinite: false }]
+          }
+        ]
+      },
+      product: 'test'
+    };
+
+    const component = shallow(<GraphCardChartLegend {...props} />);
+
     expect(
-      GraphCardChartLegend.renderLegendItem({
-        chartId: 'lorem',
-        color: '#ipsum',
+      component.instance().renderLegendItem({
+        chartId: 'loremIpsum',
+        color: '#000000',
         isDisabled: false,
         isThreshold: false,
         labelContent: 'lorem ispum',
@@ -70,9 +136,9 @@ describe('GraphCardChartLegend Component', () => {
     ).toMatchSnapshot('legend item, WITH tooltip content');
 
     expect(
-      GraphCardChartLegend.renderLegendItem({
-        chartId: 'lorem',
-        color: '#ipsum',
+      component.instance().renderLegendItem({
+        chartId: 'loremIpsum',
+        color: '#000000',
         isDisabled: false,
         isThreshold: false,
         labelContent: 'lorem ispum',
@@ -81,9 +147,9 @@ describe('GraphCardChartLegend Component', () => {
     ).toMatchSnapshot('legend item, MISSING tooltip content');
 
     expect(
-      GraphCardChartLegend.renderLegendItem({
-        chartId: 'lorem',
-        color: '#ipsum',
+      component.instance().renderLegendItem({
+        chartId: 'loremIpsum',
+        color: '#000000',
         isDisabled: true,
         isThreshold: false,
         labelContent: 'lorem ispum',

--- a/src/components/graphCard/graphCard.js
+++ b/src/components/graphCard/graphCard.js
@@ -83,7 +83,7 @@ class GraphCard extends React.Component {
    * @returns {Node}
    */
   renderChart() {
-    const { filterGraphData, graphData, graphQuery, selectOptionsType, productShortLabel } = this.props;
+    const { filterGraphData, graphData, graphQuery, selectOptionsType, productShortLabel, viewId } = this.props;
     const graphGranularity = graphQuery && graphQuery[rhsmApiTypes.RHSM_API_QUERY_GRANULARITY];
     const { selected } = graphCardTypes.getGranularityOptions(selectOptionsType);
     const updatedGranularity = graphGranularity || selected;
@@ -141,7 +141,9 @@ class GraphCard extends React.Component {
         key={helpers.generateId()}
         {...chartAreaProps}
         dataSets={filteredGraphData(graphData)}
-        chartLegend={({ datum }) => <GraphCardChartLegend datum={datum} product={productShortLabel} />}
+        chartLegend={({ chart, datum }) => (
+          <GraphCardChartLegend chart={chart} datum={datum} product={productShortLabel} viewId={viewId} />
+        )}
         chartTooltip={({ datum }) => (
           <GraphCardChartTooltip datum={datum} granularity={updatedGranularity} product={productShortLabel} />
         )}

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -35,8 +35,8 @@ msgstr \\"\\"
 
 #: src/components/c3GraphCard/c3GraphCard.js:189
 #: src/components/c3GraphCard/c3GraphCard.js:193
-#: src/components/graphCard/graphCard.js:174
-#: src/components/graphCard/graphCard.js:178
+#: src/components/graphCard/graphCard.js:176
+#: src/components/graphCard/graphCard.js:180
 msgid \\"curiosity-graph.dropdownPlaceholder\\"
 msgstr \\"\\"
 
@@ -64,7 +64,7 @@ msgstr \\"\\"
 msgid \\"curiosity-graph.noDataLabel\\"
 msgstr \\"\\"
 
-#: src/components/graphCard/graphCardChartLegend.js:80
+#: src/components/graphCard/graphCardChartLegend.js:132
 msgid \\"curiosity-graph.noLabel\\"
 msgstr \\"\\"
 
@@ -75,13 +75,13 @@ msgstr \\"\\"
 
 #: src/components/c3GraphCard/c3GraphCard.js:110
 #: src/components/c3GraphCard/c3GraphCardHelpers.js:133
-#: src/components/graphCard/graphCardChartLegend.js:78
+#: src/components/graphCard/graphCardChartLegend.js:130
 #: src/components/graphCard/graphCardChartTooltip.js:34
 msgid \\"curiosity-graph.thresholdLabel\\"
 msgstr \\"\\"
 
 #: src/components/c3GraphCard/c3GraphCard.js:93
-#: src/components/graphCard/graphCardChartLegend.js:83
+#: src/components/graphCard/graphCardChartLegend.js:135
 msgid \\"curiosity-graph.thresholdLegendTooltip\\"
 msgstr \\"\\"
 

--- a/src/redux/reducers/__tests__/__snapshots__/graphReducer.test.js.snap
+++ b/src/redux/reducers/__tests__/__snapshots__/graphReducer.test.js.snap
@@ -3,6 +3,7 @@
 exports[`GraphReducer should handle all defined error types: rejected types GET_GRAPH_REPORT_CAPACITY_RHSM 1`] = `
 Object {
   "result": Object {
+    "legend": Object {},
     "reportCapacity": Object {
       "error": true,
       "errorMessage": "MESSAGE",
@@ -22,6 +23,7 @@ Object {
 exports[`GraphReducer should handle all defined fulfilled types: fulfilled types GET_GRAPH_REPORT_CAPACITY_RHSM 1`] = `
 Object {
   "result": Object {
+    "legend": Object {},
     "reportCapacity": Object {
       "data": Object {
         "test": "success",
@@ -45,6 +47,7 @@ Object {
 exports[`GraphReducer should handle all defined pending types: pending types GET_GRAPH_REPORT_CAPACITY_RHSM 1`] = `
 Object {
   "result": Object {
+    "legend": Object {},
     "reportCapacity": Object {
       "error": false,
       "errorMessage": "",
@@ -57,5 +60,17 @@ Object {
     },
   },
   "type": "GET_GRAPH_REPORT_CAPACITY_RHSM_PENDING",
+}
+`;
+
+exports[`GraphReducer should handle specific defined types: defined type SET_GRAPH_LEGEND 1`] = `
+Object {
+  "result": Object {
+    "legend": Object {
+      "lorem": true,
+    },
+    "reportCapacity": Object {},
+  },
+  "type": "SET_GRAPH_LEGEND",
 }
 `;

--- a/src/redux/reducers/__tests__/graphReducer.test.js
+++ b/src/redux/reducers/__tests__/graphReducer.test.js
@@ -1,10 +1,25 @@
 import graphReducer from '../graphReducer';
-import { rhsmTypes as types } from '../../types';
+import { rhsmTypes as types, graphTypes } from '../../types';
 import { reduxHelpers } from '../../common/reduxHelpers';
 
 describe('GraphReducer', () => {
   it('should return the initial state', () => {
     expect(graphReducer.initialState).toBeDefined();
+  });
+
+  it('should handle specific defined types', () => {
+    const specificTypes = [graphTypes.SET_GRAPH_LEGEND];
+
+    specificTypes.forEach(value => {
+      const dispatched = {
+        type: value,
+        legend: { lorem: true }
+      };
+
+      const resultState = graphReducer(undefined, dispatched);
+
+      expect({ type: value, result: resultState }).toMatchSnapshot(`defined type ${value}`);
+    });
   });
 
   it('should handle all defined error types', () => {

--- a/src/redux/reducers/graphReducer.js
+++ b/src/redux/reducers/graphReducer.js
@@ -1,4 +1,4 @@
-import { rhsmTypes } from '../types';
+import { rhsmTypes, graphTypes } from '../types';
 import { reduxHelpers } from '../common/reduxHelpers';
 
 /**
@@ -8,22 +8,39 @@ import { reduxHelpers } from '../common/reduxHelpers';
  * @type {{reportCapacity: object}}
  */
 const initialState = {
+  legend: {},
   reportCapacity: {}
 };
 
 /**
- * Apply generated graph observer/reducer for reportCapacity to state, against actions.
+ * Apply graph interaction, and generated graph observer/reducer for reportCapacity to state,
+ * against actions.
  *
  * @param {object} state
  * @param {object} action
  * @returns {object|{}}
  */
-const graphReducer = (state = initialState, action) =>
-  reduxHelpers.generatedPromiseActionReducer(
-    [{ ref: 'reportCapacity', type: rhsmTypes.GET_GRAPH_REPORT_CAPACITY_RHSM }],
-    state,
-    action
-  );
+const graphReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case graphTypes.SET_GRAPH_LEGEND:
+      return reduxHelpers.setStateProp(
+        'legend',
+        {
+          ...action.legend
+        },
+        {
+          state,
+          reset: false
+        }
+      );
+    default:
+      return reduxHelpers.generatedPromiseActionReducer(
+        [{ ref: 'reportCapacity', type: rhsmTypes.GET_GRAPH_REPORT_CAPACITY_RHSM }],
+        state,
+        action
+      );
+  }
+};
 
 graphReducer.initialState = initialState;
 

--- a/src/redux/types/__tests__/__snapshots__/index.test.js.snap
+++ b/src/redux/types/__tests__/__snapshots__/index.test.js.snap
@@ -11,6 +11,9 @@ Object {
       "STATUS_4XX": "4XX",
       "STATUS_5XX": "5XX",
     },
+    "graph": Object {
+      "SET_GRAPH_LEGEND": "SET_GRAPH_LEGEND",
+    },
     "platform": Object {
       "PLATFORM_ADD_NOTIFICATION": "@@INSIGHTS-CORE/NOTIFICATIONS/ADD_NOTIFICATION",
       "PLATFORM_APP_NAME": "PLATFORM_APP_NAME",
@@ -36,6 +39,9 @@ Object {
       "USER_LOGOUT": "USER_LOGOUT",
     },
   },
+  "graphTypes": Object {
+    "SET_GRAPH_LEGEND": "SET_GRAPH_LEGEND",
+  },
   "platformTypes": Object {
     "PLATFORM_ADD_NOTIFICATION": "@@INSIGHTS-CORE/NOTIFICATIONS/ADD_NOTIFICATION",
     "PLATFORM_APP_NAME": "PLATFORM_APP_NAME",
@@ -49,6 +55,9 @@ Object {
     "app": Object {
       "STATUS_4XX": "4XX",
       "STATUS_5XX": "5XX",
+    },
+    "graph": Object {
+      "SET_GRAPH_LEGEND": "SET_GRAPH_LEGEND",
     },
     "platform": Object {
       "PLATFORM_ADD_NOTIFICATION": "@@INSIGHTS-CORE/NOTIFICATIONS/ADD_NOTIFICATION",
@@ -98,6 +107,9 @@ Object {
   "app": Object {
     "STATUS_4XX": "4XX",
     "STATUS_5XX": "5XX",
+  },
+  "graph": Object {
+    "SET_GRAPH_LEGEND": "SET_GRAPH_LEGEND",
   },
   "platform": Object {
     "PLATFORM_ADD_NOTIFICATION": "@@INSIGHTS-CORE/NOTIFICATIONS/ADD_NOTIFICATION",

--- a/src/redux/types/graphTypes.js
+++ b/src/redux/types/graphTypes.js
@@ -1,0 +1,12 @@
+const SET_GRAPH_LEGEND = 'SET_GRAPH_LEGEND';
+
+/**
+ * Graph action, reducer types.
+ *
+ * @type {{SET_GRAPH_LEGEND: string}}
+ */
+const graphTypes = {
+  SET_GRAPH_LEGEND
+};
+
+export { graphTypes as default, graphTypes, SET_GRAPH_LEGEND };

--- a/src/redux/types/index.js
+++ b/src/redux/types/index.js
@@ -1,13 +1,15 @@
 import { appTypes } from './appTypes';
+import { graphTypes } from './graphTypes';
 import { platformTypes } from './platformTypes';
 import { rhsmTypes } from './rhsmTypes';
 import { userTypes } from './userTypes';
 
 const reduxTypes = {
   app: appTypes,
+  graph: graphTypes,
   platform: platformTypes,
   rhsm: rhsmTypes,
   user: userTypes
 };
 
-export { reduxTypes as default, reduxTypes, appTypes, platformTypes, rhsmTypes, userTypes };
+export { reduxTypes as default, reduxTypes, appTypes, graphTypes, platformTypes, rhsmTypes, userTypes };

--- a/src/styles/_usage-graph.scss
+++ b/src/styles/_usage-graph.scss
@@ -11,10 +11,6 @@
     margin-top: -35px;
   }
 
-  .victory-legend-item:not(.pf-m-disabled) {
-    color: inherit;
-  }
-
   .victory-legend-icon {
     margin-right: 5px;
   }


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- feat(chartArea,graphCard): issues/283 interactive legend
   * chartArea, expose chart methods for interactivity, redraw
   * graphCard, pass chart methods to legend
   * graphCardChartLegend, apply redux state, add button click
   * graphReducer, apply legend toggle state
   * reduxTypes, graphTypes, set legend type
   * styling, allow button color

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- Gives the ability for a user to turn legend data facets on/off while updating the y axis domain.
   - Adds the ability to maintain the legend data facet toggles while switching granularity, this can also be added to the proof of concept c3 work.
- The custom legend works around Victory as started in #298 and utilizes JS callback structure to redraw the graph instead of trying to utilize Victory's event structure. 
   - The drawback to this appears to be a limit on the amount of interactivity that can be applied to the graph without adversely affecting the redraw speed, i.e. hovering over the legend to gain focus/blur of the different chart/graph facets appears to stutter.
   - The advantage appears as the ability for customized legends and behavior. And outside of potential Victory API breaking changes.

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. Interact with the legend and granularity selector to confirm legend toggles are maintained when switching granularity

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. Interact with the legend and granularity selector to confirm legend toggles are maintained when switching granularity

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
  
![Screen Shot 2020-06-03 at 2 17 14 PM](https://user-images.githubusercontent.com/3761375/83672887-02009180-a5a5-11ea-9732-49f94f0a4e51.png)

![Screen Shot 2020-06-03 at 2 17 28 PM](https://user-images.githubusercontent.com/3761375/83672903-09279f80-a5a5-11ea-816f-9fdb9a83b3eb.png)

![Jun-03-2020 14-19-25](https://user-images.githubusercontent.com/3761375/83673073-4e4bd180-a5a5-11ea-8b6b-974531bfd629.gif)



## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
#283 
#181
Relates #158
Relates #257 

@jeperry @rblackbu @bclarhk 