### PR TITLE
fix(build,chartArea): npm update for victory charts

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,9 +109,9 @@
     "redux-promise-middleware": "^6.1.2",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
-    "victory": "^34.2.0",
-    "victory-core": "^34.2.0",
-    "victory-legend": "^34.2.0"
+    "victory": "^34.3.11",
+    "victory-core": "^34.3.8",
+    "victory-legend": "^34.3.8"
   },
   "devDependencies": {
     "apidoc-mock": "^3.0.2",

--- a/src/components/chartArea/__tests__/__snapshots__/chartArea.test.js.snap
+++ b/src/components/chartArea/__tests__/__snapshots__/chartArea.test.js.snap
@@ -765,6 +765,194 @@ Object {
 }
 `;
 
+exports[`ChartArea Component should handle custom chart tooltips: componentTooltip 1`] = `
+<ContextProvider
+  value={
+    Object {
+      "portalDeregister": [Function],
+      "portalRegister": [Function],
+      "portalUpdate": [Function],
+    }
+  }
+>
+  <div
+    className="VictoryContainer"
+    style={
+      Object {
+        "height": "auto",
+        "pointerEvents": "none",
+        "position": "relative",
+        "touchAction": "none",
+        "width": "100%",
+      }
+    }
+  >
+    <svg
+      role="img"
+      style={
+        Object {
+          "height": "auto",
+          "pointerEvents": "all",
+          "width": "100%",
+        }
+      }
+      viewBox="0 0 undefined undefined"
+    />
+    <div
+      style={
+        Object {
+          "height": "auto",
+          "left": 0,
+          "position": "absolute",
+          "top": 0,
+          "width": "100%",
+          "zIndex": 99,
+        }
+      }
+    >
+      <Portal
+        style={
+          Object {
+            "height": "auto",
+            "overflow": "visible",
+            "width": "100%",
+          }
+        }
+        viewBox="0 0 undefined undefined"
+      />
+    </div>
+  </div>
+</ContextProvider>
+`;
+
+exports[`ChartArea Component should handle custom chart tooltips: custom tooltip, post-props chart 1`] = `
+<div
+  className="uxui-curiosity__modal uxui-curiosity__modal--loading"
+  id="curiosity-chartarea"
+>
+  <Chart
+    animate={
+      Object {
+        "duration": 0,
+      }
+    }
+    containerComponent={
+      <VictoryVoronoiCursorContainer
+        activateData={true}
+        activateLabels={true}
+        className="VictoryContainer"
+        cursorComponent={
+          <LineSegment
+            lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
+          />
+        }
+        cursorDimension="x"
+        cursorLabelComponent={
+          <VictoryLabel
+            capHeight={0.71}
+            direction="inherit"
+            lineHeight={1}
+            textComponent={<Text />}
+            tspanComponent={<TSpan />}
+          />
+        }
+        cursorLabelOffset={
+          Object {
+            "x": 5,
+            "y": -10,
+          }
+        }
+        labelComponent={<FlyoutComponent />}
+        labels={[Function]}
+        portalComponent={<Portal />}
+        portalZIndex={99}
+        responsive={true}
+        voronoiDimension="x"
+        voronoiPadding={60}
+      />
+    }
+    domain={
+      Object {
+        "y": Array [
+          0,
+          20,
+        ],
+      }
+    }
+    padding={
+      Object {
+        "bottom": 75,
+        "left": 50,
+        "right": 50,
+        "top": 50,
+      }
+    }
+    themeColor="blue"
+    width={0}
+  >
+    <ChartAxis
+      animate={false}
+      fixLabelOverlap={false}
+      tickFormat={[Function]}
+      tickValues={
+        Array [
+          1,
+        ]
+      }
+    />
+    <ChartAxis
+      animate={false}
+      dependentAxis={true}
+      showGrid={true}
+    />
+    <ChartThreshold
+      animate={false}
+      data={
+        Array [
+          Object {
+            "x": 1,
+            "xAxisLabel": "1 x axis label",
+            "y": 10,
+          },
+        ]
+      }
+      interpolation="step"
+      key="generatedid-"
+      name="chartArea-1-threshold"
+      style={
+        Object {
+          "data": Object {},
+        }
+      }
+    />
+    <ChartStack>
+      <ChartArea
+        animate={false}
+        data={
+          Array [
+            Object {
+              "x": 1,
+              "xAxisLabel": "1 x axis label",
+              "y": 0,
+            },
+          ]
+        }
+        interpolation="natural"
+        key="generatedid-"
+        name="chartArea-0-area"
+        style={
+          Object {
+            "data": Object {},
+          }
+        }
+      />
+    </ChartStack>
+  </Chart>
+</div>
+`;
+
 exports[`ChartArea Component should handle custom chart tooltips: getTooltipData:after function 1`] = `
 Array [
   Object {
@@ -814,54 +1002,58 @@ Array [
         },
       },
     },
-    "tooltip": Object {
-      "dataSets": Array [
-        Object {
-          "data": Array [
-            Object {
-              "x": 1,
-              "xAxisLabel": "1 x axis label",
-              "y": 0,
-            },
-          ],
-          "id": "loremGraph",
-          "interpolation": "natural",
-          "isStacked": true,
-        },
-        Object {
-          "data": Array [
-            Object {
+    "tooltip": <div
+      id="custom-tooltip"
+    >
+      Object {
+        "dataSets": Array [
+          Object {
+            "data": Array [
+              Object {
+                "x": 1,
+                "xAxisLabel": "1 x axis label",
+                "y": 0,
+              },
+            ],
+            "id": "loremGraph",
+            "interpolation": "natural",
+            "isStacked": true,
+          },
+          Object {
+            "data": Array [
+              Object {
+                "x": 1,
+                "xAxisLabel": "1 x axis label",
+                "y": 10,
+              },
+            ],
+            "id": "ipsumGraph",
+            "isThreshold": true,
+          },
+        ],
+        "index": 0,
+        "itemsByKey": Object {
+          "ipsumGraph": Object {
+            "color": "",
+            "data": Object {
               "x": 1,
               "xAxisLabel": "1 x axis label",
               "y": 10,
             },
-          ],
-          "id": "ipsumGraph",
-          "isThreshold": true,
-        },
-      ],
-      "index": 0,
-      "itemsByKey": Object {
-        "ipsumGraph": Object {
-          "color": "",
-          "data": Object {
-            "x": 1,
-            "xAxisLabel": "1 x axis label",
-            "y": 10,
+          },
+          "loremGraph": Object {
+            "color": "",
+            "data": Object {
+              "x": 1,
+              "xAxisLabel": "1 x axis label",
+              "y": 0,
+            },
           },
         },
-        "loremGraph": Object {
-          "color": "",
-          "data": Object {
-            "x": 1,
-            "xAxisLabel": "1 x axis label",
-            "y": 0,
-          },
-        },
-      },
-      "x": 1,
-      "y": 0,
-    },
+        "x": 1,
+        "y": 0,
+      }
+    </div>,
     "x": 1,
     "y": null,
   },

--- a/src/components/chartArea/__tests__/chartArea.test.js
+++ b/src/components/chartArea/__tests__/chartArea.test.js
@@ -296,15 +296,19 @@ describe('ChartArea Component', () => {
     expect(component.instance().getTooltipData()).toMatchSnapshot('getTooltipData:after function');
 
     component.setProps({
-      chartTooltip: propsObj => propsObj.datum
+      chartTooltip: propsObj => <div id="custom-tooltip">{propsObj.datum}</div>
     });
     expect(component.instance().getTooltipData()).toMatchSnapshot('getTooltipData:after node');
 
     // check renderTooltip
-    component.setProps({
-      chartTooltip: propsObj => propsObj.datum
-    });
-    expect(component.instance().renderTooltip()).toMatchSnapshot('renderTooltip: should return a custom tooltip');
+    const renderTooltip = component.instance().renderTooltip();
+    expect(renderTooltip).toMatchSnapshot('renderTooltip: should return a custom tooltip');
+
+    const componentTooltip = shallow(renderTooltip);
+    expect(componentTooltip).toMatchSnapshot('componentTooltip');
+
+    // confirm chart output
+    expect(component).toMatchSnapshot('custom tooltip, post-props chart');
   });
 
   it('should handle custom chart legends', () => {

--- a/src/components/chartArea/chartArea.js
+++ b/src/components/chartArea/chartArea.js
@@ -286,7 +286,16 @@ class ChartArea extends React.Component {
   }
 
   /**
-   * Return a chart/graph tooltip Victory container component to allow custom tooltips.
+   * ToDo: monitor Victory charts release version increment around Voronoi container attributes.
+   * Future updates could lead to additional unexpected behavior. Victory charts released a patch/fix
+   * around attribute behavior for Voronoi containers. The behavior was already "unexpected" in that there appears
+   * to be a need to provide the "label" attribute when using the "labelComponent" attribute, even if "label" is
+   * just a pass-through. Providing `label={() => ''}` was a work-around, that is now `label={obj => obj}`. See
+   * - https://github.com/FormidableLabs/victory/blob/master/CHANGELOG.md#3436-2020-05-18
+   * - https://github.com/FormidableLabs/victory/pull/1581
+   */
+  /**
+   * Return a chart/graph tooltip Victory container component to allow custom HTML tooltips.
    *
    * @returns {Node}
    */
@@ -351,7 +360,7 @@ class ChartArea extends React.Component {
     return (
       <VictoryVoronoiCursorContainer
         cursorDimension="x"
-        labels={() => ''}
+        labels={obj => obj}
         labelComponent={<FlyoutComponent />}
         voronoiDimension="x"
         voronoiPadding={60}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4319,6 +4319,11 @@ d3-array@1, d3-array@^1.1.1, d3-array@^1.2.0:
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
   integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
 
+d3-array@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.4.0.tgz#87f8b9ad11088769c82b5ea846bcb1cc9393f242"
+  integrity sha512-KQ41bAF2BMakf/HdKT865ALd4cgND6VcIztVQZUTt0+BH3RWy6ZYnHghVXf6NFjt2ritLr8H1T8LreAAlfiNcw==
+
 d3-axis@1:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-1.0.12.tgz#cdf20ba210cfbb43795af33756886fb3638daac9"
@@ -13132,15 +13137,15 @@ victory-area@^33.1.7:
     prop-types "^15.5.8"
     victory-core "^33.1.7"
 
-victory-area@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/victory-area/-/victory-area-34.2.0.tgz#f8dd570ccd6bef45c55df62aff8d07615290317c"
-  integrity sha512-ArjYXf73S96vRTItI3tF6YuqXTiNnYRDw16m2qVUjhGvujusAfvWYknbrPiQhUcC4SSofvwPZy7SQEJeQCe+Ew==
+victory-area@^34.3.8:
+  version "34.3.8"
+  resolved "https://registry.yarnpkg.com/victory-area/-/victory-area-34.3.8.tgz#4e07da6250af6729ca96c87826430ecb18abe5e4"
+  integrity sha512-iN5jqYxQ2qE5fGCWgJJ2YoObRgcY4h23GiFHee8OG8dKLDCQvsR4/ZKdI4I78iLrIJf4eHeKWW+1xXheoG6A6w==
   dependencies:
     d3-shape "^1.2.0"
     lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^34.2.0"
+    victory-core "^34.3.8"
 
 victory-axis@^33.1.7:
   version "33.1.7"
@@ -13151,14 +13156,14 @@ victory-axis@^33.1.7:
     prop-types "^15.5.8"
     victory-core "^33.1.7"
 
-victory-axis@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/victory-axis/-/victory-axis-34.2.0.tgz#33b7cc1e49e9041ec8761ab646b65b6d1ccbf091"
-  integrity sha512-bXB1/jo6/FPOL9wU0CnMCS09lJw+zLLm1S9lNPo3PJ1EQxhSvB9rGJGcpIykSWFUatmpsgfWH/tl4A7qvUvD6Q==
+victory-axis@^34.3.8:
+  version "34.3.8"
+  resolved "https://registry.yarnpkg.com/victory-axis/-/victory-axis-34.3.8.tgz#a0754a4e4d4986898fdb0bd5cd204b94d5866c06"
+  integrity sha512-GD0/dJAV7hY22owiC3rKalJkf6C8WZsuu3HgzBYxySr7aiQgcJDhJ+T2DIH2DH7zUQi0FeD7lA1dyDagYdcnGA==
   dependencies:
     lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^34.2.0"
+    victory-core "^34.3.8"
 
 victory-bar@^33.1.7:
   version "33.1.7"
@@ -13170,15 +13175,15 @@ victory-bar@^33.1.7:
     prop-types "^15.5.8"
     victory-core "^33.1.7"
 
-victory-bar@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/victory-bar/-/victory-bar-34.2.0.tgz#031e2e369b8e3a64fbfe19d74cd28b420335984c"
-  integrity sha512-cJSi2+D4CekSP8IcbYsW7Otl3El55TEfZIV9NSZiolKT66yWz62KkOP4nQpB2PmSX6RyceBZLgiSsk4ZpDy6rQ==
+victory-bar@^34.3.8:
+  version "34.3.8"
+  resolved "https://registry.yarnpkg.com/victory-bar/-/victory-bar-34.3.8.tgz#9dee4ef85505fc83c74102d35964d2e20d9d43fb"
+  integrity sha512-0LBT/DrScUTwgA1wkmZ1dI34Jt0sRM/1f+LKl92GAFQIQiwznzOFs0KBhywExf7weYw68mhVA6iUvwK+4uf17A==
   dependencies:
     d3-shape "^1.2.0"
     lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^34.2.0"
+    victory-core "^34.3.8"
 
 victory-box-plot@^33.1.7:
   version "33.1.7"
@@ -13190,15 +13195,15 @@ victory-box-plot@^33.1.7:
     prop-types "^15.5.8"
     victory-core "^33.1.7"
 
-victory-box-plot@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/victory-box-plot/-/victory-box-plot-34.2.0.tgz#f7b981a4f2958abed93cc43a02a3ed1fe232fa04"
-  integrity sha512-7CkN3xJ82hgEPIYKnu8LVBy6PMqitKjiG3OCWYOW/D4LenHAte4QcmRHov7KDX5pz25Cb5g46UAEJ8VazKsTyg==
+victory-box-plot@^34.3.8:
+  version "34.3.8"
+  resolved "https://registry.yarnpkg.com/victory-box-plot/-/victory-box-plot-34.3.8.tgz#0aeeba93e4dcf4ebd787380f6e535acad479b41c"
+  integrity sha512-Y0n6tVeUZrLbUkK69rJiyY0rcLMAnbUrQ2kqq8d0JF+UrYfvZQBvr6M4IVVrI0zoGUpqmx7ach5VTD6g6VEiug==
   dependencies:
     d3-array "^1.2.0"
     lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^34.2.0"
+    victory-core "^34.3.8"
 
 victory-brush-container@^33.1.7:
   version "33.1.7"
@@ -13209,15 +13214,15 @@ victory-brush-container@^33.1.7:
     prop-types "^15.5.8"
     victory-core "^33.1.7"
 
-victory-brush-container@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/victory-brush-container/-/victory-brush-container-34.2.0.tgz#c1e410be8f5bfa647912bbd0ed4237ebb57ba3ec"
-  integrity sha512-sef7M8BMgG1da/Ep/TXwleKLFXNpf+OsuagCZIzrDF4FdWDEmZv4adevv1FYMQrfvPwdEEIlTECse0P6roW3gQ==
+victory-brush-container@^34.3.8:
+  version "34.3.8"
+  resolved "https://registry.yarnpkg.com/victory-brush-container/-/victory-brush-container-34.3.8.tgz#83d607eb896c21694926295cf248063de6d605b7"
+  integrity sha512-/vQy/yEmoiUkuzVKBdMIevpez0JsqcTqFdRQtXbRmgK+1Rxt6z0HgtQazGEm7K80xHw+2yajSyG5G68ksjFjqg==
   dependencies:
     lodash "^4.17.15"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-core "^34.2.0"
+    victory-core "^34.3.8"
 
 victory-brush-line@^33.1.7:
   version "33.1.7"
@@ -13228,15 +13233,15 @@ victory-brush-line@^33.1.7:
     prop-types "^15.5.8"
     victory-core "^33.1.7"
 
-victory-brush-line@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/victory-brush-line/-/victory-brush-line-34.2.0.tgz#6fc3c611babaf01d5f57c7564aaef2cca43fb2d6"
-  integrity sha512-PW3icLL6f7Ql5K/7mQAGGU9bgnOFVsq7g4tIOAlmTSM1nPl4AqhVfz2iQThHajnqcP4PJgDAJEp22H0uodsAag==
+victory-brush-line@^34.3.8:
+  version "34.3.8"
+  resolved "https://registry.yarnpkg.com/victory-brush-line/-/victory-brush-line-34.3.8.tgz#5fd6d33d235dbc25346772efb9b2aecd289703fc"
+  integrity sha512-mY7ozEgTqvJCxxNhyHhOLk6M3CPDDFJKuUFT9B2vmQyPU5/EmFQuErVo6bl1hWkj1nzm5q916qt6GsVPC3mTdg==
   dependencies:
     lodash "^4.17.15"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-core "^34.2.0"
+    victory-core "^34.3.8"
 
 victory-candlestick@^33.1.7:
   version "33.1.7"
@@ -13247,14 +13252,14 @@ victory-candlestick@^33.1.7:
     prop-types "^15.5.8"
     victory-core "^33.1.7"
 
-victory-candlestick@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/victory-candlestick/-/victory-candlestick-34.2.0.tgz#3826761265b6d9b5ee77e094c1bd833b78ed6c28"
-  integrity sha512-PZyFjkrhEvbdqOdijPYX1uuZjz8RT+aEIJez7ovoS3dYncQ1XWnkIH3qJxNCAfOOVFG5iqOAj2gkntXQaSgzJg==
+victory-candlestick@^34.3.8:
+  version "34.3.8"
+  resolved "https://registry.yarnpkg.com/victory-candlestick/-/victory-candlestick-34.3.8.tgz#c16d918044f864c065f5c9c93d55c9f4aeb479ef"
+  integrity sha512-qvaEJsNPjKN25yu9TcH8+PZ2yBTOXvgH9Faup37jeIoKXtTVaHI1uYuZcLlp542tSbAnq/5EkQTiPXCx/C31Lg==
   dependencies:
     lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^34.2.0"
+    victory-core "^34.3.8"
 
 victory-chart@^33.1.7:
   version "33.1.7"
@@ -13269,18 +13274,18 @@ victory-chart@^33.1.7:
     victory-polar-axis "^33.1.7"
     victory-shared-events "^33.1.7"
 
-victory-chart@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/victory-chart/-/victory-chart-34.2.0.tgz#515c0f11f1668ba2e2a1a5295906f25daf75c6d2"
-  integrity sha512-bklmzjbmH7pu3UScDZ3HDlAHrLS6ha4q7UKFnJAfqFhk4Jke4JyjXg5fY25xsz4IqrYPtwvcxc0tnQemgDM1FQ==
+victory-chart@^34.3.11:
+  version "34.3.11"
+  resolved "https://registry.yarnpkg.com/victory-chart/-/victory-chart-34.3.11.tgz#308d62a836c252b7be0546ec4ef83c9608bed661"
+  integrity sha512-Fj9xWzS9649addJm9pd3pxVRoiDHoNx4p9yNLwiOgSSSPrJjJd7okGk+q5fxfVyVbztMXKsuJZ5C1OJ8qanDWQ==
   dependencies:
     lodash "^4.17.15"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-axis "^34.2.0"
-    victory-core "^34.2.0"
-    victory-polar-axis "^34.2.0"
-    victory-shared-events "^34.2.0"
+    victory-axis "^34.3.8"
+    victory-core "^34.3.8"
+    victory-polar-axis "^34.3.8"
+    victory-shared-events "^34.3.9"
 
 victory-core@^33.0.1, victory-core@^33.1.7:
   version "33.1.7"
@@ -13296,10 +13301,10 @@ victory-core@^33.0.1, victory-core@^33.1.7:
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
 
-victory-core@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/victory-core/-/victory-core-34.2.0.tgz#bbcfb465bf7ffe9b3a3c24a338cef9043feda3ff"
-  integrity sha512-7Wrysfcz8mxZFopbWb+ydFNvHDPb2Xs7+OnF5aWY64JwKEKwVBffvtcD0Yyma0Dch/zAyOEOYXyd+ddDVJ+jjw==
+victory-core@^34.3.8:
+  version "34.3.8"
+  resolved "https://registry.yarnpkg.com/victory-core/-/victory-core-34.3.8.tgz#86c951599416c4ddd0f6e8bee7214baab0b8d478"
+  integrity sha512-m3xRt05VywEb3rgAzDAZ1pgWcjeyazbRzLLmXyrS+78U/AkmvZFjgq+26o+3+tqD7s7O4jvSeFqg0XmVi51+EQ==
   dependencies:
     d3-ease "^1.0.0"
     d3-interpolate "^1.1.1"
@@ -13323,18 +13328,18 @@ victory-create-container@^33.1.7:
     victory-voronoi-container "^33.1.7"
     victory-zoom-container "^33.1.7"
 
-victory-create-container@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/victory-create-container/-/victory-create-container-34.2.0.tgz#8210b2cba8a0180cbb5c6799cf58fe963071a02c"
-  integrity sha512-LCnWvU3Cs4igGr9xjq/RJdE0A0FvhrVJ7g1jgAjATiQFVn7CJmwx/hg/8AQmno/nYV50uKDS/kgE5Z0aFDlVTw==
+victory-create-container@^34.3.10:
+  version "34.3.10"
+  resolved "https://registry.yarnpkg.com/victory-create-container/-/victory-create-container-34.3.10.tgz#e024db9755224a14ccc7434ab703be7cfc99ef55"
+  integrity sha512-JUlUHfw3Lzw8as8kyYlj2sFkrU7ER+kC/bSGDUIyYZ9ChVdXc4xy/9DzgXA/lswp5JhE92p+TGaDXToUn8UygA==
   dependencies:
     lodash "^4.17.15"
-    victory-brush-container "^34.2.0"
-    victory-core "^34.2.0"
-    victory-cursor-container "^34.2.0"
-    victory-selection-container "^34.2.0"
-    victory-voronoi-container "^34.2.0"
-    victory-zoom-container "^34.2.0"
+    victory-brush-container "^34.3.8"
+    victory-core "^34.3.8"
+    victory-cursor-container "^34.3.10"
+    victory-selection-container "^34.3.8"
+    victory-voronoi-container "^34.3.8"
+    victory-zoom-container "^34.3.8"
 
 victory-cursor-container@^33.1.7:
   version "33.1.7"
@@ -13345,14 +13350,14 @@ victory-cursor-container@^33.1.7:
     prop-types "^15.5.8"
     victory-core "^33.1.7"
 
-victory-cursor-container@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/victory-cursor-container/-/victory-cursor-container-34.2.0.tgz#3fec4fff07c64a90cec520b0ddba0842d185b25a"
-  integrity sha512-JbDN3JxumuOcxW2YHtQBzdQ4ttowER9d6yqi/6NmOY/PhNl+U+keofHWL3K9pCCqL3nJT9i3F3zozZtAtkk7EQ==
+victory-cursor-container@^34.3.10:
+  version "34.3.10"
+  resolved "https://registry.yarnpkg.com/victory-cursor-container/-/victory-cursor-container-34.3.10.tgz#708a7c15bf1e172d797103e8ebf8f273103529e7"
+  integrity sha512-Gve4i6fjhklCTW/k+RYZBf6UBAq4M/1HA32KEa/TtrQVaewLUu7O564ndcQDCqWiQEIBjKdSbEfgiq6fqT9zag==
   dependencies:
     lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^34.2.0"
+    victory-core "^34.3.8"
 
 victory-errorbar@^33.1.7:
   version "33.1.7"
@@ -13363,14 +13368,14 @@ victory-errorbar@^33.1.7:
     prop-types "^15.5.8"
     victory-core "^33.1.7"
 
-victory-errorbar@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/victory-errorbar/-/victory-errorbar-34.2.0.tgz#af5623e06e6421c9ada7a60ba568431ce520cdc5"
-  integrity sha512-u0RCadFD4779aOYXfXl46YplwoD4lRuITqIU3eVCeEeLtynS8anU2wAfbrT2VgBaaWrqFCsu9cjfXkVmN0EzUQ==
+victory-errorbar@^34.3.8:
+  version "34.3.8"
+  resolved "https://registry.yarnpkg.com/victory-errorbar/-/victory-errorbar-34.3.8.tgz#23c042c667e85f2d677dee959644e9825ac513d8"
+  integrity sha512-AIHK3LMj3HapFQthls58C6oma0reDmCNFJoqhor+9LFC0KTCsCrIZXFthSyDtzT+arOxuB6vu3j4ayOGXsurkA==
   dependencies:
     lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^34.2.0"
+    victory-core "^34.3.8"
 
 victory-group@^33.1.7:
   version "33.1.7"
@@ -13382,16 +13387,29 @@ victory-group@^33.1.7:
     react-fast-compare "^2.0.0"
     victory-core "^33.1.7"
 
-victory-group@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/victory-group/-/victory-group-34.2.0.tgz#b5d8fd43e1d07a1c75ca845342136df01232f54c"
-  integrity sha512-ZE0ERmoVUCx1wXwXTCYyfAh5Gfz4KajOvT3is06dsipxlks1TkvSgB1WgaBezxlPVnYmCCee1TEgEbvtyrU8tA==
+victory-group@^34.3.10:
+  version "34.3.10"
+  resolved "https://registry.yarnpkg.com/victory-group/-/victory-group-34.3.10.tgz#c25ac1e888f95f6284226bcf8b04744d604b7500"
+  integrity sha512-PAUjqs5O+lPc50ZB9/TK7dx/ICCB0/jscl9ZwjxcpogfQhXL/hDnOCoaF+TpH9KuvK4Tth1DQIVzw7TaUxeeWA==
   dependencies:
     lodash "^4.17.15"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-core "^34.2.0"
-    victory-shared-events "^34.2.0"
+    victory-core "^34.3.8"
+    victory-shared-events "^34.3.9"
+
+victory-histogram@^34.3.8:
+  version "34.3.8"
+  resolved "https://registry.yarnpkg.com/victory-histogram/-/victory-histogram-34.3.8.tgz#b278f957300120ca1236413d276d7ee8fd7d55b9"
+  integrity sha512-MVstAEDkWNJ6d5obAgp2TSoex+GYsXToBcgR0QMEJPj2TAKAetrUOM94H/cBzjbSQG6xo+rdNM/Ena1Sqmn2cQ==
+  dependencies:
+    d3-array "^2.4.0"
+    d3-scale "^1.0.0"
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+    victory-bar "^34.3.8"
+    victory-core "^34.3.8"
 
 victory-legend@^33.0.1, victory-legend@^33.1.7:
   version "33.1.7"
@@ -13402,14 +13420,14 @@ victory-legend@^33.0.1, victory-legend@^33.1.7:
     prop-types "^15.5.8"
     victory-core "^33.1.7"
 
-victory-legend@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/victory-legend/-/victory-legend-34.2.0.tgz#f8918a0cb08b3d8c1bfeb024db96aa3f7d33f9e3"
-  integrity sha512-JXyEy+DtVmlCgKLHAzxAuXIzOaDWN0zA+Llj599RydCsJ2pTU01BlwkrotmEAh+ucg4LNGlBG4EeyefBK963Qw==
+victory-legend@^34.3.8:
+  version "34.3.8"
+  resolved "https://registry.yarnpkg.com/victory-legend/-/victory-legend-34.3.8.tgz#bed74657cf13cb02fc49fb4825893ab854df1d1a"
+  integrity sha512-FZRCK2rETIUIS9rSbLPBgvwTetKfnT/MwvOnTG+wD29fio7cHloGHHAhxbTbhFFcs9AQRKZVpgsOA+nlb4Byew==
   dependencies:
     lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^34.2.0"
+    victory-core "^34.3.8"
 
 victory-line@^33.1.7:
   version "33.1.7"
@@ -13421,15 +13439,15 @@ victory-line@^33.1.7:
     prop-types "^15.5.8"
     victory-core "^33.1.7"
 
-victory-line@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/victory-line/-/victory-line-34.2.0.tgz#9a62b090117730b7223145da7c685708c29c6c64"
-  integrity sha512-qCUODkJE3a4Vud0xzGnKGwTSY8DY2mPScKvw92sVsvoih4nqa7QeYmVXzLvJxn1kFHDgdF/N9sY8ZHBKqk2TRQ==
+victory-line@^34.3.8:
+  version "34.3.8"
+  resolved "https://registry.yarnpkg.com/victory-line/-/victory-line-34.3.8.tgz#4b44b8a7166ce7192b7b5a3d75c9459250b7ee16"
+  integrity sha512-lxA+ncyusT230wHOzrY0SzFWQLHTHjJVA558AkrV9zB7lcUblxMoeUhaV2hgv9yWfhi6Dy/Ap3drH/Vnnz/n0Q==
   dependencies:
     d3-shape "^1.2.0"
     lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^34.2.0"
+    victory-core "^34.3.8"
 
 victory-pie@^33.1.7:
   version "33.1.7"
@@ -13441,15 +13459,15 @@ victory-pie@^33.1.7:
     prop-types "^15.5.8"
     victory-core "^33.1.7"
 
-victory-pie@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/victory-pie/-/victory-pie-34.2.0.tgz#2cf11789640b8e84cfc8acddb2a3955b5fc0b360"
-  integrity sha512-D+cpeQDOHMIAzgpsHuSs+kiUkreL9rf7pZ1GyujPJ41MSA4+WcoR08PsVxXLw1J40UpPpbrxldKW2E+ymobDFw==
+victory-pie@^34.3.8:
+  version "34.3.8"
+  resolved "https://registry.yarnpkg.com/victory-pie/-/victory-pie-34.3.8.tgz#d7dc9f34030abba8f2c81962cd394f384570264a"
+  integrity sha512-S23Y9cBsYEe/EWcVjz9Nfu/F905yjRWtVhoCEf6e+tJp3Fy7cUBQOyE1UiNKm9LEoUxrOSHhsmS4d23qIWuw6w==
   dependencies:
     d3-shape "^1.0.0"
     lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^34.2.0"
+    victory-core "^34.3.8"
 
 victory-polar-axis@^33.1.7:
   version "33.1.7"
@@ -13460,14 +13478,14 @@ victory-polar-axis@^33.1.7:
     prop-types "^15.5.8"
     victory-core "^33.1.7"
 
-victory-polar-axis@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/victory-polar-axis/-/victory-polar-axis-34.2.0.tgz#c3e2a6081865b0c72560c58f58a65522a87097a7"
-  integrity sha512-pVg2wBk8Ltg6mS0NXfEypz7JIGVcGABKAPdVl/lJV4krhSInf0pEWECSNqj1uQTo3M/mX/45yrIhGPQK0NtVFw==
+victory-polar-axis@^34.3.8:
+  version "34.3.8"
+  resolved "https://registry.yarnpkg.com/victory-polar-axis/-/victory-polar-axis-34.3.8.tgz#d6b8cf5686abafd89c311bbfebd87880e500826b"
+  integrity sha512-8ziguUnYzVlHL699AwVVUhaRSXdV1+zwi1ycE/ouW/9QyzC32NVsq+De2S8Sxf3PJ2wbOF51B6/kAWrppsNhGw==
   dependencies:
     lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^34.2.0"
+    victory-core "^34.3.8"
 
 victory-scatter@^33.1.7:
   version "33.1.7"
@@ -13478,14 +13496,14 @@ victory-scatter@^33.1.7:
     prop-types "^15.5.8"
     victory-core "^33.1.7"
 
-victory-scatter@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/victory-scatter/-/victory-scatter-34.2.0.tgz#736f7d57bd40c98ab1669ac6404030beff427646"
-  integrity sha512-pxOLic67lBdGreVUHIgyM53zg34Jy7/wJYVLiz0x9w49ErMOrioxNv2BJMNiDtHR9mp8UKe4Z18ywfAgInexsw==
+victory-scatter@^34.3.8:
+  version "34.3.8"
+  resolved "https://registry.yarnpkg.com/victory-scatter/-/victory-scatter-34.3.8.tgz#0c7afe1ed8268c2d045717bddc593cd3c4b73092"
+  integrity sha512-xocPcCD1um6DhcB6h+3ENbXlesd1EzhwVdIuLHmvdM2t32UpVxH+kX9gv/rvtDRoIaZNpb8vlbu/jWJJDY8K/g==
   dependencies:
     lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^34.2.0"
+    victory-core "^34.3.8"
 
 victory-selection-container@^33.1.7:
   version "33.1.7"
@@ -13496,14 +13514,14 @@ victory-selection-container@^33.1.7:
     prop-types "^15.5.8"
     victory-core "^33.1.7"
 
-victory-selection-container@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/victory-selection-container/-/victory-selection-container-34.2.0.tgz#95844ad3631b888ff832a8310fd663ced5358f7b"
-  integrity sha512-lgevAucMmlJdw6i8oYdDEVE8g46s/WaxcWtAFiH0GNCcJSKc6uwQyIealsMXORnaY3b9/JL+2ErgetvgwhlXJg==
+victory-selection-container@^34.3.8:
+  version "34.3.8"
+  resolved "https://registry.yarnpkg.com/victory-selection-container/-/victory-selection-container-34.3.8.tgz#b035271a1a3d2c0873d65e40b0053fa62539be01"
+  integrity sha512-Nb+EITn2REY8NtE29qlxv2ypM2fWrqVlhx8QYpeIFngii7VXeinudTF7bkDqL5XDurmce+P//WQ86nMtOLgGig==
   dependencies:
     lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^34.2.0"
+    victory-core "^34.3.8"
 
 victory-shared-events@^33.1.7:
   version "33.1.7"
@@ -13515,15 +13533,15 @@ victory-shared-events@^33.1.7:
     react-fast-compare "^2.0.0"
     victory-core "^33.1.7"
 
-victory-shared-events@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/victory-shared-events/-/victory-shared-events-34.2.0.tgz#024e6f43eb72cf1ce7479fbae328979fc9fad112"
-  integrity sha512-G3gm8/Uo/FDrjVCPF3XVWkIKKUdNa9mKqrkxbe7/aCPrIarUWnVUGg7pqUJ/w9M5Y6Ch7kLMtT9x4AEEEGl94g==
+victory-shared-events@^34.3.9:
+  version "34.3.9"
+  resolved "https://registry.yarnpkg.com/victory-shared-events/-/victory-shared-events-34.3.9.tgz#3f42f86eacff56156ba30e0567fc928cf28dd08d"
+  integrity sha512-cW4/tI2VDB+R3LzD0ZtjRc1Bo5X5CCPIZ6hJ/8q9nAfyvitHdpPyL42kO5/o2v62ksSl0kR0Zlyn4eEonXKKpg==
   dependencies:
     lodash "^4.17.15"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-core "^34.2.0"
+    victory-core "^34.3.8"
 
 victory-stack@^33.1.7:
   version "33.1.7"
@@ -13535,16 +13553,16 @@ victory-stack@^33.1.7:
     react-fast-compare "^2.0.0"
     victory-core "^33.1.7"
 
-victory-stack@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/victory-stack/-/victory-stack-34.2.0.tgz#a463363fde8773aab17c747ccc817c271e62e609"
-  integrity sha512-LsKfqI1cC7ySL3UT1DKOjaroZ13d++IGK4sDIgSiTiMpyO00YPqlppqOX9GXwAlWTysYoUKOiigvUldKT7DqHQ==
+victory-stack@^34.3.9:
+  version "34.3.9"
+  resolved "https://registry.yarnpkg.com/victory-stack/-/victory-stack-34.3.9.tgz#9c0b360baf0da9ca1d57606d68c8c2d6581128c8"
+  integrity sha512-wTbEeYFOyG/i5o2YA5blJFXb/+arCEfuzxBTg44Yu2fOcd9MJs9amBwlOo+e94Dd+pwsQeMvkzhpRKYlzFXsdQ==
   dependencies:
     lodash "^4.17.15"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-core "^34.2.0"
-    victory-shared-events "^34.2.0"
+    victory-core "^34.3.8"
+    victory-shared-events "^34.3.9"
 
 victory-tooltip@^33.1.7:
   version "33.1.7"
@@ -13555,14 +13573,14 @@ victory-tooltip@^33.1.7:
     prop-types "^15.5.8"
     victory-core "^33.1.7"
 
-victory-tooltip@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/victory-tooltip/-/victory-tooltip-34.2.0.tgz#878b06e48faf95a0d335a5dbeacddb1c488cabfe"
-  integrity sha512-OKEqfZBuyer2ZgZ+F4a4dsY6UszBkiWOfqMx+DpTgWKkj3YKkMtEH6L9h0hOIzPOrw2q6bvEVqHmMh5nrtMhxQ==
+victory-tooltip@^34.3.8:
+  version "34.3.8"
+  resolved "https://registry.yarnpkg.com/victory-tooltip/-/victory-tooltip-34.3.8.tgz#fb5c8d249f9d61cad089e0646ea7ea564385c864"
+  integrity sha512-iJ/VoDS7DphDHnYZqcfvTY/q0XMvOjU3DjwVE/A9MaQAbu+xmdYSgIn7BG5YIjSpuUglzi7h3xmK248m0RnyCw==
   dependencies:
     lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^34.2.0"
+    victory-core "^34.3.8"
 
 victory-voronoi-container@^33.1.7:
   version "33.1.7"
@@ -13575,17 +13593,17 @@ victory-voronoi-container@^33.1.7:
     victory-core "^33.1.7"
     victory-tooltip "^33.1.7"
 
-victory-voronoi-container@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/victory-voronoi-container/-/victory-voronoi-container-34.2.0.tgz#53e86ceeee078d8430023b81d7893dfe4a1b6d74"
-  integrity sha512-K3L/KIkWwA87yhrHD3TkhFVQqtRy/B5mKS5y+XMEjutknlOKywCWUhiB8U/uXd5LL1B3IIae8lb5KsJ8xLXMyQ==
+victory-voronoi-container@^34.3.8:
+  version "34.3.8"
+  resolved "https://registry.yarnpkg.com/victory-voronoi-container/-/victory-voronoi-container-34.3.8.tgz#a03124be87f34cf07139a2d9c53cc6a48457b41e"
+  integrity sha512-wx46Mf3BEprtuQ2CRod6KcO1MHm0wxOEn/NO9qzOi3GnnD+CVsVfvIG6gFTDbjoo+fsKE7fW8AWYWo8oqx9fxg==
   dependencies:
     delaunay-find "0.0.5"
     lodash "^4.17.15"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-core "^34.2.0"
-    victory-tooltip "^34.2.0"
+    victory-core "^34.3.8"
+    victory-tooltip "^34.3.8"
 
 victory-voronoi@^33.1.7:
   version "33.1.7"
@@ -13597,15 +13615,15 @@ victory-voronoi@^33.1.7:
     prop-types "^15.5.8"
     victory-core "^33.1.7"
 
-victory-voronoi@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/victory-voronoi/-/victory-voronoi-34.2.0.tgz#b89ae6d3639db2b64d532f17ef7b9bbc8a48bf59"
-  integrity sha512-SOdtLXsPTK7toX07OJxKHV6tu0g/BW/eNTc1Gxxsy2stH6iC1Axck5BBpfXmIfhn/Eu0xWlgzkskcUSJO1bIWw==
+victory-voronoi@^34.3.8:
+  version "34.3.8"
+  resolved "https://registry.yarnpkg.com/victory-voronoi/-/victory-voronoi-34.3.8.tgz#bc35fa299adcb9c630f3c955514ec8e3cb3d1ab6"
+  integrity sha512-xXn3iYk9SPm8eRofU+tyk6dWPt7hwm29068M1l6AHGfjwI1Z/wLBc+VrlIPiqswBtLc3umxvmxurXQsqH3k8NQ==
   dependencies:
     d3-voronoi "^1.1.2"
     lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^34.2.0"
+    victory-core "^34.3.8"
 
 victory-zoom-container@^33.1.7:
   version "33.1.7"
@@ -13616,14 +13634,14 @@ victory-zoom-container@^33.1.7:
     prop-types "^15.5.8"
     victory-core "^33.1.7"
 
-victory-zoom-container@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/victory-zoom-container/-/victory-zoom-container-34.2.0.tgz#20f56c6ec7f1104c7a8c012bec5536d1e61edcea"
-  integrity sha512-AGJfjCuLd3t9d9gBwupCCoxL6lf+TxqKksbUS6Y1ZEmcZQmiaCCKr2VHVP22sBokeRF+H2Fpd3GpNpqrYSb6UA==
+victory-zoom-container@^34.3.8:
+  version "34.3.8"
+  resolved "https://registry.yarnpkg.com/victory-zoom-container/-/victory-zoom-container-34.3.8.tgz#716613594ed6139bd448f6cefd6b64e2bc317a82"
+  integrity sha512-U39CScIXcOVgQqKqgboBTeGxLTkrBRxKi991HGEFI9fD22aNj4bCs+TR0k/qeAz6oi+oDkLvxI74D+7uSNQD1w==
   dependencies:
     lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^34.2.0"
+    victory-core "^34.3.8"
 
 victory@^33.0.5:
   version "33.1.7"
@@ -13656,36 +13674,37 @@ victory@^33.0.5:
     victory-voronoi-container "^33.1.7"
     victory-zoom-container "^33.1.7"
 
-victory@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/victory/-/victory-34.2.0.tgz#2b1fc5875dcbc36005318f4dd09a6edceaf585e8"
-  integrity sha512-dFmRoYkUlC7/ZwpclrWIxVZsM9BZEtjLg2d5OWXittTpJPC/PTIVOcObkWLwxVp9auMOoN+d/3ayHoSORbalRQ==
+victory@^34.3.11:
+  version "34.3.11"
+  resolved "https://registry.yarnpkg.com/victory/-/victory-34.3.11.tgz#16fb757aed1f696f53a5e088d0e8fc0b24ce3acc"
+  integrity sha512-HDzXL4pioL8cMEkNNMBvhyW19jVE+p1pkWEACvYlGhdTXsf6b/8fN2+cCl2NiQG234KeAqPKpSkcHcdkhRQxRw==
   dependencies:
-    victory-area "^34.2.0"
-    victory-axis "^34.2.0"
-    victory-bar "^34.2.0"
-    victory-box-plot "^34.2.0"
-    victory-brush-container "^34.2.0"
-    victory-brush-line "^34.2.0"
-    victory-candlestick "^34.2.0"
-    victory-chart "^34.2.0"
-    victory-core "^34.2.0"
-    victory-create-container "^34.2.0"
-    victory-cursor-container "^34.2.0"
-    victory-errorbar "^34.2.0"
-    victory-group "^34.2.0"
-    victory-legend "^34.2.0"
-    victory-line "^34.2.0"
-    victory-pie "^34.2.0"
-    victory-polar-axis "^34.2.0"
-    victory-scatter "^34.2.0"
-    victory-selection-container "^34.2.0"
-    victory-shared-events "^34.2.0"
-    victory-stack "^34.2.0"
-    victory-tooltip "^34.2.0"
-    victory-voronoi "^34.2.0"
-    victory-voronoi-container "^34.2.0"
-    victory-zoom-container "^34.2.0"
+    victory-area "^34.3.8"
+    victory-axis "^34.3.8"
+    victory-bar "^34.3.8"
+    victory-box-plot "^34.3.8"
+    victory-brush-container "^34.3.8"
+    victory-brush-line "^34.3.8"
+    victory-candlestick "^34.3.8"
+    victory-chart "^34.3.11"
+    victory-core "^34.3.8"
+    victory-create-container "^34.3.10"
+    victory-cursor-container "^34.3.10"
+    victory-errorbar "^34.3.8"
+    victory-group "^34.3.10"
+    victory-histogram "^34.3.8"
+    victory-legend "^34.3.8"
+    victory-line "^34.3.8"
+    victory-pie "^34.3.8"
+    victory-polar-axis "^34.3.8"
+    victory-scatter "^34.3.8"
+    victory-selection-container "^34.3.8"
+    victory-shared-events "^34.3.9"
+    victory-stack "^34.3.9"
+    victory-tooltip "^34.3.8"
+    victory-voronoi "^34.3.8"
+    victory-voronoi-container "^34.3.8"
+    victory-zoom-container "^34.3.8"
 
 vm-browserify@^1.0.1:
   version "1.1.2"


### PR DESCRIPTION


## What's included
<!-- Summary of changes/additions -->
- fix(build,chartArea): npm update for victory charts
   * chartArea, label attribute fix, note

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- behind the scenes update, there should be no change in functionality

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests pass

<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. confirm the GUI loads


### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm the GUI loads


### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. confirm output compiles and tests pass


## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Ongoing, #296 