### PR TITLE
fix(graphCard,chartArea): issues/365 increase stroke width

### DIFF
--- a/src/components/chartArea/__tests__/__snapshots__/chartArea.test.js.snap
+++ b/src/components/chartArea/__tests__/__snapshots__/chartArea.test.js.snap
@@ -1495,7 +1495,7 @@ exports[`ChartArea Component should render basic data: data 1`] = `
             "fill": "#ipsum",
             "stroke": "#lorem",
             "strokeDasharray": "4,3",
-            "strokeWidth": 2.5,
+            "strokeWidth": 3,
           },
         }
       }
@@ -1525,6 +1525,7 @@ exports[`ChartArea Component should render basic data: data 1`] = `
             "data": Object {
               "fill": "#ipsum",
               "stroke": "#lorem",
+              "strokeWidth": 2,
             },
           }
         }

--- a/src/components/chartArea/__tests__/chartArea.test.js
+++ b/src/components/chartArea/__tests__/chartArea.test.js
@@ -29,7 +29,8 @@ describe('ChartArea Component', () => {
           id: 'loremGraph',
           isStacked: true,
           fill: '#ipsum',
-          stroke: '#lorem'
+          stroke: '#lorem',
+          strokeWidth: 2
         },
         {
           data: [
@@ -49,7 +50,7 @@ describe('ChartArea Component', () => {
           fill: '#ipsum',
           stroke: '#lorem',
           strokeDasharray: '4,3',
-          strokeWidth: 2.5
+          strokeWidth: 3
         }
       ]
     };

--- a/src/components/chartArea/chartArea.js
+++ b/src/components/chartArea/chartArea.js
@@ -477,6 +477,10 @@ class ChartArea extends React.Component {
         dataColorStroke.data.stroke = dataSet.stroke;
       }
 
+      if (dataSet.strokeWidth) {
+        dataColorStroke.data.strokeWidth = dataSet.strokeWidth;
+      }
+
       return (
         <PfChartArea
           animate={dataSet.animate || false}

--- a/src/components/graphCard/__tests__/__snapshots__/graphCard.test.js.snap
+++ b/src/components/graphCard/__tests__/__snapshots__/graphCard.test.js.snap
@@ -29,6 +29,7 @@ Array [
     "id": "loremIpsumSockets",
     "isStacked": true,
     "isThreshold": false,
+    "strokeWidth": 2,
   },
   Object {
     "animate": Object {
@@ -59,7 +60,7 @@ Array [
     "isThreshold": true,
     "stroke": "#4cb140",
     "strokeDasharray": "4,3",
-    "strokeWidth": 2.5,
+    "strokeWidth": 3,
   },
 ]
 `;
@@ -175,6 +176,7 @@ Object {
       "id": "physicalSockets",
       "isStacked": true,
       "isThreshold": false,
+      "strokeWidth": 2,
     },
   ],
 }
@@ -267,6 +269,7 @@ exports[`GraphCard Component should render multiple states: error with 403 statu
               "id": "physicalSockets",
               "isStacked": true,
               "isThreshold": false,
+              "strokeWidth": 2,
             },
           ]
         }
@@ -379,6 +382,7 @@ exports[`GraphCard Component should render multiple states: error with 500 statu
               "id": "physicalSockets",
               "isStacked": true,
               "isThreshold": false,
+              "strokeWidth": 2,
             },
           ]
         }
@@ -491,6 +495,7 @@ exports[`GraphCard Component should render multiple states: fulfilled 1`] = `
               "id": "physicalSockets",
               "isStacked": true,
               "isThreshold": false,
+              "strokeWidth": 2,
             },
           ]
         }

--- a/src/components/graphCard/graphCard.js
+++ b/src/components/graphCard/graphCard.js
@@ -118,6 +118,7 @@ class GraphCard extends React.Component {
             duration: 250,
             onLoad: { duration: 250 }
           },
+          strokeWidth: 2,
           isStacked: !/^threshold/.test(key),
           isThreshold: /^threshold/.test(key)
         };
@@ -129,7 +130,7 @@ class GraphCard extends React.Component {
           };
           tempFiltered.stroke = chartColorGreenDark.value;
           tempFiltered.strokeDasharray = '4,3';
-          tempFiltered.strokeWidth = 2.5;
+          tempFiltered.strokeWidth = 3;
         }
 
         return tempFiltered;


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(graphCard,chartArea): issues/365 increase stroke width

### Notes
Instead of updating colors, I've increased the stroke width.  I updated the primary stroke width from 1 (default) to 2.  I also updated the dashed line stroke width from 2.5 to 3, so that it would still be visibly thicker than the other lines.

## How to test
<!-- Are there directions to test/review? -->
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![strokeWidth2](https://user-images.githubusercontent.com/2515650/91355569-54c0a280-e7bc-11ea-816c-d2e6cc3cbad8.png)


## Updates issue/story
Updates #365 
