### PR TITLE
fix(toolbar): issues/10 default usage filter category

### DIFF
--- a/src/components/toolbar/__tests__/__snapshots__/toolbar.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbar.test.js.snap
@@ -1,370 +1,460 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Toolbar Component should handle adding and clearing filters from redux state: dispatch filter 1`] = `
-[MockFunction] {
-  "calls": Array [
+Array [
+  Array [
+    Object {
+      "data": Object {
+        "currentFilter": "sla",
+      },
+      "type": "SET_FILTER_TYPE",
+    },
+  ],
+  Array [
     Array [
       Object {
         "data": Object {
-          "currentFilter": "sla",
+          "activeFilters": Set {
+            "sla",
+          },
+        },
+        "type": "SET_ACTIVE_FILTERS",
+      },
+      Object {
+        "data": Object {
+          "sla": "premium",
+        },
+        "type": "SET_QUERY_SLA_RHSM",
+      },
+    ],
+  ],
+  Array [
+    Array [
+      Object {
+        "data": Object {
+          "activeFilters": Set {
+            "sla",
+          },
+        },
+        "type": "SET_ACTIVE_FILTERS",
+      },
+      Object {
+        "data": Object {
+          "sla": "standard",
+        },
+        "type": "SET_QUERY_SLA_RHSM",
+      },
+    ],
+  ],
+  Array [
+    Array [
+      Object {
+        "data": Object {
+          "activeFilters": Set {},
+        },
+        "type": "SET_ACTIVE_FILTERS",
+      },
+      Object {
+        "data": Object {
+          "clearFilters": Object {
+            "sla": null,
+          },
+        },
+        "type": "SET_QUERY_CLEAR",
+      },
+    ],
+  ],
+  Array [
+    Object {
+      "data": Object {
+        "currentFilter": "usage",
+      },
+      "type": "SET_FILTER_TYPE",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "data": Object {
+          "activeFilters": Set {
+            "usage",
+          },
+        },
+        "type": "SET_ACTIVE_FILTERS",
+      },
+      Object {
+        "data": Object {
+          "usage": "Development/Test",
+        },
+        "type": "SET_QUERY_USAGE_RHSM",
+      },
+    ],
+  ],
+  Array [
+    Array [
+      Object {
+        "data": Object {
+          "activeFilters": Set {
+            "usage",
+          },
+        },
+        "type": "SET_ACTIVE_FILTERS",
+      },
+      Object {
+        "data": Object {
+          "usage": "Disaster Recovery",
+        },
+        "type": "SET_QUERY_USAGE_RHSM",
+      },
+    ],
+  ],
+  Array [
+    Array [
+      Object {
+        "data": Object {
+          "activeFilters": Set {},
+        },
+        "type": "SET_ACTIVE_FILTERS",
+      },
+      Object {
+        "data": Object {
+          "clearFilters": Object {
+            "usage": null,
+          },
+        },
+        "type": "SET_QUERY_CLEAR",
+      },
+    ],
+  ],
+  Array [
+    Array [
+      Object {
+        "data": Object {
+          "activeFilters": Set {},
+        },
+        "type": "SET_ACTIVE_FILTERS",
+      },
+      Object {
+        "data": Object {
+          "clearFilters": Object {
+            "sla": null,
+            "usage": null,
+          },
+        },
+        "type": "SET_QUERY_CLEAR",
+      },
+    ],
+  ],
+]
+`;
+
+exports[`Toolbar Component should handle adding and clearing filters from redux state: dispatch filter, hard reset 1`] = `
+Array [
+  Array [
+    Object {
+      "data": Object {
+        "currentFilter": "sla",
+      },
+      "type": "SET_FILTER_TYPE",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "data": Object {
+          "activeFilters": Set {
+            "sla",
+          },
+        },
+        "type": "SET_ACTIVE_FILTERS",
+      },
+      Object {
+        "data": Object {
+          "sla": "premium",
+        },
+        "type": "SET_QUERY_SLA_RHSM",
+      },
+    ],
+  ],
+  Array [
+    Array [
+      Object {
+        "data": Object {
+          "activeFilters": Set {
+            "sla",
+          },
+        },
+        "type": "SET_ACTIVE_FILTERS",
+      },
+      Object {
+        "data": Object {
+          "sla": "standard",
+        },
+        "type": "SET_QUERY_SLA_RHSM",
+      },
+    ],
+  ],
+  Array [
+    Array [
+      Object {
+        "data": Object {
+          "activeFilters": Set {},
+        },
+        "type": "SET_ACTIVE_FILTERS",
+      },
+      Object {
+        "data": Object {
+          "clearFilters": Object {
+            "sla": null,
+          },
+        },
+        "type": "SET_QUERY_CLEAR",
+      },
+    ],
+  ],
+  Array [
+    Object {
+      "data": Object {
+        "currentFilter": "usage",
+      },
+      "type": "SET_FILTER_TYPE",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "data": Object {
+          "activeFilters": Set {
+            "usage",
+          },
+        },
+        "type": "SET_ACTIVE_FILTERS",
+      },
+      Object {
+        "data": Object {
+          "usage": "Development/Test",
+        },
+        "type": "SET_QUERY_USAGE_RHSM",
+      },
+    ],
+  ],
+  Array [
+    Array [
+      Object {
+        "data": Object {
+          "activeFilters": Set {
+            "usage",
+          },
+        },
+        "type": "SET_ACTIVE_FILTERS",
+      },
+      Object {
+        "data": Object {
+          "usage": "Disaster Recovery",
+        },
+        "type": "SET_QUERY_USAGE_RHSM",
+      },
+    ],
+  ],
+  Array [
+    Array [
+      Object {
+        "data": Object {
+          "activeFilters": Set {},
+        },
+        "type": "SET_ACTIVE_FILTERS",
+      },
+      Object {
+        "data": Object {
+          "clearFilters": Object {
+            "usage": null,
+          },
+        },
+        "type": "SET_QUERY_CLEAR",
+      },
+    ],
+  ],
+  Array [
+    Array [
+      Object {
+        "data": Object {
+          "activeFilters": Set {},
+        },
+        "type": "SET_ACTIVE_FILTERS",
+      },
+      Object {
+        "data": Object {
+          "clearFilters": Object {
+            "sla": null,
+            "usage": null,
+          },
+        },
+        "type": "SET_QUERY_CLEAR",
+      },
+    ],
+  ],
+  Array [
+    Object {
+      "data": Object {
+        "currentFilter": "sla",
+      },
+      "type": "SET_FILTER_TYPE",
+    },
+  ],
+  Array [
+    Array [
+      Object {
+        "data": Object {
+          "activeFilters": Set {
+            "sla",
+          },
+        },
+        "type": "SET_ACTIVE_FILTERS",
+      },
+      Object {
+        "data": Object {
+          "sla": "premium",
+        },
+        "type": "SET_QUERY_SLA_RHSM",
+      },
+    ],
+  ],
+  Array [
+    Array [
+      Object {
+        "data": Object {
+          "activeFilters": Set {
+            "sla",
+          },
+        },
+        "type": "SET_ACTIVE_FILTERS",
+      },
+      Object {
+        "data": Object {
+          "sla": "standard",
+        },
+        "type": "SET_QUERY_SLA_RHSM",
+      },
+    ],
+  ],
+  Array [
+    Array [
+      Object {
+        "data": Object {
+          "activeFilters": Set {},
+        },
+        "type": "SET_ACTIVE_FILTERS",
+      },
+      Object {
+        "data": Object {
+          "clearFilters": Object {
+            "sla": null,
+          },
+        },
+        "type": "SET_QUERY_CLEAR",
+      },
+      Object {
+        "data": Object {
+          "currentFilter": null,
         },
         "type": "SET_FILTER_TYPE",
       },
     ],
-    Array [
-      Array [
-        Object {
-          "data": Object {
-            "activeFilters": Set {
-              "sla",
-            },
-          },
-          "type": "SET_ACTIVE_FILTERS",
-        },
-        Object {
-          "data": Object {
-            "sla": "premium",
-          },
-          "type": "SET_QUERY_SLA_RHSM",
-        },
-      ],
-    ],
-    Array [
-      Array [
-        Object {
-          "data": Object {
-            "activeFilters": Set {
-              "sla",
-            },
-          },
-          "type": "SET_ACTIVE_FILTERS",
-        },
-        Object {
-          "data": Object {
-            "sla": "standard",
-          },
-          "type": "SET_QUERY_SLA_RHSM",
-        },
-      ],
-    ],
-    Array [
-      Array [
-        Object {
-          "data": Object {
-            "currentFilter": null,
-          },
-          "type": "SET_FILTER_TYPE",
-        },
-        Object {
-          "data": Object {
-            "activeFilters": Set {},
-          },
-          "type": "SET_ACTIVE_FILTERS",
-        },
-        Object {
-          "data": Object {
-            "clearFilters": Object {
-              "sla": null,
-            },
-          },
-          "type": "SET_QUERY_CLEAR",
-        },
-      ],
-    ],
+  ],
+  Array [
+    Object {
+      "data": Object {
+        "currentFilter": "usage",
+      },
+      "type": "SET_FILTER_TYPE",
+    },
+  ],
+  Array [
     Array [
       Object {
         "data": Object {
-          "currentFilter": "usage",
+          "activeFilters": Set {
+            "usage",
+          },
+        },
+        "type": "SET_ACTIVE_FILTERS",
+      },
+      Object {
+        "data": Object {
+          "usage": "Development/Test",
+        },
+        "type": "SET_QUERY_USAGE_RHSM",
+      },
+    ],
+  ],
+  Array [
+    Array [
+      Object {
+        "data": Object {
+          "activeFilters": Set {
+            "usage",
+          },
+        },
+        "type": "SET_ACTIVE_FILTERS",
+      },
+      Object {
+        "data": Object {
+          "usage": "Disaster Recovery",
+        },
+        "type": "SET_QUERY_USAGE_RHSM",
+      },
+    ],
+  ],
+  Array [
+    Array [
+      Object {
+        "data": Object {
+          "activeFilters": Set {},
+        },
+        "type": "SET_ACTIVE_FILTERS",
+      },
+      Object {
+        "data": Object {
+          "clearFilters": Object {
+            "usage": null,
+          },
+        },
+        "type": "SET_QUERY_CLEAR",
+      },
+      Object {
+        "data": Object {
+          "currentFilter": null,
         },
         "type": "SET_FILTER_TYPE",
       },
     ],
+  ],
+  Array [
     Array [
-      Array [
-        Object {
-          "data": Object {
-            "activeFilters": Set {
-              "usage",
-            },
-          },
-          "type": "SET_ACTIVE_FILTERS",
+      Object {
+        "data": Object {
+          "activeFilters": Set {},
         },
-        Object {
-          "data": Object {
-            "usage": "Development/Test",
+        "type": "SET_ACTIVE_FILTERS",
+      },
+      Object {
+        "data": Object {
+          "clearFilters": Object {
+            "sla": null,
+            "usage": null,
           },
-          "type": "SET_QUERY_USAGE_RHSM",
         },
-      ],
-    ],
-    Array [
-      Array [
-        Object {
-          "data": Object {
-            "activeFilters": Set {
-              "usage",
-            },
-          },
-          "type": "SET_ACTIVE_FILTERS",
+        "type": "SET_QUERY_CLEAR",
+      },
+      Object {
+        "data": Object {
+          "currentFilter": null,
         },
-        Object {
-          "data": Object {
-            "usage": "Disaster Recovery",
-          },
-          "type": "SET_QUERY_USAGE_RHSM",
-        },
-      ],
-    ],
-    Array [
-      Array [
-        Object {
-          "data": Object {
-            "currentFilter": null,
-          },
-          "type": "SET_FILTER_TYPE",
-        },
-        Object {
-          "data": Object {
-            "activeFilters": Set {},
-          },
-          "type": "SET_ACTIVE_FILTERS",
-        },
-        Object {
-          "data": Object {
-            "clearFilters": Object {
-              "usage": null,
-            },
-          },
-          "type": "SET_QUERY_CLEAR",
-        },
-      ],
-    ],
-    Array [
-      Array [
-        Object {
-          "data": Object {
-            "currentFilter": null,
-          },
-          "type": "SET_FILTER_TYPE",
-        },
-        Object {
-          "data": Object {
-            "activeFilters": Set {},
-          },
-          "type": "SET_ACTIVE_FILTERS",
-        },
-        Object {
-          "data": Object {
-            "clearFilters": Object {
-              "sla": null,
-              "usage": null,
-            },
-          },
-          "type": "SET_QUERY_CLEAR",
-        },
-      ],
+        "type": "SET_FILTER_TYPE",
+      },
     ],
   ],
-  "results": Array [
-    Object {
-      "type": "return",
-      "value": Object {
-        "data": undefined,
-        "type": Object {
-          "data": Object {
-            "currentFilter": "sla",
-          },
-          "type": "SET_FILTER_TYPE",
-        },
-      },
-    },
-    Object {
-      "type": "return",
-      "value": Object {
-        "data": undefined,
-        "type": Array [
-          Object {
-            "data": Object {
-              "activeFilters": Set {
-                "sla",
-              },
-            },
-            "type": "SET_ACTIVE_FILTERS",
-          },
-          Object {
-            "data": Object {
-              "sla": "premium",
-            },
-            "type": "SET_QUERY_SLA_RHSM",
-          },
-        ],
-      },
-    },
-    Object {
-      "type": "return",
-      "value": Object {
-        "data": undefined,
-        "type": Array [
-          Object {
-            "data": Object {
-              "activeFilters": Set {
-                "sla",
-              },
-            },
-            "type": "SET_ACTIVE_FILTERS",
-          },
-          Object {
-            "data": Object {
-              "sla": "standard",
-            },
-            "type": "SET_QUERY_SLA_RHSM",
-          },
-        ],
-      },
-    },
-    Object {
-      "type": "return",
-      "value": Object {
-        "data": undefined,
-        "type": Array [
-          Object {
-            "data": Object {
-              "currentFilter": null,
-            },
-            "type": "SET_FILTER_TYPE",
-          },
-          Object {
-            "data": Object {
-              "activeFilters": Set {},
-            },
-            "type": "SET_ACTIVE_FILTERS",
-          },
-          Object {
-            "data": Object {
-              "clearFilters": Object {
-                "sla": null,
-              },
-            },
-            "type": "SET_QUERY_CLEAR",
-          },
-        ],
-      },
-    },
-    Object {
-      "type": "return",
-      "value": Object {
-        "data": undefined,
-        "type": Object {
-          "data": Object {
-            "currentFilter": "usage",
-          },
-          "type": "SET_FILTER_TYPE",
-        },
-      },
-    },
-    Object {
-      "type": "return",
-      "value": Object {
-        "data": undefined,
-        "type": Array [
-          Object {
-            "data": Object {
-              "activeFilters": Set {
-                "usage",
-              },
-            },
-            "type": "SET_ACTIVE_FILTERS",
-          },
-          Object {
-            "data": Object {
-              "usage": "Development/Test",
-            },
-            "type": "SET_QUERY_USAGE_RHSM",
-          },
-        ],
-      },
-    },
-    Object {
-      "type": "return",
-      "value": Object {
-        "data": undefined,
-        "type": Array [
-          Object {
-            "data": Object {
-              "activeFilters": Set {
-                "usage",
-              },
-            },
-            "type": "SET_ACTIVE_FILTERS",
-          },
-          Object {
-            "data": Object {
-              "usage": "Disaster Recovery",
-            },
-            "type": "SET_QUERY_USAGE_RHSM",
-          },
-        ],
-      },
-    },
-    Object {
-      "type": "return",
-      "value": Object {
-        "data": undefined,
-        "type": Array [
-          Object {
-            "data": Object {
-              "currentFilter": null,
-            },
-            "type": "SET_FILTER_TYPE",
-          },
-          Object {
-            "data": Object {
-              "activeFilters": Set {},
-            },
-            "type": "SET_ACTIVE_FILTERS",
-          },
-          Object {
-            "data": Object {
-              "clearFilters": Object {
-                "usage": null,
-              },
-            },
-            "type": "SET_QUERY_CLEAR",
-          },
-        ],
-      },
-    },
-    Object {
-      "type": "return",
-      "value": Object {
-        "data": undefined,
-        "type": Array [
-          Object {
-            "data": Object {
-              "currentFilter": null,
-            },
-            "type": "SET_FILTER_TYPE",
-          },
-          Object {
-            "data": Object {
-              "activeFilters": Set {},
-            },
-            "type": "SET_ACTIVE_FILTERS",
-          },
-          Object {
-            "data": Object {
-              "clearFilters": Object {
-                "sla": null,
-                "usage": null,
-              },
-            },
-            "type": "SET_QUERY_CLEAR",
-          },
-        ],
-      },
-    },
-  ],
-}
+]
 `;
 
 exports[`Toolbar Component should render a non-connected component: non-connected 1`] = `
@@ -414,7 +504,11 @@ exports[`Toolbar Component should render a non-connected component: non-connecte
               ]
             }
             placeholder="t(curiosity-toolbar.categoryPlaceholder)"
-            selectedOptions={Array []}
+            selectedOptions={
+              Array [
+                "t(curiosity-toolbar.usageCategory)",
+              ]
+            }
             toggleIcon={
               <FilterIcon
                 color="currentColor"
@@ -470,7 +564,7 @@ exports[`Toolbar Component should render a non-connected component: non-connecte
           categoryName="t(curiosity-toolbar.usageCategory)"
           chips={Array []}
           deleteChip={[Function]}
-          showToolbarItem={false}
+          showToolbarItem={true}
         >
           <Select
             aria-label="t(curiosity-toolbar.usageCategory)"

--- a/src/components/toolbar/__tests__/toolbar.test.js
+++ b/src/components/toolbar/__tests__/toolbar.test.js
@@ -49,25 +49,34 @@ describe('Toolbar Component', () => {
   it('should handle adding and clearing filters from redux state', () => {
     const props = {};
     const component = mount(<Toolbar {...props} />);
-    const componentInstance = component.instance();
 
-    const filters = [
-      { category: RHSM_API_QUERY_SLA, method: 'onSlaSelect' },
-      { category: RHSM_API_QUERY_USAGE, method: 'onUsageSelect' }
-    ];
+    const filterMethods = () => {
+      const componentInstance = component.instance();
 
-    filters.forEach(({ category, method }) => {
-      componentInstance.onCategorySelect({ value: category });
+      const filters = [
+        { category: RHSM_API_QUERY_SLA, method: 'onSlaSelect' },
+        { category: RHSM_API_QUERY_USAGE, method: 'onUsageSelect' }
+      ];
 
-      const [optionOne, optionTwo] = toolbarTypes.getOptions(category).options;
-      componentInstance[method]({ value: optionOne.value });
-      componentInstance[method]({ value: optionTwo.value });
+      filters.forEach(({ category, method }) => {
+        componentInstance.onCategorySelect({ value: category });
 
-      const { title: categoryTitle } = toolbarTypes.getOptions().options.find(({ value }) => value === category);
-      componentInstance.onClearFilter(categoryTitle);
-    });
+        const [optionOne, optionTwo] = toolbarTypes.getOptions(category).options;
+        componentInstance[method]({ value: optionOne.value });
+        componentInstance[method]({ value: optionTwo.value });
 
-    componentInstance.onClear();
-    expect(mockDispatch).toMatchSnapshot('dispatch filter');
+        const { title: categoryTitle } = toolbarTypes.getOptions().options.find(({ value }) => value === category);
+        componentInstance.onClearFilter(categoryTitle);
+      });
+
+      componentInstance.onClear();
+    };
+
+    filterMethods();
+    expect(mockDispatch.mock.calls).toMatchSnapshot('dispatch filter');
+
+    component.setProps({ currentFilter: null, hardFilterReset: true });
+    filterMethods();
+    expect(mockDispatch.mock.calls).toMatchSnapshot('dispatch filter, hard reset');
   });
 });

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -33,8 +33,8 @@ class Toolbar extends React.Component {
    * @event onClear
    */
   onClear = () => {
-    this.setDispatch([
-      { type: reduxTypes.toolbar.SET_FILTER_TYPE, data: { currentFilter: null } },
+    const { hardFilterReset } = this.props;
+    const dispatchActions = [
       { type: reduxTypes.toolbar.SET_ACTIVE_FILTERS, data: { activeFilters: new Set() } },
       {
         type: reduxTypes.query.SET_QUERY_CLEAR,
@@ -45,7 +45,13 @@ class Toolbar extends React.Component {
           }
         }
       }
-    ]);
+    ];
+
+    if (hardFilterReset) {
+      dispatchActions.push({ type: reduxTypes.toolbar.SET_FILTER_TYPE, data: { currentFilter: null } });
+    }
+
+    this.setDispatch(dispatchActions);
   };
 
   /**
@@ -55,7 +61,7 @@ class Toolbar extends React.Component {
    * @param {string} categoryTitle
    */
   onClearFilter = categoryTitle => {
-    const { activeFilters, currentFilter } = this.props;
+    const { activeFilters, currentFilter, hardFilterReset } = this.props;
 
     const categoryOptions = toolbarTypes.getOptions();
     const { value: categoryValue } = categoryOptions.options.find(({ title }) => title === categoryTitle) || {};
@@ -67,10 +73,7 @@ class Toolbar extends React.Component {
     const updatedActiveFilters = new Set(activeFilters);
     updatedActiveFilters.delete(categoryValue);
 
-    const updatedCurrentFilter = (updatedActiveFilters.size > 0 && currentFilter) || null;
-
-    this.setDispatch([
-      { type: reduxTypes.toolbar.SET_FILTER_TYPE, data: { currentFilter: updatedCurrentFilter } },
+    const dispatchActions = [
       { type: reduxTypes.toolbar.SET_ACTIVE_FILTERS, data: { activeFilters: updatedActiveFilters } },
       {
         type: reduxTypes.query.SET_QUERY_CLEAR,
@@ -80,7 +83,14 @@ class Toolbar extends React.Component {
           }
         }
       }
-    ]);
+    ];
+
+    if (hardFilterReset) {
+      const updatedCurrentFilter = (updatedActiveFilters.size > 0 && currentFilter) || null;
+      dispatchActions.push({ type: reduxTypes.toolbar.SET_FILTER_TYPE, data: { currentFilter: updatedCurrentFilter } });
+    }
+
+    this.setDispatch(dispatchActions);
   };
 
   /**
@@ -259,7 +269,8 @@ class Toolbar extends React.Component {
 /**
  * Prop types
  *
- * @type {{viewId: string, t: Function, activeFilters, query, currentFilter: string, isDisabled: boolean}}
+ * @type {{viewId: string, t: Function, activeFilters, hardFilterReset: boolean, query, currentFilter: string,
+ *     isDisabled: boolean}}
  */
 Toolbar.propTypes = {
   query: PropTypes.shape({
@@ -268,6 +279,7 @@ Toolbar.propTypes = {
   }),
   activeFilters: PropTypes.instanceOf(Set),
   currentFilter: PropTypes.oneOf([rhsmApiTypes.RHSM_API_QUERY_SLA, rhsmApiTypes.RHSM_API_QUERY_USAGE]),
+  hardFilterReset: PropTypes.bool,
   isDisabled: PropTypes.bool,
   t: PropTypes.func,
   viewId: PropTypes.string
@@ -276,12 +288,14 @@ Toolbar.propTypes = {
 /**
  * Default props.
  *
- * @type {{viewId: string, t: translate, activeFilters: Set, query: {}, currentFilter: null, isDisabled: boolean}}
+ * @type {{viewId: string, t: translate, activeFilters: Set, hardFilterReset: boolean, query: {},
+ *     currentFilter: null, isDisabled: boolean}}
  */
 Toolbar.defaultProps = {
   query: {},
   activeFilters: new Set(),
-  currentFilter: null,
+  currentFilter: rhsmApiTypes.RHSM_API_QUERY_USAGE,
+  hardFilterReset: false,
   isDisabled: helpers.UI_DISABLED_TOOLBAR,
   t: translate,
   viewId: 'toolbar'


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
fix(toolbar): issues/10 default usage filter category
   * toolbar, default filter category, soft filter reset

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- Toolbar filters start the initial view with the "usage" category selected
- "Clearing all" filters leaves the last selected category visually active
- The default category can be easily updated in the future

@rblackbu 

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. observe the initial starting filter category is usage, see attached screenshot

<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screen Shot 2020-08-05 at 10 48 41 AM](https://user-images.githubusercontent.com/3761375/89427502-4d503100-d709-11ea-8683-4fa05578f04c.png)

![Aug-05-2020 10-53-23](https://user-images.githubusercontent.com/3761375/89428199-1fb7b780-d70a-11ea-9dc5-4ffb7c537f94.gif)



## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Updates #10