### PR TITLE
fix(userSelectors): issues/307 missing error check

### DIFF
--- a/src/redux/selectors/__tests__/__snapshots__/userSelectors.test.js.snap
+++ b/src/redux/selectors/__tests__/__snapshots__/userSelectors.test.js.snap
@@ -1,11 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`UserSelectors should not authorize a user when global errors exist: global errors, unauthorized 1`] = `
+Object {
+  "session": Object {
+    "admin": false,
+    "authorized": false,
+    "entitled": false,
+    "error": true,
+    "errorCodes": Array [
+      "loremIpsum",
+    ],
+    "errorMessage": "lorem ipsum",
+    "permissions": Array [],
+    "status": 403,
+  },
+}
+`;
+
 exports[`UserSelectors should pass data with administrator checks: administrator, and missing user data 1`] = `
 Object {
   "session": Object {
     "admin": true,
     "authorized": false,
     "entitled": false,
+    "error": false,
     "permissions": Array [],
   },
 }
@@ -17,6 +35,7 @@ Object {
     "admin": false,
     "authorized": false,
     "entitled": true,
+    "error": false,
     "permissions": Array [],
   },
 }
@@ -28,6 +47,7 @@ Object {
     "admin": false,
     "authorized": true,
     "entitled": false,
+    "error": false,
     "permissions": Array [
       Object {
         "definitions": undefined,
@@ -84,6 +104,7 @@ Object {
     "admin": false,
     "authorized": false,
     "entitled": false,
+    "error": false,
     "locale": "en-US",
     "permissions": Array [],
   },
@@ -96,6 +117,7 @@ Object {
     "admin": false,
     "authorized": false,
     "entitled": false,
+    "error": false,
     "permissions": Array [],
   },
 }

--- a/src/redux/selectors/__tests__/userSelectors.test.js
+++ b/src/redux/selectors/__tests__/userSelectors.test.js
@@ -20,6 +20,7 @@ describe('UserSelectors', () => {
         }
       }
     };
+
     expect(userSelectors.userSession(state)).toMatchSnapshot('existing state data');
   });
 
@@ -34,6 +35,7 @@ describe('UserSelectors', () => {
         }
       }
     };
+
     expect(userSelectors.userSession(state)).toMatchSnapshot('error state data');
   });
 
@@ -102,5 +104,46 @@ describe('UserSelectors', () => {
     };
 
     expect(userSelectors.userSession(state)).toMatchSnapshot('permissions, and missing user data');
+  });
+
+  it('should not authorize a user when global errors exist', () => {
+    const state = {
+      user: {
+        session: {
+          error: true,
+          errorCodes: ['loremIpsum'],
+          errorMessage: 'lorem ipsum',
+          status: 403,
+          fulfilled: true,
+          data: {
+            user: {
+              [platformApiTypes.PLATFORM_API_RESPONSE_USER_ENTITLEMENTS]: {
+                [helpers.UI_NAME]: {
+                  [platformApiTypes.PLATFORM_API_RESPONSE_USER_ENTITLEMENTS_APP_TYPES.ENTITLED]: true
+                }
+              },
+              [platformApiTypes.PLATFORM_API_RESPONSE_USER_IDENTITY]: {
+                [platformApiTypes.PLATFORM_API_RESPONSE_USER_IDENTITY_TYPES.USER]: {
+                  [platformApiTypes.PLATFORM_API_RESPONSE_USER_IDENTITY_USER_TYPES.ORG_ADMIN]: true
+                }
+              }
+            },
+            permissions: [
+              {
+                [platformApiTypes.PLATFORM_API_RESPONSE_USER_PERMISSION_TYPES.PERMISSION]: `${helpers.UI_NAME}:*:*`
+              },
+              {
+                [platformApiTypes.PLATFORM_API_RESPONSE_USER_PERMISSION_TYPES.PERMISSION]: `${helpers.UI_NAME}:*:read`
+              },
+              {
+                [platformApiTypes.PLATFORM_API_RESPONSE_USER_PERMISSION_TYPES.PERMISSION]: `${helpers.UI_NAME}:*:write`
+              }
+            ]
+          }
+        }
+      }
+    };
+
+    expect(userSelectors.userSession(state)).toMatchSnapshot('global errors, unauthorized');
   });
 });

--- a/src/redux/selectors/userSelectors.js
+++ b/src/redux/selectors/userSelectors.js
@@ -17,19 +17,20 @@ const userSession = state => ({
 /**
  * Create selector, transform combined state, props into a consumable graph/charting object.
  *
- * @type {{session: {entitled: boolean, permissions: Array, authorized: boolean, admin: boolean}}}
+ * @type {{session: {entitled: boolean, permissions: Array, authorized: boolean, admin: boolean, error: boolean}}}
  */
 const userSessionSelector = createSelector([userSession], response => {
-  const { fulfilled = false, data = {}, ...rest } = response || {};
+  const { error = false, fulfilled = false, data = {}, ...rest } = response || {};
   const updatedSession = {
     ...rest,
     admin: false,
     authorized: false,
     entitled: false,
+    error,
     permissions: []
   };
 
-  if (fulfilled) {
+  if (!error && fulfilled) {
     const { user = {}, permissions = [] } = data;
 
     const admin = _get(


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(userSelectors): issues/307 missing error check
   * userSelectors, missing error check, check for global errors

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- The issue appears as a sequence of events, originally the global error check was last and able to override the sequence. Moving the reducer check for authorization to last broke this sequence. This fix aims to allow either sequence to work by applying a consistent "error" check to authorization.
- Unit test snapshot has been applied to avoid this issue in the future

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. login with the standard environment user
1. delete the optin via the browser console by typing:
   - `curiosity.userServices.deleteAccountOptIn()`
   - hit enter
   - refresh the page, the user should now see the opt-in screen. if the user does not see the opt-in screen (below example image) this issue needs to be reinvestigated

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
<img width="1107" alt="Screen Shot 2020-06-09 at 11 26 32 AM" src="https://user-images.githubusercontent.com/3761375/84167361-1e3c7c80-aa44-11ea-859c-8b01db5379ed.png">


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
updates #307 