### PR TITLE
fix(inventoryList): issues/10 missing platform component

### DIFF
--- a/src/components/inventoryList/__tests__/__snapshots__/inventoryList.test.js.snap
+++ b/src/components/inventoryList/__tests__/__snapshots__/inventoryList.test.js.snap
@@ -61,14 +61,18 @@ exports[`InventoryList Component should handle variations in data: filtered data
   <CardFooter
     className=""
   >
-    <Connect(Pagination)
-      dropDirection="up"
-      isDisabled={false}
-      itemCount={0}
-      perPageDefault={10}
-      productId="lorem"
-      viewId="inventoryList"
-    />
+    <TableToolbar
+      isFooter={true}
+    >
+      <Connect(Pagination)
+        dropDirection="up"
+        isDisabled={false}
+        itemCount={0}
+        perPageDefault={10}
+        productId="lorem"
+        viewId="inventoryList"
+      />
+    </TableToolbar>
   </CardFooter>
 </Card>
 `;
@@ -137,14 +141,18 @@ exports[`InventoryList Component should handle variations in data: variable data
   <CardFooter
     className=""
   >
-    <Connect(Pagination)
-      dropDirection="up"
-      isDisabled={false}
-      itemCount={0}
-      perPageDefault={10}
-      productId="lorem"
-      viewId="inventoryList"
-    />
+    <TableToolbar
+      isFooter={true}
+    >
+      <Connect(Pagination)
+        dropDirection="up"
+        isDisabled={false}
+        itemCount={0}
+        perPageDefault={10}
+        productId="lorem"
+        viewId="inventoryList"
+      />
+    </TableToolbar>
   </CardFooter>
 </Card>
 `;
@@ -193,14 +201,18 @@ exports[`InventoryList Component should render a non-connected component: non-co
   <CardFooter
     className=""
   >
-    <Connect(Pagination)
-      dropDirection="up"
-      isDisabled={false}
-      itemCount={0}
-      perPageDefault={10}
-      productId="lorem"
-      viewId="inventoryList"
-    />
+    <TableToolbar
+      isFooter={true}
+    >
+      <Connect(Pagination)
+        dropDirection="up"
+        isDisabled={false}
+        itemCount={0}
+        perPageDefault={10}
+        productId="lorem"
+        viewId="inventoryList"
+      />
+    </TableToolbar>
   </CardFooter>
 </Card>
 `;

--- a/src/components/inventoryList/inventoryList.js
+++ b/src/components/inventoryList/inventoryList.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import _isEqual from 'lodash/isEqual';
 import { TableVariant } from '@patternfly/react-table';
 import { Card, CardActions, CardBody, CardFooter, CardHeader, CardTitle, Title } from '@patternfly/react-core';
+import { TableToolbar } from '@redhat-cloud-services/frontend-components/components/cjs/TableToolbar';
 import { helpers } from '../../common';
 import { connect, reduxActions, reduxSelectors } from '../../redux';
 import Table from '../table/table';
@@ -11,6 +12,11 @@ import { inventoryListHelpers } from './inventoryListHelpers';
 import Pagination from '../pagination/pagination';
 import { RHSM_API_QUERY_TYPES } from '../../types/rhsmApiTypes';
 
+/**
+ * A system inventory component.
+ *
+ * @augments React.Component
+ */
 class InventoryList extends React.Component {
   componentDidMount() {
     this.onUpdateInventoryData();
@@ -32,6 +38,11 @@ class InventoryList extends React.Component {
     }
   };
 
+  /**
+   * Render an inventory table.
+   *
+   * @returns {Node}
+   */
   renderTable() {
     const { filterInventoryData, listData } = this.props;
     let updatedColumnHeaders = [];
@@ -60,6 +71,11 @@ class InventoryList extends React.Component {
     );
   }
 
+  /**
+   * Render an inventory card.
+   *
+   * @returns {Node}
+   */
   render() {
     const {
       cardTitle,
@@ -118,20 +134,29 @@ class InventoryList extends React.Component {
           </div>
         </CardBody>
         <CardFooter className={(error && 'blur') || ''}>
-          <Pagination
-            isDisabled={pending || error}
-            itemCount={itemCount}
-            productId={productId}
-            viewId={viewId}
-            perPageDefault={updatedPerPage}
-            dropDirection="up"
-          />
+          <TableToolbar isFooter>
+            <Pagination
+              isDisabled={pending || error}
+              itemCount={itemCount}
+              productId={productId}
+              viewId={viewId}
+              perPageDefault={updatedPerPage}
+              dropDirection="up"
+            />
+          </TableToolbar>
         </CardFooter>
       </Card>
     );
   }
 }
 
+/**
+ * Prop types.
+ *
+ * @type {{viewId: string, productId: string, filterInventoryData: Array, listData: Array, pending: boolean, query: object,
+ *     getHostsInventory: Function, perPageDefault: number, isDisabled: boolean, error: boolean, cardTitle: string,
+ *     itemCount: number}}
+ */
 InventoryList.propTypes = {
   error: PropTypes.bool,
   cardTitle: PropTypes.string,
@@ -163,6 +188,12 @@ InventoryList.propTypes = {
   viewId: PropTypes.string
 };
 
+/**
+ * Default props.
+ *
+ * @type {{viewId: string, filterInventoryData: Array, listData: Array, pending: boolean, getHostsInventory: Function,
+ *     perPageDefault: number, isDisabled: boolean, error: boolean, cardTitle: null, itemCount: number}}
+ */
 InventoryList.defaultProps = {
   error: false,
   cardTitle: null,


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(inventoryList): issues/10 missing platform component

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- Compensates for an overly aggressive CSS selector used around the inventory paging footer to aid in the Pendo resource center and maintenance display banner.
- This also pushes the footer paging to the left to compensate for the Pendo resource center icon, see below screenshot

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. Before syncing with this PR log in with a user that has zero inventory listing, typically one of the RHEL architectures. 
   1. You should see a white bar at the bottom, and multiple scrollbars on the right
   2. Sync with this PR, rebuild, refresh, the bar should no longer be seen

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
#### After
      
![Screen Shot 2020-08-21 at 2 32 14 PM](https://user-images.githubusercontent.com/3761375/90923149-278a8380-e3bb-11ea-83cb-cdd8beefb4c1.png)

    
![Screen Shot 2020-08-21 at 2 14 19 PM](https://user-images.githubusercontent.com/3761375/90923219-44bf5200-e3bb-11ea-89ab-d476fbd96ffc.png)


#### Before

![Screen Shot 2020-08-21 at 2 35 31 PM](https://user-images.githubusercontent.com/3761375/90923395-99fb6380-e3bb-11ea-860e-c25af6c30708.png)

![Screen Shot 2020-08-21 at 2 35 56 PM](https://user-images.githubusercontent.com/3761375/90923425-a8497f80-e3bb-11ea-9d6c-8e1c4545f8b3.png)



## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
updates #10