### PR TITLE
chore(build): cache for GitHub workflow PRs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,20 +17,18 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Set Node.js packages cache directory
-        id: yarn-cache-dir
-        run: echo ::set-output name=CACHE_DIR::$(yarn cache dir)
       - name: Node.js packages cache
         uses: actions/cache@v2
         id: yarn-cache
         with:
-          path: ${{ steps.yarn-cache-dir.outputs.CACHE_DIR }}
+          path: ${{ github.workspace }}/node_modules
           key: ${{ runner.os }}-${{ matrix.node-version }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.node-version }}-yarn
             ${{ runner.os }}-${{ matrix.node-version }}-
             ${{ runner.os }}-
       - name: Install Node.js packages
+        if: ${{ steps.yarn-cache.outputs.cache-hit != 'true' }}
         run: yarn install
       - name: Lint and test
         uses: actions/github-script@v2

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,6 +17,19 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Set Node.js packages cache directory
+        id: yarn-cache-dir
+        run: echo ::set-output name=CACHE_DIR::$(yarn cache dir)
+      - name: Node.js packages cache
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir.outputs.CACHE_DIR }}
+          key: ${{ runner.os }}-${{ matrix.node-version }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node-version }}-yarn
+            ${{ runner.os }}-${{ matrix.node-version }}-
+            ${{ runner.os }}-
       - name: Install Node.js packages
         run: yarn install
       - name: Lint and test


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- chore(build): cache for GitHub workflow PRs

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- This will be squashed into #434 #427
- ~This only caches the yarn cache, NOT the node_modules directory which would contain the `bin` and hence aliases. As a future update we can look at caching the node_modules, For now we've gained an additional `25 sec` averaged reduction in CI runtime~
   - A slight modification to the `path: ${{ steps.yarn-cache-dir.outputs.CACHE_DIR }}` towards `path: ${{ github.workspace }}/node_modules ` may work
      - This reduces the average runtime by over a minute...

## How to test
Once this is merged
1. rebase your PR against the CI branch
1. open a PR against CI, there should be a "checks" tab on GitHub PRs
   ![Screen Shot 2020-09-16 at 10 22 31 PM](https://user-images.githubusercontent.com/3761375/93412422-225e0e80-f86b-11ea-9e07-518212d42f82.png)
1. the new workflow should be visible as "Pull request"
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Ongoing, #275 #427 #434 