### PR TITLE
fix(toolbar): issues/400 page reset on filter update

### DIFF
--- a/src/components/openshiftView/__tests__/__snapshots__/openshiftView.test.js.snap
+++ b/src/components/openshiftView/__tests__/__snapshots__/openshiftView.test.js.snap
@@ -17,6 +17,7 @@ exports[`OpenshiftView Component should display an alternate graph on query-stri
           },
         ]
       }
+      productId="lorem ipsum"
       query={
         Object {
           "granularity": "daily",
@@ -151,6 +152,7 @@ exports[`OpenshiftView Component should have a fallback title: title 1`] = `
           },
         ]
       }
+      productId="lorem ipsum"
       query={
         Object {
           "granularity": "daily",
@@ -467,6 +469,7 @@ exports[`OpenshiftView Component should render a non-connected component: non-co
           },
         ]
       }
+      productId="lorem ipsum"
       query={
         Object {
           "granularity": "daily",

--- a/src/components/openshiftView/openshiftView.js
+++ b/src/components/openshiftView/openshiftView.js
@@ -116,7 +116,12 @@ class OpenshiftView extends React.Component {
           {t(`curiosity-view.title`, { appName: helpers.UI_DISPLAY_NAME, context: viewId })}
         </PageHeader>
         <PageToolbar>
-          <Toolbar filterOptions={initialToolbarFilters} query={toolbarQuery} viewId={viewId} />
+          <Toolbar
+            filterOptions={initialToolbarFilters}
+            productId={routeDetail.pathParameter}
+            query={toolbarQuery}
+            viewId={viewId}
+          />
         </PageToolbar>
         <PageSection>
           {(isC3 && (

--- a/src/components/pagination/__tests__/__snapshots__/pagination.test.js.snap
+++ b/src/components/pagination/__tests__/__snapshots__/pagination.test.js.snap
@@ -26,14 +26,14 @@ Array [
         "viewId": "pagination",
       },
       Object {
-        "offset": 10,
-        "type": "SET_QUERY_RHSM_offset",
-        "viewId": "lorem",
-      },
-      Object {
         "limit": 10,
         "type": "SET_QUERY_RHSM_limit",
         "viewId": "pagination",
+      },
+      Object {
+        "offset": 10,
+        "type": "SET_QUERY_RHSM_offset",
+        "viewId": "lorem",
       },
       Object {
         "limit": 10,
@@ -50,14 +50,14 @@ Array [
         "viewId": "pagination",
       },
       Object {
-        "offset": 0,
-        "type": "SET_QUERY_RHSM_offset",
-        "viewId": "lorem",
-      },
-      Object {
         "limit": 20,
         "type": "SET_QUERY_RHSM_limit",
         "viewId": "pagination",
+      },
+      Object {
+        "offset": 0,
+        "type": "SET_QUERY_RHSM_offset",
+        "viewId": "lorem",
       },
       Object {
         "limit": 20,
@@ -142,14 +142,14 @@ Array [
         "viewId": "pagination",
       },
       Object {
-        "offset": 0,
-        "type": "SET_QUERY_RHSM_offset",
-        "viewId": "lorem",
-      },
-      Object {
         "limit": 100,
         "type": "SET_QUERY_RHSM_limit",
         "viewId": "pagination",
+      },
+      Object {
+        "offset": 0,
+        "type": "SET_QUERY_RHSM_offset",
+        "viewId": "lorem",
       },
       Object {
         "limit": 100,

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -25,29 +25,34 @@ class Pagination extends React.Component {
     const { offsetDefault, perPageDefault, productId, query, viewId } = this.props;
     const updatedPerPage = query?.[RHSM_API_QUERY_TYPES.LIMIT] || perPageDefault;
     const offset = updatedPerPage * (page - 1) || offsetDefault;
-
-    store.dispatch([
+    const updatedActions = [
       {
         type: reduxTypes.query.SET_QUERY_RHSM_TYPES[RHSM_API_QUERY_TYPES.OFFSET],
         viewId,
         [RHSM_API_QUERY_TYPES.OFFSET]: offset
       },
       {
-        type: reduxTypes.query.SET_QUERY_RHSM_TYPES[RHSM_API_QUERY_TYPES.OFFSET],
-        viewId: productId,
-        [RHSM_API_QUERY_TYPES.OFFSET]: offset
-      },
-      {
         type: reduxTypes.query.SET_QUERY_RHSM_TYPES[RHSM_API_QUERY_TYPES.LIMIT],
         viewId,
-        [RHSM_API_QUERY_TYPES.LIMIT]: updatedPerPage
-      },
-      {
-        type: reduxTypes.query.SET_QUERY_RHSM_TYPES[RHSM_API_QUERY_TYPES.LIMIT],
-        viewId: productId,
         [RHSM_API_QUERY_TYPES.LIMIT]: updatedPerPage
       }
-    ]);
+    ];
+
+    if (productId && productId !== viewId) {
+      updatedActions.push({
+        type: reduxTypes.query.SET_QUERY_RHSM_TYPES[RHSM_API_QUERY_TYPES.OFFSET],
+        viewId: productId,
+        [RHSM_API_QUERY_TYPES.OFFSET]: offset
+      });
+
+      updatedActions.push({
+        type: reduxTypes.query.SET_QUERY_RHSM_TYPES[RHSM_API_QUERY_TYPES.LIMIT],
+        viewId: productId,
+        [RHSM_API_QUERY_TYPES.LIMIT]: updatedPerPage
+      });
+    }
+
+    store.dispatch(updatedActions);
   };
 
   /**
@@ -59,29 +64,33 @@ class Pagination extends React.Component {
    */
   onPerPage = ({ perPage }) => {
     const { offsetDefault, productId, viewId } = this.props;
-
-    store.dispatch([
+    const updatedActions = [
       {
         type: reduxTypes.query.SET_QUERY_RHSM_TYPES[RHSM_API_QUERY_TYPES.OFFSET],
         viewId,
         [RHSM_API_QUERY_TYPES.OFFSET]: offsetDefault
       },
       {
-        type: reduxTypes.query.SET_QUERY_RHSM_TYPES[RHSM_API_QUERY_TYPES.OFFSET],
-        viewId: productId,
-        [RHSM_API_QUERY_TYPES.OFFSET]: offsetDefault
-      },
-      {
         type: reduxTypes.query.SET_QUERY_RHSM_TYPES[RHSM_API_QUERY_TYPES.LIMIT],
         viewId,
-        [RHSM_API_QUERY_TYPES.LIMIT]: perPage
-      },
-      {
-        type: reduxTypes.query.SET_QUERY_RHSM_TYPES[RHSM_API_QUERY_TYPES.LIMIT],
-        viewId: productId,
         [RHSM_API_QUERY_TYPES.LIMIT]: perPage
       }
-    ]);
+    ];
+
+    if (productId && productId !== viewId) {
+      updatedActions.push({
+        type: reduxTypes.query.SET_QUERY_RHSM_TYPES[RHSM_API_QUERY_TYPES.OFFSET],
+        viewId: productId,
+        [RHSM_API_QUERY_TYPES.OFFSET]: offsetDefault
+      });
+
+      updatedActions.push({
+        type: reduxTypes.query.SET_QUERY_RHSM_TYPES[RHSM_API_QUERY_TYPES.LIMIT],
+        viewId: productId,
+        [RHSM_API_QUERY_TYPES.LIMIT]: perPage
+      });
+    }
+    store.dispatch(updatedActions);
   };
 
   // ToDo: Consider using the PfPagination "offset" prop

--- a/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
+++ b/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
@@ -21,6 +21,7 @@ exports[`RhelView Component should display an alternate graph on query-string up
           },
         ]
       }
