### PR TITLE
fix(chartArea): issues/318 inaccurate voronoi x coords

### DIFF
--- a/src/components/chartArea/__tests__/__snapshots__/chartArea.test.js.snap
+++ b/src/components/chartArea/__tests__/__snapshots__/chartArea.test.js.snap
@@ -869,7 +869,6 @@ exports[`ChartArea Component should handle custom chart tooltips: custom tooltip
         portalComponent={<Portal />}
         portalZIndex={99}
         responsive={true}
-        voronoiDimension="x"
         voronoiPadding={60}
       />
     }
@@ -1095,7 +1094,6 @@ exports[`ChartArea Component should handle custom chart tooltips: renderTooltip:
   portalComponent={<Portal />}
   portalZIndex={99}
   responsive={true}
-  voronoiDimension="x"
   voronoiPadding={60}
 />
 `;

--- a/src/components/chartArea/chartArea.js
+++ b/src/components/chartArea/chartArea.js
@@ -295,6 +295,11 @@ class ChartArea extends React.Component {
    * - https://github.com/FormidableLabs/victory/pull/1581
    */
   /**
+   * FixMe: Victory charts voronoi containers throw inaccurate coordinates on large graph widths
+   * Issue is "patched" by removing the "x" dimension attribute for voronoi.
+   * - https://github.com/RedHatInsights/curiosity-frontend/issues/318
+   */
+  /**
    * Return a chart/graph tooltip Victory container component to allow custom HTML tooltips.
    *
    * @returns {Node}
@@ -345,7 +350,7 @@ class ChartArea extends React.Component {
       if (htmlContent) {
         return (
           <g>
-            <foreignObject x={xCoordinate} y={obj.y / 2} width="100%" height="100%">
+            <foreignObject x={xCoordinate} y={obj.y / 2.2} width="100%" height="100%">
               <div ref={this.tooltipRef} style={{ display: 'inline-block' }} xmlns="http://www.w3.org/1999/xhtml">
                 {htmlContent}
               </div>
@@ -362,7 +367,6 @@ class ChartArea extends React.Component {
         cursorDimension="x"
         labels={obj => obj}
         labelComponent={<FlyoutComponent />}
-        voronoiDimension="x"
         voronoiPadding={60}
       />
     );


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(chartArea): issues/318 inaccurate voronoi x coords
   * chartArea, large resized graph widths throw inaccurate voronoi x coords

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- The issue only manifests when the graph is extended beyond a certain width. User display sizes as noted in #318 are a factor, the exact cause remains unknown due to time constraints and scope creep.
- This patch affects, slightly, the positioning associated with the tooltip following the graph cursor position

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. select the "weekly" granularity, or **select another granularity other than "daily"**
   - hover over slowly along the graph horizontally noting that each tooltip represents the corresponding x axis tick

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Jun-17-2020 21-11-00](https://user-images.githubusercontent.com/3761375/84966297-331dad80-b0df-11ea-8f57-651363ebdc78.gif)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Updates #318 