### PR TITLE
fix(testing): platform component import exceptions

### DIFF
--- a/src/components/authentication/authentication.js
+++ b/src/components/authentication/authentication.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { BinocularsIcon, LockIcon } from '@patternfly/react-icons';
-import { Maintenance } from '@redhat-cloud-services/frontend-components/components/Maintenance';
+import { Maintenance } from '@redhat-cloud-services/frontend-components/components/cjs/Maintenance';
 import { connectRouter, reduxActions, reduxSelectors } from '../../redux';
 import { rhsmApiTypes } from '../../types';
 import { helpers } from '../../common';

--- a/tests/__snapshots__/platform.test.js.snap
+++ b/tests/__snapshots__/platform.test.js.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Platform Configuration should have a name reference that matches configuration: ui name 1`] = `
+exports[`Platform Configuration, Build should have a name reference that matches configuration: ui name 1`] = `
 Array [
   "REACT_APP_UI_NAME=subscriptions",
   "",
 ]
 `;
 
-exports[`Platform Configuration should have a proxy configuration with path references that match configuration: proxy references 1`] = `
+exports[`Platform Configuration, Build should have a proxy configuration with path references that match configuration: proxy references 1`] = `
 Array [
   "'/apps/subscriptions': {",
   "'/beta/apps/subscriptions': {",
@@ -19,7 +19,7 @@ Array [
 ]
 `;
 
-exports[`Platform Configuration should have path references that match configuration: path references 1`] = `
+exports[`Platform Configuration, Build should have path references that match configuration: path references 1`] = `
 Array [
   "PUBLIC_URL=\${UI_DEPLOY_PATH_PREFIX}/apps/subscriptions/",
   "REACT_APP_CONFIG_SERVICE_LOCALES=\${UI_DEPLOY_PATH_PREFIX}/apps/subscriptions/locales/locales.json",
@@ -27,3 +27,5 @@ Array [
   "",
 ]
 `;
+
+exports[`Platform Configuration, Build should use direct imports for platform components, with exceptions: direct import exceptions 1`] = `Array []`;

--- a/tests/platform.test.js
+++ b/tests/platform.test.js
@@ -1,7 +1,7 @@
 const { execSync } = require('child_process');
 const packageJson = require('../package');
 
-describe('Platform Configuration', () => {
+describe('Platform Configuration, Build', () => {
   it('should have a name reference that matches configuration', () => {
     const envFile = './.env';
     const { appname } = packageJson.insights;
@@ -29,5 +29,20 @@ describe('Platform Configuration', () => {
         .split('\n')
         .map(value => value.trim())
     ).toMatchSnapshot('proxy references');
+  });
+
+  it('should use direct imports for platform components, with exceptions', () => {
+    const srcDir = 'src';
+    const output = execSync(
+      `echo "$(cd ./${srcDir} && git grep -n -E "(@redhat-cloud-services/frontend-components/components/)")"`
+    );
+
+    expect(
+      output
+        .toString()
+        .trim()
+        .split(/[\n\r]/g)
+        .filter(str => !/\/(cjs|esm)\//.test(str))
+    ).toMatchSnapshot('direct import exceptions');
   });
 });


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(testing): platform component import exceptions

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- Simple testing check that gets overlooked. Checks for exceptions around the Platform team's preferred way of importing components

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->

### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. Tests should run automatically, and all pass
   1. You can also attempt to run the integration checks under dev mode with `$ yarn test:integration-dev`


## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
  
![Screen Shot 2020-08-21 at 3 16 49 PM](https://user-images.githubusercontent.com/3761375/90926582-615e8880-e3c1-11ea-9d52-cec15c681cad.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Ongoing