### PR TITLE
chore(build): travis stages for specific branches

### DIFF
--- a/.github/workflows/commit_lint.yml
+++ b/.github/workflows/commit_lint.yml
@@ -18,8 +18,9 @@ jobs:
         run: |
           git remote add ssh-origin "https://github.com/$GITHUB_REPOSITORY"
           git fetch ssh-origin
-          COMMITS=$(git cherry -v ssh-origin/${{ env.BRANCH }} | grep "+")
-          echo ::set-env name=GIT_COMMITS::$COMMITS
+          echo 'GIT_COMMITS<<EOF' >> $GITHUB_ENV
+          git cherry -v ssh-origin/${{ env.BRANCH }} | grep "+" >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,15 @@ cache: yarn
 jobs:
   include:
     - stage: Test
-      script: yarn test:lint
-    - before_script: yarn global add codecov
-      script: yarn test:ci
+      before_script: yarn global add codecov
+      script: yarn test
       after_success: codecov
     - stage: Beta Deploy
+      if: branch IN (stage, dev, ci)
       script: yarn build && curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/bootstrap.sh
         | bash -s
     - stage: Stable Deploy
+      if: branch IN (master, main, prod, test, qa)
       script: yarn build && curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/bootstrap.sh
         | bash -s
 env:


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- chore(build): travis stages for specific branches
- chore(build): workflow for commits, deprecated set-env

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- Coordinates CI against GitHub PR workflow. Once the GitHub workflows merge into master Travis will be limited to branch pushes only. This focuses Travis build stages to specific branches in order to avoid duplicated effort handled by GitHub workflows, and potentially unnecessary cycles since deploys are already branch specific.
- Replace deprecated env var "set" for GitHub workflow

## How to test
- Confirm Travis stages have fired correctly for this PR. They should be
   - Test
   - Beta Deploy
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Ongoing, #275