### PR TITLE
chore(build): expanded cache for GitHub workflow PRs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,18 +17,26 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Node.js packages cache
+      - name: Set Node.js packages yarn cache directory
+        id: yarn-cache-dir
+        run: echo ::set-output name=CACHE_DIR::$(yarn cache dir)
+      - name: Node.js yarn cache
         uses: actions/cache@v2
-        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir.outputs.CACHE_DIR }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn
+      - name: Node.js modules cache
+        uses: actions/cache@v2
+        id: modules-cache
         with:
           path: ${{ github.workspace }}/node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-${{ matrix.node-version }}-modules-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-yarn
-            ${{ runner.os }}-${{ matrix.node-version }}-
-            ${{ runner.os }}-
+            ${{ runner.os }}-${{ matrix.node-version }}-modules
       - name: Install Node.js packages
-        if: ${{ steps.yarn-cache.outputs.cache-hit != 'true' }}
+        if: ${{ steps.modules-cache.outputs.cache-hit != 'true' }}
         run: yarn install
       - name: Lint and test
         uses: actions/github-script@v2


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- chore(build): expanded cache for GitHub workflow PRs

### Notes
- This will be squashed into #434 #427 #435
- This type of caching appears to help with running multiple node versions
<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
Once this is merged
1. rebase your PR against the CI branch
1. open a PR against CI, there should be a "checks" tab on GitHub PRs
   ![Screen Shot 2020-09-16 at 10 22 31 PM](https://user-images.githubusercontent.com/3761375/93412422-225e0e80-f86b-11ea-9e07-518212d42f82.png)
1. the new workflow should be visible as "Pull request"
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Ongoing, #275 #427 #434 #435 