+      productId="lorem ipsum"
       query={
         Object {
           "granularity": "daily",
@@ -140,6 +141,7 @@ exports[`RhelView Component should have a fallback title: title 1`] = `
           },
         ]
       }
+      productId="lorem ipsum"
       query={
         Object {
           "granularity": "daily",
@@ -432,6 +434,7 @@ exports[`RhelView Component should render a non-connected component: non-connect
           },
         ]
       }
+      productId="lorem ipsum"
       query={
         Object {
           "granularity": "daily",

--- a/src/components/rhelView/rhelView.js
+++ b/src/components/rhelView/rhelView.js
@@ -53,7 +53,12 @@ class RhelView extends React.Component {
           {t(`curiosity-view.title`, { appName: helpers.UI_DISPLAY_NAME, context: viewId })}
         </PageHeader>
         <PageToolbar>
-          <Toolbar filterOptions={initialToolbarFilters} query={toolbarQuery} viewId={viewId} />
+          <Toolbar
+            filterOptions={initialToolbarFilters}
+            productId={routeDetail.pathParameter}
+            query={toolbarQuery}
+            viewId={viewId}
+          />
         </PageToolbar>
         <PageSection>
           {(isC3 && (

--- a/src/components/toolbar/__tests__/__snapshots__/toolbar.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbar.test.js.snap
@@ -1,5 +1,58 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Toolbar Component should dispatch filters towards redux state with paging resets: NO paging state 1`] = `
+Array [
+  Array [
+    Array [
+      Object {
+        "lorem": "ipsum",
+        "type": "lorem ipsum",
+        "viewId": "toolbar",
+      },
+    ],
+  ],
+]
+`;
+
+exports[`Toolbar Component should dispatch filters towards redux state with paging resets: WITH paging state, NO product id 1`] = `
+Array [
+  Array [
+    Object {
+      "lorem": "ipsum",
+      "type": "lorem ipsum",
+      "viewId": "toolbar",
+    },
+    Object {
+      "offset": 0,
+      "type": "SET_QUERY_RHSM_offset",
+      "viewId": "toolbar",
+    },
+  ],
+]
+`;
+
+exports[`Toolbar Component should dispatch filters towards redux state with paging resets: WITH paging state, WITH product id 1`] = `
+Array [
+  Array [
+    Object {
+      "lorem": "ipsum",
+      "type": "lorem ipsum",
+      "viewId": "toolbar",
+    },
+    Object {
+      "offset": 0,
+      "type": "SET_QUERY_RHSM_offset",
+      "viewId": "toolbar",
+    },
+    Object {
+      "offset": 0,
+      "type": "SET_QUERY_RHSM_offset",
+      "viewId": "lorem",
+    },
+  ],
+]
+`;
+
 exports[`Toolbar Component should handle adding and clearing filters from redux state: dispatch filter 1`] = `
 Array [
   Array [
@@ -27,6 +80,7 @@ Array [
         "type": "SET_QUERY_RHSM_sla",
       },
     ],
+    true,
   ],
   Array [
     Array [
@@ -45,6 +99,7 @@ Array [
         "type": "SET_QUERY_RHSM_sla",
       },
     ],
+    true,
   ],
   Array [
     Array [
@@ -63,6 +118,7 @@ Array [
         "type": "SET_QUERY_CLEAR",
       },
     ],
+    true,
   ],
   Array [
     Object {
@@ -89,6 +145,7 @@ Array [
         "type": "SET_QUERY_RHSM_usage",
       },
     ],
+    true,
   ],
   Array [
     Array [
@@ -107,6 +164,7 @@ Array [
         "type": "SET_QUERY_RHSM_usage",
       },
     ],
+    true,
   ],
   Array [
     Array [
@@ -125,6 +183,7 @@ Array [
         "type": "SET_QUERY_CLEAR",
       },
     ],
+    true,
   ],
   Array [
     Array [
@@ -144,6 +203,7 @@ Array [
         "type": "SET_QUERY_CLEAR",
       },
     ],
+    true,
   ],
 ]
 `;
@@ -175,6 +235,7 @@ Array [
         "type": "SET_QUERY_RHSM_sla",
       },
     ],
+    true,
   ],
   Array [
     Array [
@@ -193,6 +254,7 @@ Array [
         "type": "SET_QUERY_RHSM_sla",
       },
     ],
+    true,
   ],
   Array [
     Array [
@@ -211,6 +273,7 @@ Array [
         "type": "SET_QUERY_CLEAR",
       },
     ],
+    true,
   ],
   Array [
     Object {
@@ -237,6 +300,7 @@ Array [
         "type": "SET_QUERY_RHSM_usage",
       },
     ],
+    true,
   ],
   Array [
     Array [
@@ -255,6 +319,7 @@ Array [
         "type": "SET_QUERY_RHSM_usage",
       },
     ],
+    true,
   ],
   Array [
     Array [
@@ -273,6 +338,7 @@ Array [
         "type": "SET_QUERY_CLEAR",
       },
     ],
+    true,
   ],
   Array [
     Array [
@@ -292,6 +358,7 @@ Array [
         "type": "SET_QUERY_CLEAR",
       },
     ],
+    true,
   ],
   Array [
     Object {
@@ -318,6 +385,7 @@ Array [
         "type": "SET_QUERY_RHSM_sla",
       },
     ],
+    true,
   ],
   Array [
     Array [
@@ -336,6 +404,7 @@ Array [
         "type": "SET_QUERY_RHSM_sla",
       },
     ],
+    true,
   ],
   Array [
     Array [
@@ -360,6 +429,7 @@ Array [
         "type": "SET_FILTER_TYPE",
       },
     ],
+    true,
   ],
   Array [
     Object {
@@ -386,6 +456,7 @@ Array [
         "type": "SET_QUERY_RHSM_usage",
       },
     ],
+    true,
   ],
   Array [
     Array [
@@ -404,6 +475,7 @@ Array [
         "type": "SET_QUERY_RHSM_usage",
       },
     ],
+    true,
   ],
   Array [
     Array [
@@ -428,6 +500,7 @@ Array [
         "type": "SET_FILTER_TYPE",
       },
     ],
+    true,
   ],
   Array [
     Array [
@@ -453,6 +526,7 @@ Array [
         "type": "SET_FILTER_TYPE",
       },
     ],
+    true,
   ],
 ]
 `;

--- a/src/components/toolbar/__tests__/toolbar.test.js
+++ b/src/components/toolbar/__tests__/toolbar.test.js
@@ -1,14 +1,15 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
+import { store } from '../../../redux';
 import { Toolbar } from '../toolbar';
 import { toolbarTypes } from '../toolbarTypes';
 import { RHSM_API_QUERY_TYPES } from '../../../types/rhsmApiTypes';
 
 describe('Toolbar Component', () => {
-  let mockDispatch;
+  let mockSetDispatch;
 
   beforeEach(() => {
-    mockDispatch = jest.spyOn(Toolbar.prototype, 'setDispatch').mockImplementation((type, data) => ({ type, data }));
+    mockSetDispatch = jest.spyOn(Toolbar.prototype, 'setDispatch').mockImplementation((type, data) => ({ type, data }));
   });
 
   afterEach(() => {
@@ -87,10 +88,51 @@ describe('Toolbar Component', () => {
     };
 
     filterMethods();
-    expect(mockDispatch.mock.calls).toMatchSnapshot('dispatch filter');
+    expect(mockSetDispatch.mock.calls).toMatchSnapshot('dispatch filter');
 
     component.setProps({ currentFilter: null, hardFilterReset: true });
     filterMethods();
-    expect(mockDispatch.mock.calls).toMatchSnapshot('dispatch filter, hard reset');
+    expect(mockSetDispatch.mock.calls).toMatchSnapshot('dispatch filter, hard reset');
+  });
+
+  it('should dispatch filters towards redux state with paging resets', () => {
+    // Restore the original setDispatch functionality for testing
+    mockSetDispatch.mockRestore();
+    const mockStoreDispatch = jest.spyOn(store, 'dispatch').mockImplementation((type, data) => ({ type, data }));
+
+    const props = {};
+    const component = shallow(<Toolbar {...props} />);
+    const componentInstance = component.instance();
+
+    componentInstance.setDispatch({
+      type: 'lorem ipsum',
+      data: { lorem: 'ipsum' }
+    });
+    expect(mockStoreDispatch.mock.calls).toMatchSnapshot('NO paging state');
+
+    componentInstance.setDispatch(
+      {
+        type: 'lorem ipsum',
+        data: { lorem: 'ipsum' }
+      },
+      true
+    );
+    expect(mockStoreDispatch.mock.calls[mockStoreDispatch.mock.calls.length - 1]).toMatchSnapshot(
+      'WITH paging state, NO product id'
+    );
+
+    component.setProps({
+      productId: 'lorem'
+    });
+    componentInstance.setDispatch(
+      {
+        type: 'lorem ipsum',
+        data: { lorem: 'ipsum' }
+      },
+      true
+    );
+    expect(mockStoreDispatch.mock.calls[mockStoreDispatch.mock.calls.length - 1]).toMatchSnapshot(
+      'WITH paging state, WITH product id'
+    );
   });
 });

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -151,7 +151,7 @@ class Toolbar extends React.Component {
         [RHSM_API_QUERY_TYPES.OFFSET]: 0
       });
 
-      if (productId) {
+      if (productId && productId !== viewId) {
         updatedActions.push({
           type: reduxTypes.query.SET_QUERY_RHSM_TYPES[RHSM_API_QUERY_TYPES.OFFSET],
           viewId: productId,

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -50,7 +50,7 @@ class Toolbar extends React.Component {
       dispatchActions.push({ type: reduxTypes.toolbar.SET_FILTER_TYPE, data: { currentFilter: null } });
     }
 
-    this.setDispatch(dispatchActions);
+    this.setDispatch(dispatchActions, true);
   };
 
   /**
@@ -89,7 +89,7 @@ class Toolbar extends React.Component {
       dispatchActions.push({ type: reduxTypes.toolbar.SET_FILTER_TYPE, data: { currentFilter: updatedCurrentFilter } });
     }
 
-    this.setDispatch(dispatchActions);
+    this.setDispatch(dispatchActions, true);
   };
 
   /**
@@ -115,30 +115,50 @@ class Toolbar extends React.Component {
     const { value } = event;
     const updatedActiveFilters = new Set(activeFilters).add(field);
 
-    this.setDispatch([
-      {
-        type: reduxTypes.toolbar.SET_ACTIVE_FILTERS,
-        data: { activeFilters: updatedActiveFilters }
-      },
-      {
-        type: reduxTypes.query.SET_QUERY_RHSM_TYPES[field],
-        data: { [field]: value }
-      }
-    ]);
+    this.setDispatch(
+      [
+        {
+          type: reduxTypes.toolbar.SET_ACTIVE_FILTERS,
+          data: { activeFilters: updatedActiveFilters }
+        },
+        {
+          type: reduxTypes.query.SET_QUERY_RHSM_TYPES[field],
+          data: { [field]: value }
+        }
+      ],
+      true
+    );
   };
 
   /**
    * Dispatch a Redux store type.
    *
    * @param {Array|object} actions
+   * @param {boolean} resetPaging
    */
-  setDispatch(actions) {
-    const { viewId } = this.props;
+  setDispatch(actions, resetPaging = false) {
+    const { productId, viewId } = this.props;
     const updatedActions = ((Array.isArray(actions) && actions) || [actions]).map(({ type, data }) => ({
       type,
       viewId,
       ...data
     }));
+
+    if (resetPaging) {
+      updatedActions.push({
+        type: reduxTypes.query.SET_QUERY_RHSM_TYPES[RHSM_API_QUERY_TYPES.OFFSET],
+        viewId,
+        [RHSM_API_QUERY_TYPES.OFFSET]: 0
+      });
+
+      if (productId) {
+        updatedActions.push({
+          type: reduxTypes.query.SET_QUERY_RHSM_TYPES[RHSM_API_QUERY_TYPES.OFFSET],
+          viewId: productId,
+          [RHSM_API_QUERY_TYPES.OFFSET]: 0
+        });
+      }
+    }
 
     store.dispatch(updatedActions);
   }
@@ -279,6 +299,7 @@ Toolbar.propTypes = {
   ),
   hardFilterReset: PropTypes.bool,
   isDisabled: PropTypes.bool,
+  productId: PropTypes.string,
   t: PropTypes.func,
   viewId: PropTypes.string
 };
@@ -306,6 +327,7 @@ Toolbar.defaultProps = {
   ],
   hardFilterReset: false,
   isDisabled: helpers.UI_DISABLED_TOOLBAR,
+  productId: null,
   t: translate,
   viewId: 'toolbar'
 };


### PR DESCRIPTION

## What's included
<!-- Summary of changes/additions -->
- fix(toolbar): issues/400 page reset on filter update
   * openshiftView, rhelView, pass productId to toolbar
   * toolbar, reset page on filter selection and clear

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- Reset the paging offset when a user updates the primary toolbar filters, includes clearing them

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Env check
Steps to reproduce bug, an error should be throw and the GUI displays an error state
1. Locate an account with over 10 inventory listings
1. navigate to the last offset/page with the paging controls
1. select a filter from the primary toolbar that will reduce the inventory results

#### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. perform the same steps as the Env check, confirm no error is thrown

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
#400 