### PR TITLE
fix(i18n,translate): issues/354 remove withTranslation

### DIFF
--- a/src/components/authentication/__tests__/__snapshots__/authentication.test.js.snap
+++ b/src/components/authentication/__tests__/__snapshots__/authentication.test.js.snap
@@ -67,6 +67,7 @@ exports[`Authentication Component should render a non-connected component error:
     <PageLayout>
       <PageHeader
         key=".0"
+        t={[Function]}
         viewId={null}
       >
         <PageHeader>

--- a/src/components/authentication/authentication.js
+++ b/src/components/authentication/authentication.js
@@ -1,11 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { BinocularsIcon, LockIcon } from '@patternfly/react-icons';
-import { connectRouterTranslate, reduxActions, reduxSelectors } from '../../redux';
+import { connectRouter, reduxActions, reduxSelectors } from '../../redux';
 import { rhsmApiTypes } from '../../types';
 import { helpers } from '../../common';
 import { Redirect, routerHelpers, routerTypes } from '../router/router';
 import MessageView from '../messageView/messageView';
+import { translate } from '../i18n/i18n';
 
 /**
  * An authentication pass-through component.
@@ -82,9 +83,8 @@ class Authentication extends Component {
 /**
  * Prop types.
  *
- * @type {{authorizeUser: Function, onNavigation: Function, setAppName: Function, navigation: Array,
- *     t: Function, children: Node, initializeChrome: Function, session: object, history: object,
- *     setNavigation: Function}}
+ * @type {{authorizeUser: Function, onNavigation: Function, setAppName: Function, t: Function,
+ *     children: Node, initializeChrome: Function, session: object, history: object}}
  */
 Authentication.propTypes = {
   authorizeUser: PropTypes.func,
@@ -110,9 +110,9 @@ Authentication.propTypes = {
 /**
  * Default props.
  *
- * @type {{authorizeUser: Function, onNavigation: Function, setAppName: Function, navigation: Array,
- *     t: Function, initializeChrome: Function, session: {authorized: boolean, pending: boolean,
- *     errorMessage: string, error: boolean, status: null}, setNavigation: Function}}
+ * @type {{authorizeUser: Function, onNavigation: Function, setAppName: Function, t: translate,
+ *     initializeChrome: Function, session: {authorized: boolean, errorCodes: Array, pending: boolean,
+ *     errorMessage: string, error: boolean, status: null}}}
  */
 Authentication.defaultProps = {
   authorizeUser: helpers.noop,
@@ -127,7 +127,7 @@ Authentication.defaultProps = {
     pending: false,
     status: null
   },
-  t: helpers.noopTranslate
+  t: translate
 };
 
 /**
@@ -150,6 +150,6 @@ const mapDispatchToProps = dispatch => ({
  */
 const makeMapStateToProps = reduxSelectors.user.makeUserSession();
 
-const ConnectedAuthentication = connectRouterTranslate(makeMapStateToProps, mapDispatchToProps)(Authentication);
+const ConnectedAuthentication = connectRouter(makeMapStateToProps, mapDispatchToProps)(Authentication);
 
 export { ConnectedAuthentication as default, ConnectedAuthentication, Authentication };

--- a/src/components/c3GraphCard/c3GraphCard.js
+++ b/src/components/c3GraphCard/c3GraphCard.js
@@ -4,13 +4,14 @@ import { Card, CardTitle, CardHeader, CardActions, CardBody } from '@patternfly/
 import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components/components/cjs/Skeleton';
 import _isEqual from 'lodash/isEqual';
 import { Select } from '../form/select';
-import { connectTranslate, reduxActions, reduxSelectors, reduxTypes, store } from '../../redux';
+import { connect, reduxActions, reduxSelectors, reduxTypes, store } from '../../redux';
 import { helpers, dateHelpers } from '../../common';
 import { rhsmApiTypes, RHSM_API_QUERY_GRANULARITY_TYPES as GRANULARITY_TYPES } from '../../types/rhsmApiTypes';
 import { c3GraphCardHelpers } from './c3GraphCardHelpers';
 import { C3GraphCardLegendItem } from './c3GraphCardLegendItem';
 import { graphCardTypes } from '../graphCard/graphCardTypes';
 import { C3Chart } from '../c3Chart/c3Chart';
+import { translate } from '../i18n/i18n';
 
 /**
  * A chart/graph card.
@@ -247,7 +248,7 @@ C3GraphCard.propTypes = {
  * Default props.
  *
  * @type {{getGraphReportsCapacity: Function, productShortLabel: string, selectOptionsType: string,
- *     viewId: string, t: Function, children: null, pending: boolean, graphData: object,
+ *     viewId: string, t: translate, children: null, pending: boolean, graphData: object,
  *     isDisabled: boolean, error: boolean, cardTitle: null, filterGraphData: Array}}
  */
 C3GraphCard.defaultProps = {
@@ -260,7 +261,7 @@ C3GraphCard.defaultProps = {
   isDisabled: helpers.UI_DISABLED_GRAPH,
   pending: false,
   selectOptionsType: 'default',
-  t: helpers.noopTranslate,
+  t: translate,
   productShortLabel: '',
   viewId: 'graphCard'
 };
@@ -282,6 +283,6 @@ const mapDispatchToProps = dispatch => ({
   getGraphReportsCapacity: (id, query) => dispatch(reduxActions.rhsm.getGraphReportsCapacity(id, query))
 });
 
-const ConnectedGraphCard = connectTranslate(makeMapStateToProps, mapDispatchToProps)(C3GraphCard);
+const ConnectedGraphCard = connect(makeMapStateToProps, mapDispatchToProps)(C3GraphCard);
 
 export { ConnectedGraphCard as default, ConnectedGraphCard, C3GraphCard };

--- a/src/components/graphCard/graphCard.js
+++ b/src/components/graphCard/graphCard.js
@@ -4,7 +4,7 @@ import { Card, CardTitle, CardHeader, CardActions, CardBody } from '@patternfly/
 import { chart_color_green_300 as chartColorGreenDark } from '@patternfly/react-tokens';
 import _isEqual from 'lodash/isEqual';
 import { Select } from '../form/select';
-import { connectTranslate, reduxActions, reduxSelectors, reduxTypes, store } from '../../redux';
+import { connect, reduxActions, reduxSelectors, reduxTypes, store } from '../../redux';
 import { helpers, dateHelpers } from '../../common';
 import { rhsmApiTypes, RHSM_API_QUERY_GRANULARITY_TYPES as GRANULARITY_TYPES } from '../../types/rhsmApiTypes';
 import { graphCardHelpers } from './graphCardHelpers';
@@ -13,6 +13,7 @@ import GraphCardChartTooltip from './graphCardChartTooltip';
 import GraphCardChartLegend from './graphCardChartLegend';
 import { ChartArea } from '../chartArea/chartArea';
 import { Loader } from '../loader/loader';
+import { translate } from '../i18n/i18n';
 
 /**
  * A chart/graph card.
@@ -228,7 +229,7 @@ GraphCard.propTypes = {
  * Default props.
  *
  * @type {{getGraphReportsCapacity: Function, productShortLabel: string, selectOptionsType: string,
- *     viewId: string, t: Function, children: null, pending: boolean, graphData: object,
+ *     viewId: string, t: translate, children: null, pending: boolean, graphData: object,
  *     isDisabled: boolean, error: boolean, cardTitle: null, filterGraphData: Array}}
  */
 GraphCard.defaultProps = {
@@ -241,7 +242,7 @@ GraphCard.defaultProps = {
   isDisabled: helpers.UI_DISABLED_GRAPH,
   pending: false,
   selectOptionsType: 'default',
-  t: helpers.noopTranslate,
+  t: translate,
   productShortLabel: '',
   viewId: 'graphCard'
 };
@@ -263,6 +264,6 @@ const mapDispatchToProps = dispatch => ({
  */
 const makeMapStateToProps = reduxSelectors.graphCard.makeGraphCard();
 
-const ConnectedGraphCard = connectTranslate(makeMapStateToProps, mapDispatchToProps)(GraphCard);
+const ConnectedGraphCard = connect(makeMapStateToProps, mapDispatchToProps)(GraphCard);
 
 export { ConnectedGraphCard as default, ConnectedGraphCard, GraphCard };

--- a/src/components/graphCard/graphCardChartLegend.js
+++ b/src/components/graphCard/graphCardChartLegend.js
@@ -2,8 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { EyeSlashIcon } from '@patternfly/react-icons';
-import { connectTranslate, store, reduxTypes } from '../../redux';
+import { connect, store, reduxTypes } from '../../redux';
 import { helpers } from '../../common';
+import { translate } from '../i18n/i18n';
 
 /**
  * A custom chart legend.
@@ -196,7 +197,7 @@ GraphCardChartLegend.propTypes = {
 /**
  * Default props.
  *
- * @type {{datum: {dataSets: Array}, product: string, viewId: string, t: Function, legend: {},
+ * @type {{datum: {dataSets: Array}, product: string, viewId: string, t: translate, legend: object,
  *     chart: {hide: Function, toggle: Function, isToggled: Function}}}
  */
 GraphCardChartLegend.defaultProps = {
@@ -210,12 +211,12 @@ GraphCardChartLegend.defaultProps = {
   },
   legend: {},
   product: '',
-  t: helpers.noopTranslate,
+  t: translate,
   viewId: 'graphCardLegend'
 };
 
 const mapStateToProps = ({ graph }) => ({ legend: graph.legend });
 
-const ConnectedGraphCardChartLegend = connectTranslate(mapStateToProps)(GraphCardChartLegend);
+const ConnectedGraphCardChartLegend = connect(mapStateToProps)(GraphCardChartLegend);
 
 export { ConnectedGraphCardChartLegend as default, ConnectedGraphCardChartLegend, GraphCardChartLegend };

--- a/src/components/graphCard/graphCardChartTooltip.js
+++ b/src/components/graphCard/graphCardChartTooltip.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withTranslation } from 'react-i18next';
 import { getTooltipDate } from './graphCardHelpers';
-import { helpers } from '../../common';
+import { translate } from '../i18n/i18n';
 
 /**
  * A custom chart tooltip.
@@ -113,14 +112,12 @@ GraphCardChartTooltip.propTypes = {
 /**
  * Default props.
  *
- * @type {{datum: {}, product: string, t: Function}}
+ * @type {{datum: object, product: string, t: translate}}
  */
 GraphCardChartTooltip.defaultProps = {
   datum: {},
   product: '',
-  t: helpers.noopTranslate
+  t: translate
 };
 
-const TranslatedGraphCardChartTooltip = withTranslation()(GraphCardChartTooltip);
-
-export { TranslatedGraphCardChartTooltip as default, TranslatedGraphCardChartTooltip, GraphCardChartTooltip };
+export { GraphCardChartTooltip as default, GraphCardChartTooltip };

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -207,7 +207,7 @@ Array [
       },
       Object {
         "key": "curiosity-optin.cardIsErrorDescription",
-        "match": "translate('curiosity-optin.cardIsErrorDescription', { appName: helpers.UI_DISPLAY_NAME }, [ <Button isInline component=\\"a\\" variant=\\"link\\" target=\\"_blank\\" href=\\"https://access.redhat.com/account-team\\" /> ])",
+        "match": "t('curiosity-optin.cardIsErrorDescription', { appName: helpers.UI_DISPLAY_NAME }, [ <Button isInline component=\\"a\\" variant=\\"link\\" target=\\"_blank\\" href=\\"https://access.redhat.com/account-team\\" /> ])",
       },
       Object {
         "key": "curiosity-optin.buttonIsActive",
@@ -276,7 +276,7 @@ Array [
     "keys": Array [
       Object {
         "key": "",
-        "match": "translate(\`curiosity-view.\${viewId}Subtitle\`, {}, [ <Button isInline component=\\"a\\" variant=\\"link\\" icon={<ExternalLinkSquareAltIcon />} iconPosition=\\"right\\" target=\\"_blank\\" href=\\"https://access.redhat.com/documentation/en-us/subscription_central/2020-04/html/getting_started_with_subscription_watch/con-how-does-subscriptionwatch-show-data_assembly-opening-subscriptionwatch-ctxt/\\" /> ])",
+        "match": "t(\`curiosity-view.\${viewId}Subtitle\`, {}, [ <Button isInline component=\\"a\\" variant=\\"link\\" icon={<ExternalLinkSquareAltIcon />} iconPosition=\\"right\\" target=\\"_blank\\" href=\\"https://access.redhat.com/documentation/en-us/subscription_central/2020-04/html/getting_started_with_subscription_watch/con-how-does-subscriptionwatch-show-data_assembly-opening-subscriptionwatch-ctxt/\\" /> ])",
       },
     ],
   },

--- a/src/components/i18n/__tests__/i18n.test.js
+++ b/src/components/i18n/__tests__/i18n.test.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import { mount, shallow } from 'enzyme';
 import _get from 'lodash/get';
 import { I18n, translate, translateComponent } from '../i18n';
-import { helpers } from '../../../common';
 import enLocales from '../../../../public/locales/en-US';
 
 /**
@@ -101,7 +100,7 @@ describe('I18n Component', () => {
     };
 
     ExampleComponent.defaultProps = {
-      t: helpers.noopTranslate
+      t: translate
     };
 
     const TranslatedComponent = translateComponent(ExampleComponent);

--- a/src/components/i18n/i18n.js
+++ b/src/components/i18n/i18n.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import i18next from 'i18next';
 import XHR from 'i18next-xhr-backend';
-import { initReactI18next, Trans, withTranslation } from 'react-i18next';
+import { initReactI18next, Trans } from 'react-i18next';
 import { helpers } from '../../common/helpers';
 
 /**
@@ -27,12 +27,16 @@ const translate = (translateKey, values = null, components) => {
 };
 
 /**
- * Apply string replacements against a component.
+ * Apply string replacements against a component, HOC.
  *
- * @param {Node} component
+ * @param {Node} Component
  * @returns {Node}
  */
-const translateComponent = component => (!helpers.TEST_MODE && withTranslation()(component)) || component;
+const translateComponent = Component => {
+  const withTranslation = ({ ...props }) => <Component {...props} t={translate} i18n={i18next} />;
+  withTranslation.displayName = 'withTranslation';
+  return withTranslation;
+};
 
 /**
  * ToDo: reevaluate the "I18nextProvider" on package update.

--- a/src/components/loader/__tests__/__snapshots__/loader.test.js.snap
+++ b/src/components/loader/__tests__/__snapshots__/loader.test.js.snap
@@ -79,6 +79,7 @@ exports[`Loader Component should handle variant loader components: variant: tabl
 exports[`Loader Component should handle variant loader components: variant: title 1`] = `
 <PageLayout>
   <PageHeader
+    t={[Function]}
     viewId={null}
   >
     <Skeleton

--- a/src/components/messageView/__tests__/__snapshots__/messageView.test.js.snap
+++ b/src/components/messageView/__tests__/__snapshots__/messageView.test.js.snap
@@ -3,6 +3,7 @@
 exports[`MessageView Component should have fallback conditions for all props: fallback display 1`] = `
 <PageLayout>
   <PageHeader
+    t={[Function]}
     viewId={null}
   >
     Subscription Watch
@@ -17,6 +18,7 @@ exports[`MessageView Component should have fallback conditions for all props: fa
 exports[`MessageView Component should render a non-connected component: non-connected 1`] = `
 <PageLayout>
   <PageHeader
+    t={[Function]}
     viewId={null}
   >
     Subscription Watch

--- a/src/components/openshiftView/__tests__/__snapshots__/openshiftView.test.js.snap
+++ b/src/components/openshiftView/__tests__/__snapshots__/openshiftView.test.js.snap
@@ -3,17 +3,20 @@
 exports[`OpenshiftView Component should display an alternate graph on query-string update: alternate graph 1`] = `
 <PageLayout>
   <PageHeader
+    t={[Function]}
     viewId="OpenShift"
   >
     t(curiosity-view.OpenShiftTitle, Subscription Watch)
   </PageHeader>
   <PageToolbar>
-    <withI18nextTranslation(Toolbar)
+    <Toolbar
       graphQuery={
         Object {
           "granularity": "daily",
         }
       }
+      isDisabled={false}
+      t={[Function]}
       viewId="OpenShift"
     />
   </PageToolbar>
@@ -74,17 +77,20 @@ exports[`OpenshiftView Component should display an alternate graph on query-stri
 exports[`OpenshiftView Component should have a fallback title: title 1`] = `
 <PageLayout>
   <PageHeader
+    t={[Function]}
     viewId="OpenShift"
   >
     t(curiosity-view.OpenShiftTitle, Subscription Watch)
   </PageHeader>
   <PageToolbar>
-    <withI18nextTranslation(Toolbar)
+    <Toolbar
       graphQuery={
         Object {
           "granularity": "daily",
         }
       }
+      isDisabled={false}
+      t={[Function]}
       viewId="OpenShift"
     />
   </PageToolbar>
@@ -145,17 +151,20 @@ exports[`OpenshiftView Component should have a fallback title: title 1`] = `
 exports[`OpenshiftView Component should render a non-connected component: non-connected 1`] = `
 <PageLayout>
   <PageHeader
+    t={[Function]}
     viewId="OpenShift"
   >
     t(curiosity-view.OpenShiftTitle, Subscription Watch)
   </PageHeader>
   <PageToolbar>
-    <withI18nextTranslation(Toolbar)
+    <Toolbar
       graphQuery={
         Object {
           "granularity": "daily",
         }
       }
+      isDisabled={false}
+      t={[Function]}
       viewId="OpenShift"
     />
   </PageToolbar>

--- a/src/components/openshiftView/openshiftView.js
+++ b/src/components/openshiftView/openshiftView.js
@@ -6,12 +6,13 @@ import {
 } from '@patternfly/react-tokens';
 import { PageLayout, PageHeader, PageSection, PageToolbar } from '../pageLayout/pageLayout';
 import { RHSM_API_QUERY_GRANULARITY_TYPES as GRANULARITY_TYPES, rhsmApiTypes } from '../../types/rhsmApiTypes';
-import { connectTranslate, reduxSelectors } from '../../redux';
+import { connect, reduxSelectors } from '../../redux';
 import GraphCard from '../graphCard/graphCard';
 import C3GraphCard from '../c3GraphCard/c3GraphCard';
 import { Select } from '../form/select';
 import Toolbar from '../toolbar/toolbar';
 import { helpers } from '../../common';
+import { translate } from '../i18n/i18n';
 
 /**
  * An OpenShift encompassing view.
@@ -143,7 +144,7 @@ OpenshiftView.propTypes = {
 /**
  * Default props.
  *
- * @type {{initialFilters: Array, initialOption: string, viewId: string, t: Function, graphQuery: object}}
+ * @type {{initialFilters: Array, initialOption: string, viewId: string, t: translate, graphQuery: object}}
  */
 OpenshiftView.defaultProps = {
   graphQuery: {
@@ -161,7 +162,7 @@ OpenshiftView.defaultProps = {
     { id: 'thresholdSockets' },
     { id: 'thresholdCores' }
   ],
-  t: helpers.noopTranslate,
+  t: translate,
   viewId: 'OpenShift'
 };
 
@@ -172,6 +173,6 @@ OpenshiftView.defaultProps = {
  */
 const makeMapStateToProps = reduxSelectors.view.makeView(OpenshiftView.defaultProps);
 
-const ConnectedOpenshiftView = connectTranslate(makeMapStateToProps)(OpenshiftView);
+const ConnectedOpenshiftView = connect(makeMapStateToProps)(OpenshiftView);
 
 export { ConnectedOpenshiftView as default, ConnectedOpenshiftView, OpenshiftView };

--- a/src/components/optinView/optinView.js
+++ b/src/components/optinView/optinView.js
@@ -16,7 +16,7 @@ import {
   Spinner,
   Title
 } from '@patternfly/react-core';
-import { connectTranslate, reduxActions } from '../../redux';
+import { connect, reduxActions } from '../../redux';
 import { translate } from '../i18n/i18n';
 import { PageLayout } from '../pageLayout/pageLayout';
 import { helpers } from '../../common';
@@ -64,7 +64,7 @@ class OptinView extends React.Component {
     if (error) {
       return (
         <p>
-          {translate('curiosity-optin.cardIsErrorDescription', { appName: helpers.UI_DISPLAY_NAME }, [
+          {t('curiosity-optin.cardIsErrorDescription', { appName: helpers.UI_DISPLAY_NAME }, [
             <Button
               isInline
               component="a"
@@ -216,7 +216,7 @@ OptinView.propTypes = {
 /**
  * Default props.
  *
- * @type {{t: Function, session: {status: null}, updateAccountOptIn: Function, pending: boolean,
+ * @type {{t: translate, session: {status: null}, updateAccountOptIn: Function, pending: boolean,
  *     fulfilled: boolean, error: boolean}}
  */
 OptinView.defaultProps = {
@@ -226,7 +226,7 @@ OptinView.defaultProps = {
   session: {
     status: null
   },
-  t: helpers.noopTranslate,
+  t: translate,
   updateAccountOptIn: helpers.noop
 };
 
@@ -249,6 +249,6 @@ const mapDispatchToProps = dispatch => ({
  */
 const mapStateToProps = ({ user }) => ({ ...user.optin, session: user.session });
 
-const ConnectedOptinView = connectTranslate(mapStateToProps, mapDispatchToProps)(OptinView);
+const ConnectedOptinView = connect(mapStateToProps, mapDispatchToProps)(OptinView);
 
 export { ConnectedOptinView as default, ConnectedOptinView, OptinView };

--- a/src/components/pageLayout/__tests__/__snapshots__/pageHeader.test.js.snap
+++ b/src/components/pageLayout/__tests__/__snapshots__/pageHeader.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`PageHeader Component should render a basic component: basic 1`] = `
 <PageHeader
+  t={[Function]}
   viewId={null}
 >
   <PageHeader>
@@ -46,6 +47,7 @@ exports[`PageHeader Component should render a basic component: basic 1`] = `
 
 exports[`PageHeader Component should render string node types: string 1`] = `
 <PageHeader
+  t={[Function]}
   viewId={null}
 >
   <PageHeader>
@@ -80,6 +82,7 @@ exports[`PageHeader Component should render string node types: string 1`] = `
 
 exports[`PageHeader Component should render the subtitle when viewId is provided: with subtitle 1`] = `
 <PageHeader
+  t={[Function]}
   viewId="RHEL"
 >
   <PageHeader>

--- a/src/components/pageLayout/__tests__/__snapshots__/pageLayout.test.js.snap
+++ b/src/components/pageLayout/__tests__/__snapshots__/pageLayout.test.js.snap
@@ -23,6 +23,7 @@ exports[`PageLayout Component should render header and section children: multipl
 <PageLayout>
   <PageHeader
     key=".1"
+    t={[Function]}
     viewId={null}
   >
     <PageHeader>

--- a/src/components/pageLayout/pageHeader.js
+++ b/src/components/pageLayout/pageHeader.js
@@ -14,14 +14,15 @@ import { translate } from '../i18n/i18n';
  * @param {object} props
  * @param {Node} props.children
  * @param {string} props.viewId
+ * @param {Function} props.t
  * @returns {Node}
  */
-const PageHeader = ({ children, viewId }) => (
+const PageHeader = ({ children, t, viewId }) => (
   <RcsPageHeader>
     <PageHeaderTitle title={children} className="pf-u-mb-sm" />
     {viewId && (
       <p>
-        {translate(`curiosity-view.${viewId}Subtitle`, {}, [
+        {t(`curiosity-view.${viewId}Subtitle`, {}, [
           <Button
             isInline
             component="a"
@@ -40,17 +41,21 @@ const PageHeader = ({ children, viewId }) => (
 /**
  * Prop types.
  *
- * @type {{children: Node, viewId: string}}
+ * @type {{viewId: string, t: Function, children: Node}}
  */
 PageHeader.propTypes = {
   children: PropTypes.node.isRequired,
+  t: PropTypes.func,
   viewId: PropTypes.string
 };
 
 /**
  * Default props.
+ *
+ * @type {{viewId: null, t: translate}}
  */
 PageHeader.defaultProps = {
+  t: translate,
   viewId: null
 };
 

--- a/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
+++ b/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
@@ -3,17 +3,20 @@
 exports[`RhelView Component should display an alternate graph on query-string update: alternate graph 1`] = `
 <PageLayout>
   <PageHeader
+    t={[Function]}
     viewId="RHEL"
   >
     t(curiosity-view.RHELTitle, Subscription Watch)
   </PageHeader>
   <PageToolbar>
-    <withI18nextTranslation(Toolbar)
+    <Toolbar
       graphQuery={
         Object {
           "granularity": "daily",
         }
       }
+      isDisabled={false}
+      t={[Function]}
       viewId="RHEL"
     />
   </PageToolbar>
@@ -62,17 +65,20 @@ exports[`RhelView Component should display an alternate graph on query-string up
 exports[`RhelView Component should have a fallback title: title 1`] = `
 <PageLayout>
   <PageHeader
+    t={[Function]}
     viewId="RHEL"
   >
     t(curiosity-view.RHELTitle, Subscription Watch)
   </PageHeader>
   <PageToolbar>
-    <withI18nextTranslation(Toolbar)
+    <Toolbar
       graphQuery={
         Object {
           "granularity": "daily",
         }
       }
+      isDisabled={false}
+      t={[Function]}
       viewId="RHEL"
     />
   </PageToolbar>
@@ -121,17 +127,20 @@ exports[`RhelView Component should have a fallback title: title 1`] = `
 exports[`RhelView Component should render a non-connected component: non-connected 1`] = `
 <PageLayout>
   <PageHeader
+    t={[Function]}
     viewId="RHEL"
   >
     t(curiosity-view.RHELTitle, Subscription Watch)
   </PageHeader>
   <PageToolbar>
-    <withI18nextTranslation(Toolbar)
+    <Toolbar
       graphQuery={
         Object {
           "granularity": "daily",
         }
       }
+      isDisabled={false}
+      t={[Function]}
       viewId="RHEL"
     />
   </PageToolbar>

--- a/src/components/rhelView/rhelView.js
+++ b/src/components/rhelView/rhelView.js
@@ -10,11 +10,12 @@ import {
 } from '@patternfly/react-tokens';
 import { PageLayout, PageHeader, PageSection, PageToolbar } from '../pageLayout/pageLayout';
 import { RHSM_API_QUERY_GRANULARITY_TYPES as GRANULARITY_TYPES, rhsmApiTypes } from '../../types/rhsmApiTypes';
-import { connectTranslate, reduxSelectors } from '../../redux';
+import { connect, reduxSelectors } from '../../redux';
 import GraphCard from '../graphCard/graphCard';
 import C3GraphCard from '../c3GraphCard/c3GraphCard';
 import Toolbar from '../toolbar/toolbar';
 import { helpers } from '../../common';
+import { translate } from '../i18n/i18n';
 
 /**
  * A Red Hat Enterprise Linux encompassing view, and system architectures.
@@ -95,7 +96,7 @@ RhelView.propTypes = {
 /**
  * Default props.
  *
- * @type {{initialFilters: Array, viewId: string, t: Function, graphQuery: object}}
+ * @type {{initialFilters: Array, viewId: string, t: translate, graphQuery: object}}
  */
 RhelView.defaultProps = {
   graphQuery: {
@@ -122,7 +123,7 @@ RhelView.defaultProps = {
     },
     { id: 'thresholdSockets' }
   ],
-  t: helpers.noopTranslate,
+  t: translate,
   viewId: 'RHEL'
 };
 
@@ -133,6 +134,6 @@ RhelView.defaultProps = {
  */
 const makeMapStateToProps = reduxSelectors.view.makeView(RhelView.defaultProps);
 
-const ConnectedRhelView = connectTranslate(makeMapStateToProps)(RhelView);
+const ConnectedRhelView = connect(makeMapStateToProps)(RhelView);
 
 export { ConnectedRhelView as default, ConnectedRhelView, RhelView };

--- a/src/components/table/__tests__/__snapshots__/tableSkeleton.test.js.snap
+++ b/src/components/table/__tests__/__snapshots__/tableSkeleton.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TableSkeleton Component should allow variations in table layout: borders and table header row removed 1`] = `
-<withI18nextTranslation(Table)
+<Table
   ariaLabel="t(curiosity-inventory.tableSkeletonAriaLabel)"
   borders={false}
   className="curiosity-skeleton-table "
@@ -68,12 +68,14 @@ exports[`TableSkeleton Component should allow variations in table layout: border
       },
     ]
   }
+  summary={null}
+  t={[Function]}
   variant={null}
 />
 `;
 
 exports[`TableSkeleton Component should allow variations in table layout: className and variant 1`] = `
-<withI18nextTranslation(Table)
+<Table
   ariaLabel="t(curiosity-inventory.tableSkeletonAriaLabel)"
   borders={false}
   className="curiosity-skeleton-table lorem-ipsum-class"
@@ -140,12 +142,14 @@ exports[`TableSkeleton Component should allow variations in table layout: classN
       },
     ]
   }
+  summary={null}
+  t={[Function]}
   variant="compact"
 />
 `;
 
 exports[`TableSkeleton Component should allow variations in table layout: column and row count  1`] = `
-<withI18nextTranslation(Table)
+<Table
   ariaLabel="t(curiosity-inventory.tableSkeletonAriaLabel)"
   borders={true}
   className="curiosity-skeleton-table "
@@ -212,12 +216,14 @@ exports[`TableSkeleton Component should allow variations in table layout: column
       },
     ]
   }
+  summary={null}
+  t={[Function]}
   variant={null}
 />
 `;
 
 exports[`TableSkeleton Component should render a non-connected component: non-connected 1`] = `
-<withI18nextTranslation(Table)
+<Table
   ariaLabel="t(curiosity-inventory.tableSkeletonAriaLabel)"
   borders={true}
   className="curiosity-skeleton-table "
@@ -284,6 +290,8 @@ exports[`TableSkeleton Component should render a non-connected component: non-co
       },
     ]
   }
+  summary={null}
+  t={[Function]}
   variant={null}
 />
 `;

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Grid, GridItem } from '@patternfly/react-core';
-import { withTranslation } from 'react-i18next';
 import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';
 import { Table as PfTable, TableBody, TableHeader, TableVariant } from '@patternfly/react-table';
 import _isEqual from 'lodash/isEqual';
 import { TableEmpty } from './tableEmpty';
-import { helpers } from '../../common/helpers';
+import { translate } from '../i18n/i18n';
 
 /**
  * A table.
@@ -201,7 +200,7 @@ Table.propTypes = {
 /**
  * Default props.
  *
- * @type {{summary: null, t: Function, borders: boolean, children: null, isHeader: boolean,
+ * @type {{summary: null, t: translate, borders: boolean, children: null, isHeader: boolean,
  *     variant: null, className: null, rows: Array, ariaLabel: null}}
  */
 Table.defaultProps = {
@@ -212,10 +211,8 @@ Table.defaultProps = {
   isHeader: true,
   rows: [],
   summary: null,
-  t: helpers.noopTranslate,
+  t: translate,
   variant: null
 };
 
-const TranslatedTable = withTranslation()(Table);
-
-export { TranslatedTable as default, TranslatedTable, Table };
+export { Table as default, Table };

--- a/src/components/table/tableSkeleton.js
+++ b/src/components/table/tableSkeleton.js
@@ -1,10 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withTranslation } from 'react-i18next';
 import { TableVariant } from '@patternfly/react-table';
 import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components/components/cjs/Skeleton';
-import { helpers } from '../../common/helpers';
 import Table from './table';
+import { translate } from '../i18n/i18n';
 
 /**
  * Render a table with skeleton loaders.
@@ -57,7 +56,8 @@ TableSkeleton.propTypes = {
 /**
  * Default props.
  *
- * @type {{borders: boolean, isHeader: boolean, colCount: number, variant: null, className: null, rowCount: number}}
+ * @type {{t: translate, borders: boolean, isHeader: boolean, colCount: number, variant: null, className: null,
+ *     rowCount: number}}
  */
 TableSkeleton.defaultProps = {
   borders: true,
@@ -65,10 +65,8 @@ TableSkeleton.defaultProps = {
   colCount: 1,
   isHeader: true,
   rowCount: 5,
-  t: helpers.noopTranslate,
+  t: translate,
   variant: null
 };
 
-const TranslatedTableSkeleton = withTranslation()(TableSkeleton);
-
-export { TranslatedTableSkeleton as default, TranslatedTableSkeleton, TableSkeleton };
+export { TableSkeleton as default, TableSkeleton };

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withTranslation } from 'react-i18next';
 import { Toolbar as PfToolbar, ToolbarContent, ToolbarFilter, ToolbarGroup } from '@patternfly/react-core';
 import { Select } from '../form/select';
 import { reduxTypes, store } from '../../redux';
 import { rhsmApiTypes } from '../../types/rhsmApiTypes';
 import { toolbarTypes } from './toolbarTypes';
 import { helpers } from '../../common';
+import { translate } from '../i18n/i18n';
 
 /**
  * Application filter toolbar.
@@ -135,15 +135,13 @@ Toolbar.propTypes = {
 /**
  * Default props.
  *
- * @type {{viewId: string, t: Function, isDisabled: boolean, graphQuery: {}}}
+ * @type {{viewId: string, t: translate, isDisabled: boolean, graphQuery: {}}}
  */
 Toolbar.defaultProps = {
   graphQuery: {},
   isDisabled: helpers.UI_DISABLED_TOOLBAR,
-  t: helpers.noopTranslate,
+  t: translate,
   viewId: 'toolbar'
 };
 
-const TranslatedToolbar = withTranslation()(Toolbar);
-
-export { TranslatedToolbar as default, TranslatedToolbar, Toolbar };
+export { Toolbar as default, Toolbar };

--- a/src/redux/index.js
+++ b/src/redux/index.js
@@ -1,30 +1,12 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import { withTranslation } from 'react-i18next';
 import { store } from './store';
 import { reduxActions } from './actions';
 import { reduxReducers } from './reducers';
 import { reduxSelectors } from './selectors';
 import { reduxTypes } from './types';
-import { helpers } from '../common/helpers';
-
-const connectTranslate = (mapStateToProps, mapDispatchToProps) => component =>
-  connect(mapStateToProps, mapDispatchToProps)((!helpers.TEST_MODE && withTranslation()(component)) || component);
-
-const connectRouterTranslate = (mapStateToProps, mapDispatchToProps) => component =>
-  withRouter(connectTranslate(mapStateToProps, mapDispatchToProps)(component));
 
 const connectRouter = (mapStateToProps, mapDispatchToProps) => component =>
   withRouter(connect(mapStateToProps, mapDispatchToProps)(component));
 
-export {
-  connect,
-  connectRouter,
-  connectRouterTranslate,
-  connectTranslate,
-  reduxActions,
-  reduxReducers,
-  reduxSelectors,
-  reduxTypes,
-  store
-};
+export { connect, connectRouter, reduxActions, reduxReducers, reduxSelectors, reduxTypes, store };


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(i18n,translate): issues/354 remove withTranslation
   * i18n, replace withTranslation new HOC, use direct translate function
   * redux, remove withTranslation convenience HOCs

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- Behind the scenes updates, there should be no visual difference regarding copy
- This converts the use of the "t" function to now include the ability to replace tokens giving us the ability to use components in them. This makes use of existing functionality, gives consistency in behavior by reorganizing and cleaning up how the "t" function functions
- Updates the "translateComponent" method to be a replacement for "withTranslation" in the event we need a Higher Order Component in the future

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`

<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. Confirm locale strings are still being replaced and that no i18next tokens are being displayed.

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Updates #354 