### PR TITLE
chore(build): full error annotations for GitHub workflow PRs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,19 +20,41 @@ jobs:
       - name: Install Node.js packages
         run: yarn install
       - name: Lint and test
-        run: yarn test
+        uses: actions/github-script@v2
+        with:
+          script: |
+            const { execSync } = require('child_process');
+            try {
+              console.log(`${execSync('yarn test', { stdio: 'pipe' })}`);
+            } catch ({ stdout, stderr }) {
+              core.setFailed(`${stdout}\n${stderr}`);
+            }
       - name: Code coverage
         if: ${{ success() }}
         uses: codecov/codecov-action@v1
-      - name: Setup beta integration
-        if: ${{ success() }}
-        run: echo ::set-env name=BUILD_STAGE::Beta
       - name: Confirm beta integration
         if: ${{ success() }}
-        run: yarn build
-      - name: Setup stable integration
-        if: ${{ success() }}
-        run: echo ::set-env name=BUILD_STAGE::Stable
+        uses: actions/github-script@v2
+        with:
+          script: |
+            const { execSync } = require('child_process');
+            try {
+              console.log(`${execSync('yarn build', { stdio: 'pipe' })}`);
+            } catch ({ stdout, stderr }) {
+              core.setFailed(`${stdout}\n${stderr}`);
+            }
+        env:
+          BUILD_STAGE: Beta
       - name: Confirm stable integration
         if: ${{ success() }}
-        run: yarn build
+        uses: actions/github-script@v2
+        with:
+          script: |
+            const { execSync } = require('child_process');
+            try {
+              console.log(`${execSync('yarn build', { stdio: 'pipe' })}`);
+            } catch ({ stdout, stderr }) {
+              core.setFailed(`${stdout}\n${stderr}`);
+            }
+        env:
+          BUILD_STAGE: Stable


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- ~chore(build): commit depth for GitHub workflow PRs~
- chore(build): full error annotations for GitHub workflow PRs

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- ~Expands the number of commits available for the commit lint test currently embedded in the integration tests.~ This appears to be a non-issue if #432 is merged.
- Exposes the error annotations so the logs do not have to be opened. It appears `stderr` for test output is limited... not useful unless it's also combined with the output from `stdout`
- Once tested this will be squashed into the commit from  #427

## How to test
Once this is merged
1. rebase your PR against the CI branch
1. open a PR against CI, there should be a "checks" tab on GitHub PRs
   ![Screen Shot 2020-09-16 at 10 22 31 PM](https://user-images.githubusercontent.com/3761375/93412422-225e0e80-f86b-11ea-9e07-518212d42f82.png)
1. the new workflow should be visible as "Pull request"
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Ongoing, #275 #427 