### PR TITLE
fix(redirect): issues/328 lazy load routing

### DIFF
--- a/src/components/loader/loader.js
+++ b/src/components/loader/loader.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Skeleton } from '@redhat-cloud-services/frontend-components/components/Skeleton';
+import { Skeleton } from '@redhat-cloud-services/frontend-components/components/cjs/Skeleton';
 import { Spinner } from '@redhat-cloud-services/frontend-components/components/cjs/Spinner';
 import { PageHeader, PageLayout } from '../pageLayout/pageLayout';
 

--- a/src/components/router/redirect.js
+++ b/src/components/router/redirect.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { withRouter, Route } from 'react-router-dom';
 import { routerHelpers } from './routerHelpers';
 import { helpers } from '../../common';
+import { Loader } from '../loader/loader';
 
 /**
  * A routing redirect.
@@ -31,7 +32,12 @@ const Redirect = ({ baseName, history, isRedirect, isReplace, url, route }) => {
   if (isRedirect === true) {
     if (route && history) {
       const routeDetail = routerHelpers.getRouteDetail({ pathname: route });
-      return <Route path="*">{routeDetail && <routeDetail.component />}</Route>;
+
+      return (
+        <React.Suspense fallback={<Loader variant="title" />}>
+          <Route path="*">{routeDetail && <routeDetail.component />}</Route>
+        </React.Suspense>
+      );
     }
 
     const forcePath = url || (route && path.join(baseName, route));


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(redirect): issues/328 lazy load routing 
  - redirect, apply suspense for lazy loaded redirect route
- fix(loader): issues/328 loading component 
  - loader, resource path consistency

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- These commits will be squashed into the commits from PR #337 once QE approves

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. login with credentials
1. delete the users/account optin
1. refresh the page, it should render the optin view accordingly

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Closes #328 
Updates #342 
