### PR TITLE
chore(build): travis limit prod release to specific message

### DIFF
--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -38,7 +38,9 @@ releaseProd()
   fi
 
   if [[ "${TRAVIS_BRANCH}" = "prod-stable" || "${TRAVIS_BRANCH}" = "prod" || "${TRAVIS_BRANCH}" = "main" || "${TRAVIS_BRANCH}" = "master" ]] && [[ $TRAVIS_BUILD_STAGE_NAME != *"Beta"* ]];  then
-    release "prod-stable"
+    if [[ "${TRAVIS_COMMIT_MESSAGE}" = *"chore(release):"* ]]; then
+      release "prod-stable"
+    fi
   fi
 }
 #


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- chore(build): travis limit prod release to specific message

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- limit Travis prod-stable pushes to commit messages with Curiosity's standard release message `chore(release)`. This is prep for applying an automated release commit to the prod-stable based branch
- this is a first round, may be useful to also apply this to the stage branch eventually

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Ongoing, #275 