### PR TITLE
fix(pageHeader): update subheading external link icon

### DIFF
--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -276,7 +276,7 @@ Array [
     "keys": Array [
       Object {
         "key": "",
-        "match": "t(\`curiosity-view.\${viewId}Subtitle\`, {}, [ <Button isInline component=\\"a\\" variant=\\"link\\" icon={<ExternalLinkSquareAltIcon />} iconPosition=\\"right\\" target=\\"_blank\\" href=\\"https://access.redhat.com/documentation/en-us/subscription_central/2020-04/html/getting_started_with_subscription_watch/con-how-does-subscriptionwatch-show-data_assembly-opening-subscriptionwatch-ctxt/\\" /> ])",
+        "match": "t(\`curiosity-view.\${viewId}Subtitle\`, {}, [ <Button isInline component=\\"a\\" variant=\\"link\\" icon={<ExternalLinkAltIcon />} iconPosition=\\"right\\" target=\\"_blank\\" href=\\"https://access.redhat.com/documentation/en-us/subscription_central/2020-04/html/getting_started_with_subscription_watch/con-how-does-subscriptionwatch-show-data_assembly-opening-subscriptionwatch-ctxt/\\" /> ])",
       },
     ],
   },

--- a/src/components/pageLayout/pageHeader.js
+++ b/src/components/pageLayout/pageHeader.js
@@ -5,7 +5,7 @@ import {
   PageHeaderTitle
 } from '@redhat-cloud-services/frontend-components/components/cjs/PageHeader';
 import { Button } from '@patternfly/react-core';
-import { ExternalLinkSquareAltIcon } from '@patternfly/react-icons';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { translate } from '../i18n/i18n';
 
 /**
@@ -27,7 +27,7 @@ const PageHeader = ({ children, t, viewId }) => (
             isInline
             component="a"
             variant="link"
-            icon={<ExternalLinkSquareAltIcon />}
+            icon={<ExternalLinkAltIcon />}
             iconPosition="right"
             target="_blank"
             href="https://access.redhat.com/documentation/en-us/subscription_central/2020-04/html/getting_started_with_subscription_watch/con-how-does-subscriptionwatch-show-data_assembly-opening-subscriptionwatch-ctxt/"


### PR DESCRIPTION
## What's included
- fix(pageHeader): update subheading external link icon
  - pageHeader, update external link icon from ExternalLinkSquareAltIcon to ExternalLinkAltIcon

<!-- ### Notes -->
<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. visit `/rhel-sw/all` and confirm the link icon in the header is correct
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![external_link_icon](https://user-images.githubusercontent.com/2515650/89444774-37019f80-d720-11ea-9db9-1dcf3fe6d038.png)


## Updates issue/story
Updates #367 
