### PR TITLE
fix(graphCardChartLegend): issues/158 disable tooltips

### DIFF
--- a/src/components/graphCard/__tests__/__snapshots__/graphCardChartLegend.test.js.snap
+++ b/src/components/graphCard/__tests__/__snapshots__/graphCardChartLegend.test.js.snap
@@ -189,311 +189,126 @@ exports[`GraphCardChartLegend Component should handle variations in data when re
 
 exports[`GraphCardChartLegend Component should render a basic component: basic 1`] = `
 <Fragment>
-  <Tooltip
-    appendTo={[Function]}
-    aria="describedby"
-    boundary="window"
-    className=""
-    content={
-      <p>
-        t(curiosity-graph.loremIpsumLegendTooltip)
-      </p>
-    }
-    distance={-10}
-    enableFlip={true}
-    entryDelay={100}
-    exitDelay={0}
-    flipBehavior={
-      Array [
-        "top",
-        "right",
-        "bottom",
-        "left",
-        "top",
-        "right",
-        "bottom",
-      ]
-    }
-    id=""
-    isAppLauncher={false}
-    isContentLeftAligned={false}
-    isVisible={false}
-    key="curiosity-tooltip-loremIpsum"
-    maxWidth="18.75rem"
-    position="top"
-    tippyProps={Object {}}
-    trigger="mouseenter focus"
-    zIndex={9999}
-  >
-    <Component
-      className="victory-legend-item"
-      component="a"
-      icon={
-        <div
-          aria-hidden={true}
-          className="legend-icon"
-          style={
-            Object {
-              "backgroundColor": "#000000",
-              "visibility": "visible",
-            }
+  <Component
+    className="victory-legend-item"
+    component="a"
+    icon={
+      <div
+        aria-hidden={true}
+        className="legend-icon"
+        style={
+          Object {
+            "backgroundColor": "#000000",
+            "visibility": "visible",
           }
-        />
-      }
-      isDisabled={false}
-      key="curiosity-button-loremIpsum"
-      onClick={[Function]}
-      onKeyPress={[Function]}
-      tabIndex={0}
-      variant="link"
-    >
-      t(curiosity-graph.loremIpsumLabel, [object Object])
-    </Component>
-  </Tooltip>
+        }
+      />
+    }
+    isDisabled={false}
+    key="curiosity-button-loremIpsum"
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
+    variant="link"
+  >
+    t(curiosity-graph.loremIpsumLabel, [object Object])
+  </Component>
 </Fragment>
 `;
 
 exports[`GraphCardChartLegend Component should render basic data: data 1`] = `
 <Fragment>
-  <Tooltip
-    appendTo={[Function]}
-    aria="describedby"
-    boundary="window"
-    className=""
-    content={
-      <p>
-        t(curiosity-graph.loremIpsumLegendTooltip)
-      </p>
-    }
-    distance={-10}
-    enableFlip={true}
-    entryDelay={100}
-    exitDelay={0}
-    flipBehavior={
-      Array [
-        "top",
-        "right",
-        "bottom",
-        "left",
-        "top",
-        "right",
-        "bottom",
-      ]
-    }
-    id=""
-    isAppLauncher={false}
-    isContentLeftAligned={false}
-    isVisible={false}
-    key="curiosity-tooltip-loremIpsum"
-    maxWidth="18.75rem"
-    position="top"
-    tippyProps={Object {}}
-    trigger="mouseenter focus"
-    zIndex={9999}
-  >
-    <Component
-      className="victory-legend-item"
-      component="a"
-      icon={
-        <div
-          aria-hidden={true}
-          className="legend-icon"
-          style={
-            Object {
-              "backgroundColor": "#000000",
-              "visibility": "visible",
-            }
+  <Component
+    className="victory-legend-item"
+    component="a"
+    icon={
+      <div
+        aria-hidden={true}
+        className="legend-icon"
+        style={
+          Object {
+            "backgroundColor": "#000000",
+            "visibility": "visible",
           }
-        />
-      }
-      isDisabled={false}
-      key="curiosity-button-loremIpsum"
-      onClick={[Function]}
-      onKeyPress={[Function]}
-      tabIndex={0}
-      variant="link"
-    >
-      t(curiosity-graph.loremIpsumLabel, [object Object])
-    </Component>
-  </Tooltip>
-  <Tooltip
-    appendTo={[Function]}
-    aria="describedby"
-    boundary="window"
-    className=""
-    content={
-      <p>
-        t(curiosity-graph.ametConsecteturLegendTooltip)
-      </p>
+        }
+      />
     }
-    distance={-10}
-    enableFlip={true}
-    entryDelay={100}
-    exitDelay={0}
-    flipBehavior={
-      Array [
-        "top",
-        "right",
-        "bottom",
-        "left",
-        "top",
-        "right",
-        "bottom",
-      ]
-    }
-    id=""
-    isAppLauncher={false}
-    isContentLeftAligned={false}
-    isVisible={false}
-    key="curiosity-tooltip-ametConsectetur"
-    maxWidth="18.75rem"
-    position="top"
-    tippyProps={Object {}}
-    trigger="mouseenter focus"
-    zIndex={9999}
+    isDisabled={false}
+    key="curiosity-button-loremIpsum"
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
+    variant="link"
   >
-    <Component
-      className="victory-legend-item"
-      component="a"
-      icon={
-        <EyeSlashIcon
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
-          title={null}
-        />
-      }
-      isDisabled={true}
-      key="curiosity-button-ametConsectetur"
-      onClick={[Function]}
-      onKeyPress={[Function]}
-      tabIndex={0}
-      variant="link"
-    >
-      t(curiosity-graph.ametConsecteturLabel, [object Object])
-    </Component>
-  </Tooltip>
-  <Tooltip
-    appendTo={[Function]}
-    aria="describedby"
-    boundary="window"
-    className=""
-    content={
-      <p>
-        t(curiosity-graph.thresholdLegendTooltip)
-      </p>
+    t(curiosity-graph.loremIpsumLabel, [object Object])
+  </Component>
+  <Component
+    className="victory-legend-item"
+    component="a"
+    icon={
+      <EyeSlashIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+        title={null}
+      />
     }
-    distance={-10}
-    enableFlip={true}
-    entryDelay={100}
-    exitDelay={0}
-    flipBehavior={
-      Array [
-        "top",
-        "right",
-        "bottom",
-        "left",
-        "top",
-        "right",
-        "bottom",
-      ]
-    }
-    id=""
-    isAppLauncher={false}
-    isContentLeftAligned={false}
-    isVisible={false}
-    key="curiosity-tooltip-dolorSit"
-    maxWidth="18.75rem"
-    position="top"
-    tippyProps={Object {}}
-    trigger="mouseenter focus"
-    zIndex={9999}
+    isDisabled={true}
+    key="curiosity-button-ametConsectetur"
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
+    variant="link"
   >
-    <Component
-      className="victory-legend-item"
-      component="a"
-      icon={
-        <hr
-          aria-hidden={true}
-          className="threshold-legend-icon"
-          style={
-            Object {
-              "borderTopColor": "#ff0000",
-              "visibility": "visible",
-            }
+    t(curiosity-graph.ametConsecteturLabel, [object Object])
+  </Component>
+  <Component
+    className="victory-legend-item"
+    component="a"
+    icon={
+      <hr
+        aria-hidden={true}
+        className="threshold-legend-icon"
+        style={
+          Object {
+            "borderTopColor": "#ff0000",
+            "visibility": "visible",
           }
-        />
-      }
-      isDisabled={false}
-      key="curiosity-button-dolorSit"
-      onClick={[Function]}
-      onKeyPress={[Function]}
-      tabIndex={0}
-      variant="link"
-    >
-      t(curiosity-graph.thresholdLabel)
-    </Component>
-  </Tooltip>
-  <Tooltip
-    appendTo={[Function]}
-    aria="describedby"
-    boundary="window"
-    className=""
-    content={
-      <p>
-        t(curiosity-graph.thresholdLegendTooltip)
-      </p>
+        }
+      />
     }
-    distance={-10}
-    enableFlip={true}
-    entryDelay={100}
-    exitDelay={0}
-    flipBehavior={
-      Array [
-        "top",
-        "right",
-        "bottom",
-        "left",
-        "top",
-        "right",
-        "bottom",
-      ]
-    }
-    id=""
-    isAppLauncher={false}
-    isContentLeftAligned={false}
-    isVisible={false}
-    key="curiosity-tooltip-nonCursus"
-    maxWidth="18.75rem"
-    position="top"
-    tippyProps={Object {}}
-    trigger="mouseenter focus"
-    zIndex={9999}
+    isDisabled={false}
+    key="curiosity-button-dolorSit"
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
+    variant="link"
   >
-    <Component
-      className="victory-legend-item"
-      component="a"
-      icon={
-        <hr
-          aria-hidden={true}
-          className="threshold-legend-icon"
-          style={
-            Object {
-              "borderTopColor": "#ff0000",
-              "visibility": "visible",
-            }
+    t(curiosity-graph.thresholdLabel)
+  </Component>
+  <Component
+    className="victory-legend-item"
+    component="a"
+    icon={
+      <hr
+        aria-hidden={true}
+        className="threshold-legend-icon"
+        style={
+          Object {
+            "borderTopColor": "#ff0000",
+            "visibility": "visible",
           }
-        />
-      }
-      isDisabled={false}
-      key="curiosity-button-nonCursus"
-      onClick={[Function]}
-      onKeyPress={[Function]}
-      tabIndex={0}
-      variant="link"
-    >
-      t(curiosity-graph.thresholdLabel)
-    </Component>
-  </Tooltip>
+        }
+      />
+    }
+    isDisabled={false}
+    key="curiosity-button-nonCursus"
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={0}
+    variant="link"
+  >
+    t(curiosity-graph.thresholdLabel)
+  </Component>
 </Fragment>
 `;

--- a/src/components/graphCard/graphCardChartLegend.js
+++ b/src/components/graphCard/graphCardChartLegend.js
@@ -131,16 +131,17 @@ class GraphCardChartLegend extends React.Component {
             t(`curiosity-graph.${id}Label`, { product }) ||
             t(`curiosity-graph.noLabel`, { product });
 
-          const tooltipContent =
-            (isThreshold && t(`curiosity-graph.thresholdLegendTooltip`)) || t(`curiosity-graph.${id}LegendTooltip`);
+          // ToDo: Disabled tooltip content, reactivate accordingly, issues/158
+          // const tooltipContent =
+          //  (isThreshold && t(`curiosity-graph.thresholdLegendTooltip`)) || t(`curiosity-graph.${id}LegendTooltip`);
 
           return this.renderLegendItem({
             chartId: id,
             color: stroke,
             labelContent,
             isDisabled,
-            isThreshold,
-            tooltipContent
+            isThreshold
+            // tooltipContent
           });
         })}
       </React.Fragment>

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -81,7 +81,6 @@ msgid \\"curiosity-graph.thresholdLabel\\"
 msgstr \\"\\"
 
 #: src/components/c3GraphCard/c3GraphCard.js:93
-#: src/components/graphCard/graphCardChartLegend.js:135
 msgid \\"curiosity-graph.thresholdLegendTooltip\\"
 msgstr \\"\\"
 


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(graphCardChartLegend): issues/158 disable tooltips

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- Temporary disable for legend chart tooltips while the copy is being worked through.

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. hover over the legend, no tooltips should appear

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. hover over the legend, no tooltips should appear

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
#158 