### PR TITLE
fix(openshiftView,rhelView): issues/468 header names

### DIFF
--- a/public/locales/en-US.json
+++ b/public/locales/en-US.json
@@ -61,7 +61,8 @@
     "header": "{{context}}",
     "header_cores": "Cores",
     "header_displayName": "Name",
-    "header_hardwareType": "Infrastructure",
+    "header_guestsDisplayName": "VM name",
+    "header_hardwareType": "Type",
     "header_inventoryId": "UUID",
     "header_sockets": "Sockets",
     "header_lastSeen": "Last seen"

--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -47,7 +47,9 @@ const noopPromise = Promise.resolve({});
  * @returns {string}
  */
 const noopTranslate = (key, value, components) =>
-  `t(${key}${(value && `, ${value}`) || ''}${(components && `, ${components}`) || ''})`;
+  `t(${key}${(value && `, ${(typeof value === 'string' && value) || (value && JSON.stringify(value))}`) || ''}${
+    (components && `, ${components}`) || ''
+  })`;
 
 /**
  * Is dev mode active.

--- a/src/components/c3GraphCard/tests/__snapshots__/c3GraphCard.test.js.snap
+++ b/src/components/c3GraphCard/tests/__snapshots__/c3GraphCard.test.js.snap
@@ -32,7 +32,7 @@ Object {
     ],
   ],
   "names": Object {
-    "loremIpsumSockets": "t(curiosity-graph.loremIpsumSocketsLabel, [object Object])",
+    "loremIpsumSockets": "t(curiosity-graph.loremIpsumSocketsLabel, {\\"product\\":\\"\\"})",
     "thresholdLoremIpsumSockets": "t(curiosity-graph.thresholdLabel)",
   },
   "types": Object {
@@ -68,7 +68,7 @@ Array [
       </p>
     }
   >
-    t(curiosity-graph.loremLabel, [object Object])
+    t(curiosity-graph.loremLabel, {"product":""})
   </C3GraphCardLegendItem>,
   <C3GraphCardLegendItem
     chart={
@@ -181,7 +181,7 @@ Object {
       ],
     ],
     "names": Object {
-      "physicalSockets": "t(curiosity-graph.physicalSocketsLabel, [object Object])",
+      "physicalSockets": "t(curiosity-graph.physicalSocketsLabel, {\\"product\\":\\"\\"})",
     },
     "types": Object {
       "physicalSockets": "area-spline",
@@ -298,7 +298,7 @@ exports[`C3GraphCard Component should render multiple states: error with 403 sta
                 ],
               ],
               "names": Object {
-                "physicalSockets": "t(curiosity-graph.physicalSocketsLabel, [object Object])",
+                "physicalSockets": "t(curiosity-graph.physicalSocketsLabel, {\\"product\\":\\"\\"})",
               },
               "types": Object {
                 "physicalSockets": "area-spline",
@@ -455,7 +455,7 @@ exports[`C3GraphCard Component should render multiple states: error with 500 sta
                 ],
               ],
               "names": Object {
-                "physicalSockets": "t(curiosity-graph.physicalSocketsLabel, [object Object])",
+                "physicalSockets": "t(curiosity-graph.physicalSocketsLabel, {\\"product\\":\\"\\"})",
               },
               "types": Object {
                 "physicalSockets": "area-spline",
@@ -612,7 +612,7 @@ exports[`C3GraphCard Component should render multiple states: fulfilled 1`] = `
                 ],
               ],
               "names": Object {
-                "physicalSockets": "t(curiosity-graph.physicalSocketsLabel, [object Object])",
+                "physicalSockets": "t(curiosity-graph.physicalSocketsLabel, {\\"product\\":\\"\\"})",
               },
               "types": Object {
                 "physicalSockets": "area-spline",

--- a/src/components/c3GraphCard/tests/__snapshots__/c3GraphCardHelpers.test.js.snap
+++ b/src/components/c3GraphCard/tests/__snapshots__/c3GraphCardHelpers.test.js.snap
@@ -66,10 +66,10 @@ Object {
           ],
         ],
         "names": Object {
-          "dolor": "t(curiosity-graph.dolorLabel, [object Object])",
-          "ipsum": "t(curiosity-graph.ipsumLabel, [object Object])",
-          "lorem": "t(curiosity-graph.loremLabel, [object Object])",
-          "sit": "t(curiosity-graph.sitLabel, [object Object])",
+          "dolor": "t(curiosity-graph.dolorLabel, {\\"product\\":\\"lorem\\"})",
+          "ipsum": "t(curiosity-graph.ipsumLabel, {\\"product\\":\\"lorem\\"})",
+          "lorem": "t(curiosity-graph.loremLabel, {\\"product\\":\\"lorem\\"})",
+          "sit": "t(curiosity-graph.sitLabel, {\\"product\\":\\"lorem\\"})",
         },
         "types": Object {
           "dolor": "area-spline",

--- a/src/components/graphCard/__tests__/__snapshots__/graphCardChartLegend.test.js.snap
+++ b/src/components/graphCard/__tests__/__snapshots__/graphCardChartLegend.test.js.snap
@@ -23,7 +23,7 @@ exports[`GraphCardChartLegend Component should handle a click event: click event
   tabIndex={0}
   variant="link"
 >
-  t(curiosity-graph.loremIpsumLabel,curiosity-graph.noLabel, [object Object])
+  t(curiosity-graph.loremIpsumLabel,curiosity-graph.noLabel, {"product":"test","context":"test"})
 </Button>
 `;
 
@@ -50,7 +50,7 @@ exports[`GraphCardChartLegend Component should handle a click event: click event
   tabIndex={0}
   variant="link"
 >
-  t(curiosity-graph.loremIpsumLabel,curiosity-graph.noLabel, [object Object])
+  t(curiosity-graph.loremIpsumLabel,curiosity-graph.noLabel, {"product":"test","context":"test"})
 </Button>
 `;
 
@@ -72,7 +72,7 @@ exports[`GraphCardChartLegend Component should handle a click event: click event
   tabIndex={0}
   variant="link"
 >
-  t(curiosity-graph.loremIpsumLabel,curiosity-graph.noLabel, [object Object])
+  t(curiosity-graph.loremIpsumLabel,curiosity-graph.noLabel, {"product":"test","context":"test"})
 </Button>
 `;
 
@@ -167,7 +167,7 @@ exports[`GraphCardChartLegend Component should render a basic component: basic 1
   <Tooltip
     content={
       <p>
-        t(curiosity-graph.loremIpsumLegendTooltip, [object Object])
+        t(curiosity-graph.loremIpsumLegendTooltip, {"product":"","context":""})
       </p>
     }
     distance={5}
@@ -199,7 +199,7 @@ exports[`GraphCardChartLegend Component should render a basic component: basic 1
       tabIndex={0}
       variant="link"
     >
-      t(curiosity-graph.loremIpsumLabel,curiosity-graph.noLabel, [object Object])
+      t(curiosity-graph.loremIpsumLabel,curiosity-graph.noLabel, {"product":"","context":""})
     </Button>
   </Tooltip>
 </Fragment>
@@ -210,7 +210,7 @@ exports[`GraphCardChartLegend Component should render basic data: data 1`] = `
   <Tooltip
     content={
       <p>
-        t(curiosity-graph.loremIpsumLegendTooltip, [object Object])
+        t(curiosity-graph.loremIpsumLegendTooltip, {"product":"test","context":"test"})
       </p>
     }
     distance={5}
@@ -242,13 +242,13 @@ exports[`GraphCardChartLegend Component should render basic data: data 1`] = `
       tabIndex={0}
       variant="link"
     >
-      t(curiosity-graph.loremIpsumLabel,curiosity-graph.noLabel, [object Object])
+      t(curiosity-graph.loremIpsumLabel,curiosity-graph.noLabel, {"product":"test","context":"test"})
     </Button>
   </Tooltip>
   <Tooltip
     content={
       <p>
-        t(curiosity-graph.ametConsecteturLegendTooltip, [object Object])
+        t(curiosity-graph.ametConsecteturLegendTooltip, {"product":"test","context":"test"})
       </p>
     }
     distance={5}
@@ -275,13 +275,13 @@ exports[`GraphCardChartLegend Component should render basic data: data 1`] = `
       tabIndex={0}
       variant="link"
     >
-      t(curiosity-graph.ametConsecteturLabel,curiosity-graph.noLabel, [object Object])
+      t(curiosity-graph.ametConsecteturLabel,curiosity-graph.noLabel, {"product":"test","context":"test"})
     </Button>
   </Tooltip>
   <Tooltip
     content={
       <p>
-        t(curiosity-graph.dolorSitLegendTooltip,curiosity-graph.thresholdLegendTooltip, [object Object])
+        t(curiosity-graph.dolorSitLegendTooltip,curiosity-graph.thresholdLegendTooltip, {"product":"test","context":"test"})
       </p>
     }
     distance={5}
@@ -313,13 +313,13 @@ exports[`GraphCardChartLegend Component should render basic data: data 1`] = `
       tabIndex={0}
       variant="link"
     >
-      t(curiosity-graph.dolorSitLabel,curiosity-graph.thresholdLabel, [object Object])
+      t(curiosity-graph.dolorSitLabel,curiosity-graph.thresholdLabel, {"product":"test","context":"test"})
     </Button>
   </Tooltip>
   <Tooltip
     content={
       <p>
-        t(curiosity-graph.nonCursusLegendTooltip,curiosity-graph.thresholdLegendTooltip, [object Object])
+        t(curiosity-graph.nonCursusLegendTooltip,curiosity-graph.thresholdLegendTooltip, {"product":"test","context":"test"})
       </p>
     }
     distance={5}
@@ -351,7 +351,7 @@ exports[`GraphCardChartLegend Component should render basic data: data 1`] = `
       tabIndex={0}
       variant="link"
     >
-      t(curiosity-graph.nonCursusLabel,curiosity-graph.thresholdLabel, [object Object])
+      t(curiosity-graph.nonCursusLabel,curiosity-graph.thresholdLabel, {"product":"test","context":"test"})
     </Button>
   </Tooltip>
 </Fragment>

--- a/src/components/graphCard/__tests__/__snapshots__/graphCardChartTooltips.test.js.snap
+++ b/src/components/graphCard/__tests__/__snapshots__/graphCardChartTooltips.test.js.snap
@@ -29,7 +29,7 @@ exports[`GraphCardChartTooltip Component should render basic data: data 1`] = `
     </thead>
     <tbody>
       <tr
-        key="tooltip-t(curiosity-graph.loremIpsumLabel, [object Object])"
+        key="tooltip-t(curiosity-graph.loremIpsumLabel, {\\"product\\":\\"\\"})"
       >
         <th>
           <div
@@ -41,14 +41,14 @@ exports[`GraphCardChartTooltip Component should render basic data: data 1`] = `
               }
             }
           />
-          t(curiosity-graph.loremIpsumLabel, [object Object])
+          t(curiosity-graph.loremIpsumLabel, {"product":""})
         </th>
         <td>
           0
         </td>
       </tr>
       <tr
-        key="tooltip-t(curiosity-graph.dolorSitLabel, [object Object])"
+        key="tooltip-t(curiosity-graph.dolorSitLabel, {\\"product\\":\\"\\"})"
       >
         <th>
           <div
@@ -60,7 +60,7 @@ exports[`GraphCardChartTooltip Component should render basic data: data 1`] = `
               }
             }
           />
-          t(curiosity-graph.dolorSitLabel, [object Object])
+          t(curiosity-graph.dolorSitLabel, {"product":""})
         </th>
         <td>
           1

--- a/src/components/guestsList/__tests__/__snapshots__/guestsList.test.js.snap
+++ b/src/components/guestsList/__tests__/__snapshots__/guestsList.test.js.snap
@@ -22,8 +22,8 @@ exports[`GuestsList Component should handle multiple display states: fulfilled 1
         className="curiosity-inventory-list"
         columnHeaders={
           Array [
-            "t(curiosity-inventory.header, [object Object])",
-            "t(curiosity-inventory.header, [object Object])",
+            "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})",
+            "t(curiosity-inventory.header, {\\"context\\":\\"dolor\\"})",
           ]
         }
         isHeader={true}
@@ -157,7 +157,7 @@ exports[`GuestsList Component should handle variations in data: filtered data 1`
         className="curiosity-inventory-list"
         columnHeaders={
           Array [
-            "t(curiosity-inventory.header, [object Object])",
+            "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})",
           ]
         }
         isHeader={true}
@@ -206,8 +206,8 @@ exports[`GuestsList Component should handle variations in data: variable data 1`
         className="curiosity-inventory-list"
         columnHeaders={
           Array [
-            "t(curiosity-inventory.header, [object Object])",
-            "t(curiosity-inventory.header, [object Object])",
+            "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})",
+            "t(curiosity-inventory.header, {\\"context\\":\\"dolor\\"})",
           ]
         }
         isHeader={true}

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -205,6 +205,10 @@ Array [
         "match": "t('curiosity-inventory.cardHeading')",
       },
       Object {
+        "key": "curiosity-inventory.header",
+        "match": "translate('curiosity-inventory.header', { context: 'guestsDisplayName' })",
+      },
+      Object {
         "key": "curiosity-inventory.label",
         "match": "translate('curiosity-inventory.label', { context: 'numberOfGuests', value: numberOfGuests.value }, [ <PfLabel color=\\"blue\\" /> ])",
       },
@@ -322,6 +326,10 @@ Array [
       Object {
         "key": "curiosity-inventory.cardHeading",
         "match": "t('curiosity-inventory.cardHeading')",
+      },
+      Object {
+        "key": "curiosity-inventory.header",
+        "match": "translate('curiosity-inventory.header', { context: 'guestsDisplayName' })",
       },
       Object {
         "key": "curiosity-inventory.label",

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -9,19 +9,10 @@ Object {
 }
 `;
 
-exports[`I18n Component should attempt to perform translate with a node: translated node 1`] = `"<div>t(lorem.ipsum, [object Object], [object Object])</div>"`;
+exports[`I18n Component should attempt to perform translate with a node: translated node 1`] = `"<div>t(lorem.ipsum, {&quot;hello&quot;:&quot;world&quot;}, [object Object])</div>"`;
 
 exports[`I18n Component should generate a predictable locale key output snapshot: key output 1`] = `
 Array [
-  Object {
-    "file": "./src/common/helpers.js",
-    "keys": Array [
-      Object {
-        "key": "",
-        "match": "t(\${key}\${(value && \`, \${value}\`)",
-      },
-    ],
-  },
   Object {
     "file": "./src/components/authentication/authentication.js",
     "keys": Array [

--- a/src/components/inventoryList/__tests__/__snapshots__/inventoryList.test.js.snap
+++ b/src/components/inventoryList/__tests__/__snapshots__/inventoryList.test.js.snap
@@ -7,9 +7,9 @@ exports[`InventoryList Component should handle expandable guests data: number of
   className="curiosity-inventory-list"
   columnHeaders={
     Array [
-      "t(curiosity-inventory.header, [object Object])",
-      "t(curiosity-inventory.header, [object Object])",
-      "t(curiosity-inventory.header, [object Object])",
+      "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})",
+      "t(curiosity-inventory.header, {\\"context\\":\\"dolor\\"})",
+      "t(curiosity-inventory.header, {\\"context\\":\\"numberOfGuests\\"})",
     ]
   }
   isHeader={true}
@@ -38,10 +38,10 @@ exports[`InventoryList Component should handle expandable guests data: number of
   className="curiosity-inventory-list"
   columnHeaders={
     Array [
-      "t(curiosity-inventory.header, [object Object])",
-      "t(curiosity-inventory.header, [object Object])",
-      "t(curiosity-inventory.header, [object Object])",
-      "t(curiosity-inventory.header, [object Object])",
+      "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})",
+      "t(curiosity-inventory.header, {\\"context\\":\\"dolor\\"})",
+      "t(curiosity-inventory.header, {\\"context\\":\\"numberOfGuests\\"})",
+      "t(curiosity-inventory.header, {\\"context\\":\\"subscriptionManagerId\\"})",
     ]
   }
   isHeader={true}
@@ -166,7 +166,7 @@ exports[`InventoryList Component should handle variations in data: filtered data
           className="curiosity-inventory-list"
           columnHeaders={
             Array [
-              "t(curiosity-inventory.header, [object Object])",
+              "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})",
             ]
           }
           isHeader={true}
@@ -263,8 +263,8 @@ exports[`InventoryList Component should handle variations in data: variable data
           className="curiosity-inventory-list"
           columnHeaders={
             Array [
-              "t(curiosity-inventory.header, [object Object])",
-              "t(curiosity-inventory.header, [object Object])",
+              "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})",
+              "t(curiosity-inventory.header, {\\"context\\":\\"dolor\\"})",
             ]
           }
           isHeader={true}

--- a/src/components/inventoryList/__tests__/__snapshots__/inventoryListHelpers.test.js.snap
+++ b/src/components/inventoryList/__tests__/__snapshots__/inventoryListHelpers.test.js.snap
@@ -68,16 +68,16 @@ Object {
     "sit",
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, [object Object])",
-    "t(curiosity-inventory.header, [object Object])",
+    "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"dolor\\"})",
   ],
   "data": Object {
     "dolor": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"dolor\\"})",
       "value": "sit",
     },
     "lorem": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})",
       "value": "ipsum",
     },
   },
@@ -90,15 +90,15 @@ Object {
     "ipsum/sit",
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, [object Object])/t(curiosity-inventory.header, [object Object])",
+    "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})/t(curiosity-inventory.header, {\\"context\\":\\"dolor\\"})",
   ],
   "data": Object {
     "dolor": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"dolor\\"})",
       "value": "sit",
     },
     "lorem": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})",
       "value": "ipsum",
     },
   },
@@ -116,15 +116,15 @@ Object {
     },
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, [object Object])",
+    "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})",
   ],
   "data": Object {
     "dolor": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"dolor\\"})",
       "value": "sit",
     },
     "lorem": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})",
       "value": "ipsum",
     },
   },
@@ -146,11 +146,11 @@ Object {
   ],
   "data": Object {
     "dolor": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"dolor\\"})",
       "value": "sit",
     },
     "lorem": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})",
       "value": "ipsum",
     },
   },
@@ -163,15 +163,15 @@ Object {
     "ipsum",
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, [object Object])",
+    "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})",
   ],
   "data": Object {
     "dolor": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"dolor\\"})",
       "value": "sit",
     },
     "lorem": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})",
       "value": "ipsum",
     },
   },

--- a/src/components/openshiftView/__tests__/__snapshots__/openshiftView.test.js.snap
+++ b/src/components/openshiftView/__tests__/__snapshots__/openshiftView.test.js.snap
@@ -6,7 +6,7 @@ exports[`OpenshiftView Component should display an alternate graph on query-stri
     productLabel="OpenShift"
     t={[Function]}
   >
-    t(curiosity-view.title, [object Object])
+    t(curiosity-view.title, {"appName":"Subscription Watch","context":"OpenShift"})
   </PageHeader>
   <PageToolbar>
     <Connect(Toolbar)
@@ -70,11 +70,11 @@ exports[`OpenshiftView Component should display an alternate graph on query-stri
         options={
           Array [
             Object {
-              "title": "t(curiosity-toolbar.uom, [object Object])",
+              "title": "t(curiosity-toolbar.uom, {\\"context\\":\\"cores\\"})",
               "value": "cores",
             },
             Object {
-              "title": "t(curiosity-toolbar.uom, [object Object])",
+              "title": "t(curiosity-toolbar.uom, {\\"context\\":\\"sockets\\"})",
               "value": "sockets",
             },
           ]
@@ -151,7 +151,7 @@ exports[`OpenshiftView Component should have a fallback title: title 1`] = `
     productLabel="OpenShift"
     t={[Function]}
   >
-    t(curiosity-view.title, [object Object])
+    t(curiosity-view.title, {"appName":"Subscription Watch","context":"OpenShift"})
   </PageHeader>
   <PageToolbar>
     <Connect(Toolbar)
@@ -215,11 +215,11 @@ exports[`OpenshiftView Component should have a fallback title: title 1`] = `
         options={
           Array [
             Object {
-              "title": "t(curiosity-toolbar.uom, [object Object])",
+              "title": "t(curiosity-toolbar.uom, {\\"context\\":\\"cores\\"})",
               "value": "cores",
             },
             Object {
-              "title": "t(curiosity-toolbar.uom, [object Object])",
+              "title": "t(curiosity-toolbar.uom, {\\"context\\":\\"sockets\\"})",
               "value": "sockets",
             },
           ]
@@ -300,29 +300,29 @@ Object {
     />,
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, [object Object])",
-    "t(curiosity-inventory.header, [object Object])",
-    "t(curiosity-inventory.header, [object Object])",
+    "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"inventoryId\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
   ],
   "data": Object {
     "displayName": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
       "value": "lorem",
     },
     "inventoryId": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"inventoryId\\"})",
       "value": "lorem inventory id",
     },
     "lastSeen": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
       "value": "lorem date obj",
     },
     "loremIpsum": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"loremIpsum\\"})",
       "value": "hello world",
     },
     "subscriptionManagerId": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"subscriptionManagerId\\"})",
       "value": "lorem subscription id",
     },
   },
@@ -347,29 +347,29 @@ Object {
     />,
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, [object Object])",
-    "t(curiosity-inventory.header, [object Object])",
-    "t(curiosity-inventory.header, [object Object])",
+    "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"inventoryId\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
   ],
   "data": Object {
     "displayName": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
       "value": "lorem",
     },
     "inventoryId": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"inventoryId\\"})",
       "value": "lorem inventory id",
     },
     "lastSeen": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
       "value": "lorem date obj",
     },
     "loremIpsum": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"loremIpsum\\"})",
       "value": "hello world",
     },
     "subscriptionManagerId": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"subscriptionManagerId\\"})",
       "value": "lorem subscription id",
     },
   },
@@ -382,10 +382,10 @@ Object {
     <React.Fragment>
       lorem
        
-      t(curiosity-inventory.label, [object Object], [object Object])
+      t(curiosity-inventory.label, {"context":"numberOfGuests","value":3}, [object Object])
     </React.Fragment>,
     <React.Fragment>
-      t(curiosity-inventory.hardwareType, [object Object])
+      t(curiosity-inventory.hardwareType, {"context":"ipsum"})
        
       
     </React.Fragment>,
@@ -396,43 +396,43 @@ Object {
     />,
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, [object Object])",
-    "t(curiosity-inventory.header, [object Object])",
-    "t(curiosity-inventory.header, [object Object])",
-    "t(curiosity-inventory.header, [object Object])",
-    "t(curiosity-inventory.header, [object Object])",
+    "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"hardwareType\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"sockets\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"cores\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
   ],
   "data": Object {
     "cores": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"cores\\"})",
       "value": 12,
     },
     "displayName": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
       "value": "lorem",
     },
     "hardwareType": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"hardwareType\\"})",
       "value": "ipsum",
     },
     "inventoryId": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"inventoryId\\"})",
       "value": "lorem inventory id",
     },
     "lastSeen": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
       "value": "lorem date obj",
     },
     "loremIpsum": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"loremIpsum\\"})",
       "value": "hello world",
     },
     "numberOfGuests": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"numberOfGuests\\"})",
       "value": 3,
     },
     "sockets": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"sockets\\"})",
       "value": 10,
     },
   },
@@ -451,10 +451,10 @@ Object {
     >
       lorem
        
-      t(curiosity-inventory.label, [object Object], [object Object])
+      t(curiosity-inventory.label, {"context":"numberOfGuests","value":3}, [object Object])
     </Button>,
     <React.Fragment>
-      t(curiosity-inventory.hardwareType, [object Object])
+      t(curiosity-inventory.hardwareType, {"context":"ipsum"})
        
       
     </React.Fragment>,
@@ -465,43 +465,43 @@ Object {
     />,
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, [object Object])",
-    "t(curiosity-inventory.header, [object Object])",
-    "t(curiosity-inventory.header, [object Object])",
-    "t(curiosity-inventory.header, [object Object])",
-    "t(curiosity-inventory.header, [object Object])",
+    "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"hardwareType\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"sockets\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"cores\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
   ],
   "data": Object {
     "cores": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"cores\\"})",
       "value": 12,
     },
     "displayName": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
       "value": "lorem",
     },
     "hardwareType": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"hardwareType\\"})",
       "value": "ipsum",
     },
     "inventoryId": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"inventoryId\\"})",
       "value": "lorem inventory id",
     },
     "lastSeen": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
       "value": "lorem date obj",
     },
     "loremIpsum": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"loremIpsum\\"})",
       "value": "hello world",
     },
     "numberOfGuests": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"numberOfGuests\\"})",
       "value": 3,
     },
     "sockets": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"sockets\\"})",
       "value": 10,
     },
   },
@@ -591,7 +591,7 @@ exports[`OpenshiftView Component should render a non-connected component: non-co
     productLabel="OpenShift"
     t={[Function]}
   >
-    t(curiosity-view.title, [object Object])
+    t(curiosity-view.title, {"appName":"Subscription Watch","context":"OpenShift"})
   </PageHeader>
   <PageToolbar>
     <Connect(Toolbar)
@@ -655,11 +655,11 @@ exports[`OpenshiftView Component should render a non-connected component: non-co
         options={
           Array [
             Object {
-              "title": "t(curiosity-toolbar.uom, [object Object])",
+              "title": "t(curiosity-toolbar.uom, {\\"context\\":\\"cores\\"})",
               "value": "cores",
             },
             Object {
-              "title": "t(curiosity-toolbar.uom, [object Object])",
+              "title": "t(curiosity-toolbar.uom, {\\"context\\":\\"sockets\\"})",
               "value": "sockets",
             },
           ]

--- a/src/components/openshiftView/__tests__/__snapshots__/openshiftView.test.js.snap
+++ b/src/components/openshiftView/__tests__/__snapshots__/openshiftView.test.js.snap
@@ -93,6 +93,7 @@ exports[`OpenshiftView Component should display an alternate graph on query-stri
         Array [
           Object {
             "cell": [Function],
+            "header": "t(curiosity-inventory.header, {\\"context\\":\\"guestsDisplayName\\"})",
             "id": "displayName",
           },
           Object {
@@ -238,6 +239,7 @@ exports[`OpenshiftView Component should have a fallback title: title 1`] = `
         Array [
           Object {
             "cell": [Function],
+            "header": "t(curiosity-inventory.header, {\\"context\\":\\"guestsDisplayName\\"})",
             "id": "displayName",
           },
           Object {
@@ -300,7 +302,7 @@ Object {
     />,
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"guestsDisplayName\\"})",
     "t(curiosity-inventory.header, {\\"context\\":\\"inventoryId\\"})",
     "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
   ],
@@ -347,7 +349,7 @@ Object {
     />,
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"guestsDisplayName\\"})",
     "t(curiosity-inventory.header, {\\"context\\":\\"inventoryId\\"})",
     "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
   ],
@@ -537,6 +539,7 @@ Object {
   "initialGuestsFilters": Array [
     Object {
       "cell": [Function],
+      "header": "t(curiosity-inventory.header, {\\"context\\":\\"guestsDisplayName\\"})",
       "id": "displayName",
     },
     Object {
@@ -678,6 +681,7 @@ exports[`OpenshiftView Component should render a non-connected component: non-co
         Array [
           Object {
             "cell": [Function],
+            "header": "t(curiosity-inventory.header, {\\"context\\":\\"guestsDisplayName\\"})",
             "id": "displayName",
           },
           Object {

--- a/src/components/openshiftView/openshiftView.js
+++ b/src/components/openshiftView/openshiftView.js
@@ -256,6 +256,7 @@ OpenshiftView.defaultProps = {
   initialGuestsFilters: [
     {
       id: 'displayName',
+      header: translate('curiosity-inventory.header', { context: 'guestsDisplayName' }),
       cell: (data, session) => {
         const { displayName, inventoryId } = data;
         const { inventory: authorized } = session?.authorized || {};

--- a/src/components/optinView/__tests__/__snapshots__/optinView.test.js.snap
+++ b/src/components/optinView/__tests__/__snapshots__/optinView.test.js.snap
@@ -19,13 +19,13 @@ exports[`OptinView Component should render a non-connected component: non-connec
               headingLevel="h1"
               size="2xl"
             >
-              t(curiosity-optin.cardTitle, [object Object])
+              t(curiosity-optin.cardTitle, {"appName":"Subscription Watch"})
             </Title>
           </CardTitle>
           <CardBody
             key="heading1Desc"
           >
-            t(curiosity-optin.cardDescription, [object Object])
+            t(curiosity-optin.cardDescription, {"appName":"Subscription Watch"})
           </CardBody>
           <CardTitle
             key="heading2Title"
@@ -79,7 +79,7 @@ exports[`OptinView Component should render a non-connected component: non-connec
                   isDisabled={true}
                   variant="primary"
                 >
-                  t(curiosity-optin.buttonIsActive, [object Object])
+                  t(curiosity-optin.buttonIsActive, {"appName":"Subscription Watch"})
                 </Button>
               </ActionGroup>
             </Form>
@@ -150,7 +150,7 @@ exports[`OptinView Component should render an API state driven view: 4XX view 1`
         isDisabled={true}
         variant="primary"
       >
-        t(curiosity-optin.buttonIsActive, [object Object])
+        t(curiosity-optin.buttonIsActive, {"appName":"Subscription Watch"})
       </Button>
     </ActionGroup>
   </Form>
@@ -165,7 +165,7 @@ exports[`OptinView Component should render an API state driven view: 200 view 1`
         isDisabled={true}
         variant="primary"
       >
-        t(curiosity-optin.buttonIsActive, [object Object])
+        t(curiosity-optin.buttonIsActive, {"appName":"Subscription Watch"})
       </Button>
     </ActionGroup>
   </Form>
@@ -180,7 +180,7 @@ exports[`OptinView Component should render an API state driven view: 401 view 1`
         isDisabled={true}
         variant="primary"
       >
-        t(curiosity-optin.buttonIsActive, [object Object])
+        t(curiosity-optin.buttonIsActive, {"appName":"Subscription Watch"})
       </Button>
     </ActionGroup>
   </Form>
@@ -195,7 +195,7 @@ exports[`OptinView Component should render an API state driven view: 403 view 1`
         onClick={[Function]}
         variant="primary"
       >
-        t(curiosity-optin.buttonActivate, [object Object])
+        t(curiosity-optin.buttonActivate, {"appName":"Subscription Watch"})
       </Button>
     </ActionGroup>
   </Form>
@@ -210,7 +210,7 @@ exports[`OptinView Component should render an API state driven view: 500 view 1`
         isDisabled={true}
         variant="primary"
       >
-        t(curiosity-optin.buttonIsActive, [object Object])
+        t(curiosity-optin.buttonIsActive, {"appName":"Subscription Watch"})
       </Button>
     </ActionGroup>
   </Form>
@@ -220,7 +220,7 @@ exports[`OptinView Component should render an API state driven view: 500 view 1`
 exports[`OptinView Component should render an API state driven view: error view 1`] = `
 <CardFooter>
   <p>
-    t(curiosity-optin.cardIsErrorDescription, [object Object], [object Object])
+    t(curiosity-optin.cardIsErrorDescription, {"appName":"Subscription Watch"}, [object Object])
   </p>
 </CardFooter>
 `;
@@ -233,7 +233,7 @@ exports[`OptinView Component should render an API state driven view: fulfilled v
         isDisabled={true}
         variant="primary"
       >
-        t(curiosity-optin.buttonIsActive, [object Object])
+        t(curiosity-optin.buttonIsActive, {"appName":"Subscription Watch"})
       </Button>
     </ActionGroup>
     <p>
@@ -262,13 +262,13 @@ exports[`OptinView Component should render an API state driven view: initial vie
               headingLevel="h1"
               size="2xl"
             >
-              t(curiosity-optin.cardTitle, [object Object])
+              t(curiosity-optin.cardTitle, {"appName":"Subscription Watch"})
             </Title>
           </CardTitle>
           <CardBody
             key="heading1Desc"
           >
-            t(curiosity-optin.cardDescription, [object Object])
+            t(curiosity-optin.cardDescription, {"appName":"Subscription Watch"})
           </CardBody>
           <CardTitle
             key="heading2Title"
@@ -322,7 +322,7 @@ exports[`OptinView Component should render an API state driven view: initial vie
                   isDisabled={true}
                   variant="primary"
                 >
-                  t(curiosity-optin.buttonIsActive, [object Object])
+                  t(curiosity-optin.buttonIsActive, {"appName":"Subscription Watch"})
                 </Button>
               </ActionGroup>
             </Form>
@@ -393,7 +393,7 @@ exports[`OptinView Component should render an API state driven view: null or und
         isDisabled={true}
         variant="primary"
       >
-        t(curiosity-optin.buttonIsActive, [object Object])
+        t(curiosity-optin.buttonIsActive, {"appName":"Subscription Watch"})
       </Button>
     </ActionGroup>
   </Form>
@@ -412,7 +412,7 @@ exports[`OptinView Component should render an API state driven view: pending vie
           size="sm"
         />
          
-        t(curiosity-optin.buttonActivate, [object Object])
+        t(curiosity-optin.buttonActivate, {"appName":"Subscription Watch"})
       </Button>
     </ActionGroup>
   </Form>

--- a/src/components/pageLayout/__tests__/__snapshots__/pageHeader.test.js.snap
+++ b/src/components/pageLayout/__tests__/__snapshots__/pageHeader.test.js.snap
@@ -111,7 +111,7 @@ exports[`PageHeader Component should render the subtitle when viewId is provided
         </Title>
       </PageHeaderTitle>
       <p>
-        t(curiosity-view.subtitle, [object Object], [object Object])
+        t(curiosity-view.subtitle, {"appName":"Subscription Watch","context":"RHEL"}, [object Object])
       </p>
     </section>
   </PageHeader>

--- a/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
+++ b/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
@@ -6,7 +6,7 @@ exports[`RhelView Component should display an alternate graph on query-string up
     productLabel="RHEL"
     t={[Function]}
   >
-    t(curiosity-view.title, [object Object])
+    t(curiosity-view.title, {"appName":"Subscription Watch","context":"RHEL"})
   </PageHeader>
   <PageToolbar>
     <Connect(Toolbar)
@@ -136,7 +136,7 @@ exports[`RhelView Component should have a fallback title: title 1`] = `
     productLabel="RHEL"
     t={[Function]}
   >
-    t(curiosity-view.title, [object Object])
+    t(curiosity-view.title, {"appName":"Subscription Watch","context":"RHEL"})
   </PageHeader>
   <PageToolbar>
     <Connect(Toolbar)
@@ -270,29 +270,29 @@ Object {
     />,
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, [object Object])",
-    "t(curiosity-inventory.header, [object Object])",
-    "t(curiosity-inventory.header, [object Object])",
+    "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"inventoryId\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
   ],
   "data": Object {
     "displayName": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
       "value": "lorem",
     },
     "inventoryId": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"inventoryId\\"})",
       "value": "lorem inventory id",
     },
     "lastSeen": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
       "value": "lorem date obj",
     },
     "loremIpsum": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"loremIpsum\\"})",
       "value": "hello world",
     },
     "subscriptionManagerId": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"subscriptionManagerId\\"})",
       "value": "lorem subscription id",
     },
   },
@@ -317,29 +317,29 @@ Object {
     />,
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, [object Object])",
-    "t(curiosity-inventory.header, [object Object])",
-    "t(curiosity-inventory.header, [object Object])",
+    "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"inventoryId\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
   ],
   "data": Object {
     "displayName": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
       "value": "lorem",
     },
     "inventoryId": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"inventoryId\\"})",
       "value": "lorem inventory id",
     },
     "lastSeen": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
       "value": "lorem date obj",
     },
     "loremIpsum": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"loremIpsum\\"})",
       "value": "hello world",
     },
     "subscriptionManagerId": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"subscriptionManagerId\\"})",
       "value": "lorem subscription id",
     },
   },
@@ -352,10 +352,10 @@ Object {
     <React.Fragment>
       lorem
        
-      t(curiosity-inventory.label, [object Object], [object Object])
+      t(curiosity-inventory.label, {"context":"numberOfGuests","value":3}, [object Object])
     </React.Fragment>,
     <React.Fragment>
-      t(curiosity-inventory.hardwareType, [object Object])
+      t(curiosity-inventory.hardwareType, {"context":"ipsum"})
        
       
     </React.Fragment>,
@@ -365,42 +365,42 @@ Object {
     />,
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, [object Object])",
-    "t(curiosity-inventory.header, [object Object])",
-    "t(curiosity-inventory.header, [object Object])",
-    "t(curiosity-inventory.header, [object Object])",
+    "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"hardwareType\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"sockets\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
   ],
   "data": Object {
     "cores": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"cores\\"})",
       "value": 12,
     },
     "displayName": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
       "value": "lorem",
     },
     "hardwareType": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"hardwareType\\"})",
       "value": "ipsum",
     },
     "inventoryId": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"inventoryId\\"})",
       "value": "lorem inventory id",
     },
     "lastSeen": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
       "value": "lorem date obj",
     },
     "loremIpsum": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"loremIpsum\\"})",
       "value": "hello world",
     },
     "numberOfGuests": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"numberOfGuests\\"})",
       "value": 3,
     },
     "sockets": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"sockets\\"})",
       "value": 10,
     },
   },
@@ -419,10 +419,10 @@ Object {
     >
       lorem
        
-      t(curiosity-inventory.label, [object Object], [object Object])
+      t(curiosity-inventory.label, {"context":"numberOfGuests","value":3}, [object Object])
     </Button>,
     <React.Fragment>
-      t(curiosity-inventory.hardwareType, [object Object])
+      t(curiosity-inventory.hardwareType, {"context":"ipsum"})
        
       
     </React.Fragment>,
@@ -432,42 +432,42 @@ Object {
     />,
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, [object Object])",
-    "t(curiosity-inventory.header, [object Object])",
-    "t(curiosity-inventory.header, [object Object])",
-    "t(curiosity-inventory.header, [object Object])",
+    "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"hardwareType\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"sockets\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
   ],
   "data": Object {
     "cores": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"cores\\"})",
       "value": 12,
     },
     "displayName": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
       "value": "lorem",
     },
     "hardwareType": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"hardwareType\\"})",
       "value": "ipsum",
     },
     "inventoryId": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"inventoryId\\"})",
       "value": "lorem inventory id",
     },
     "lastSeen": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
       "value": "lorem date obj",
     },
     "loremIpsum": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"loremIpsum\\"})",
       "value": "hello world",
     },
     "numberOfGuests": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"numberOfGuests\\"})",
       "value": 3,
     },
     "sockets": Object {
-      "title": "t(curiosity-inventory.header, [object Object])",
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"sockets\\"})",
       "value": 10,
     },
   },
@@ -549,7 +549,7 @@ exports[`RhelView Component should render a non-connected component: non-connect
     productLabel="RHEL"
     t={[Function]}
   >
-    t(curiosity-view.title, [object Object])
+    t(curiosity-view.title, {"appName":"Subscription Watch","context":"RHEL"})
   </PageHeader>
   <PageToolbar>
     <Connect(Toolbar)

--- a/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
+++ b/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
@@ -80,6 +80,7 @@ exports[`RhelView Component should display an alternate graph on query-string up
         Array [
           Object {
             "cell": [Function],
+            "header": "t(curiosity-inventory.header, {\\"context\\":\\"guestsDisplayName\\"})",
             "id": "displayName",
           },
           Object {
@@ -210,6 +211,7 @@ exports[`RhelView Component should have a fallback title: title 1`] = `
         Array [
           Object {
             "cell": [Function],
+            "header": "t(curiosity-inventory.header, {\\"context\\":\\"guestsDisplayName\\"})",
             "id": "displayName",
           },
           Object {
@@ -270,7 +272,7 @@ Object {
     />,
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"guestsDisplayName\\"})",
     "t(curiosity-inventory.header, {\\"context\\":\\"inventoryId\\"})",
     "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
   ],
@@ -317,7 +319,7 @@ Object {
     />,
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
+    "t(curiosity-inventory.header, {\\"context\\":\\"guestsDisplayName\\"})",
     "t(curiosity-inventory.header, {\\"context\\":\\"inventoryId\\"})",
     "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
   ],
@@ -502,6 +504,7 @@ Object {
   "initialGuestsFilters": Array [
     Object {
       "cell": [Function],
+      "header": "t(curiosity-inventory.header, {\\"context\\":\\"guestsDisplayName\\"})",
       "id": "displayName",
     },
     Object {
@@ -623,6 +626,7 @@ exports[`RhelView Component should render a non-connected component: non-connect
         Array [
           Object {
             "cell": [Function],
+            "header": "t(curiosity-inventory.header, {\\"context\\":\\"guestsDisplayName\\"})",
             "id": "displayName",
           },
           Object {

--- a/src/components/rhelView/rhelView.js
+++ b/src/components/rhelView/rhelView.js
@@ -178,6 +178,7 @@ RhelView.defaultProps = {
   initialGuestsFilters: [
     {
       id: 'displayName',
+      header: translate('curiosity-inventory.header', { context: 'guestsDisplayName' }),
       cell: (data, session) => {
         const { displayName, inventoryId } = data;
         const { inventory: authorized } = session?.authorized || {};

--- a/src/components/table/__tests__/__snapshots__/table.test.js.snap
+++ b/src/components/table/__tests__/__snapshots__/table.test.js.snap
@@ -9,7 +9,7 @@ exports[`Table Component should allow expandable content: expandable content 1`]
     span={12}
   >
     <Table
-      aria-label="t(curiosity-inventory.tableAriaLabel, [object Object])"
+      aria-label="t(curiosity-inventory.tableAriaLabel, {\\"appName\\":\\"Subscription Watch\\"})"
       borders={true}
       canSelectAll={true}
       cells={
@@ -78,7 +78,7 @@ exports[`Table Component should allow expandable content: expanded row 1`] = `
     span={12}
   >
     <Table
-      aria-label="t(curiosity-inventory.tableAriaLabel, [object Object])"
+      aria-label="t(curiosity-inventory.tableAriaLabel, {\\"appName\\":\\"Subscription Watch\\"})"
       borders={true}
       canSelectAll={true}
       cells={
@@ -147,7 +147,7 @@ exports[`Table Component should allow sortable content: sortable content 1`] = `
     span={12}
   >
     <Table
-      aria-label="t(curiosity-inventory.tableAriaLabel, [object Object])"
+      aria-label="t(curiosity-inventory.tableAriaLabel, {\\"appName\\":\\"Subscription Watch\\"})"
       borders={true}
       canSelectAll={true}
       cells={
@@ -210,7 +210,7 @@ exports[`Table Component should allow sortable content: sorted column callback 1
     span={12}
   >
     <Table
-      aria-label="t(curiosity-inventory.tableAriaLabel, [object Object])"
+      aria-label="t(curiosity-inventory.tableAriaLabel, {\\"appName\\":\\"Subscription Watch\\"})"
       borders={true}
       canSelectAll={true}
       cells={
@@ -350,7 +350,7 @@ exports[`Table Component should allow variations in table layout: borders and ta
     span={12}
   >
     <Table
-      aria-label="t(curiosity-inventory.tableAriaLabel, [object Object])"
+      aria-label="t(curiosity-inventory.tableAriaLabel, {\\"appName\\":\\"Subscription Watch\\"})"
       borders={false}
       canSelectAll={true}
       cells={
@@ -462,7 +462,7 @@ exports[`Table Component should allow variations in table layout: generated rows
     span={12}
   >
     <Table
-      aria-label="t(curiosity-inventory.tableAriaLabel, [object Object])"
+      aria-label="t(curiosity-inventory.tableAriaLabel, {\\"appName\\":\\"Subscription Watch\\"})"
       borders={true}
       canSelectAll={true}
       cells={
@@ -519,7 +519,7 @@ exports[`Table Component should pass child components, nodes when there are no r
     span={12}
   >
     <Table
-      aria-label="t(curiosity-inventory.tableAriaLabel, [object Object])"
+      aria-label="t(curiosity-inventory.tableAriaLabel, {\\"appName\\":\\"Subscription Watch\\"})"
       borders={true}
       canSelectAll={true}
       cells={
@@ -560,7 +560,7 @@ exports[`Table Component should render a non-connected component: non-connected 
     span={12}
   >
     <Table
-      aria-label="t(curiosity-inventory.tableAriaLabel, [object Object])"
+      aria-label="t(curiosity-inventory.tableAriaLabel, {\\"appName\\":\\"Subscription Watch\\"})"
       borders={true}
       canSelectAll={true}
       cells={

--- a/src/components/toolbar/__tests__/__snapshots__/toolbar.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbar.test.js.snap
@@ -157,7 +157,7 @@ Array [
       Object {
         "data": Object {
           "clearFilters": Object {
-            "sla": null,
+            "usage": null,
           },
         },
         "type": "SET_QUERY_CLEAR",
@@ -312,7 +312,7 @@ Array [
       Object {
         "data": Object {
           "clearFilters": Object {
-            "sla": null,
+            "usage": null,
           },
         },
         "type": "SET_QUERY_CLEAR",
@@ -468,7 +468,7 @@ Array [
       Object {
         "data": Object {
           "clearFilters": Object {
-            "sla": null,
+            "usage": null,
           },
         },
         "type": "SET_QUERY_CLEAR",
@@ -548,11 +548,11 @@ exports[`Toolbar Component should render a non-connected component: non-connecte
             options={
               Array [
                 Object {
-                  "title": "t(curiosity-toolbar.category, [object Object])",
+                  "title": "t(curiosity-toolbar.category, {\\"context\\":\\"sla\\"})",
                   "value": "sla",
                 },
                 Object {
-                  "title": "t(curiosity-toolbar.category, [object Object])",
+                  "title": "t(curiosity-toolbar.category, {\\"context\\":\\"usage\\"})",
                   "value": "usage",
                 },
               ]
@@ -560,7 +560,7 @@ exports[`Toolbar Component should render a non-connected component: non-connecte
             placeholder="t(curiosity-toolbar.placeholder)"
             selectedOptions={
               Array [
-                "t(curiosity-toolbar.category, [object Object])",
+                "t(curiosity-toolbar.category, {\\"context\\":\\"usage\\"})",
               ]
             }
             toggleIcon={
@@ -574,14 +574,14 @@ exports[`Toolbar Component should render a non-connected component: non-connecte
           />
         </ToolbarItem>
         <ToolbarFilter
-          categoryName="t(curiosity-toolbar.category, [object Object])"
+          categoryName="t(curiosity-toolbar.category, {\\"context\\":\\"sla\\"})"
           chips={Array []}
           deleteChip={[Function]}
           key="sla"
           showToolbarItem={false}
         >
           <Select
-            aria-label="t(curiosity-toolbar.category, [object Object])"
+            aria-label="t(curiosity-toolbar.category, {\\"context\\":\\"sla\\"})"
             ariaLabel="Select option"
             className=""
             id="generatedid-"
@@ -609,21 +609,21 @@ exports[`Toolbar Component should render a non-connected component: non-connecte
                 },
               ]
             }
-            placeholder="t(curiosity-toolbar.placeholder, [object Object])"
+            placeholder="t(curiosity-toolbar.placeholder, {\\"context\\":\\"sla\\"})"
             selectedOptions={Array []}
             toggleIcon={null}
             variant="single"
           />
         </ToolbarFilter>
         <ToolbarFilter
-          categoryName="t(curiosity-toolbar.category, [object Object])"
+          categoryName="t(curiosity-toolbar.category, {\\"context\\":\\"usage\\"})"
           chips={Array []}
           deleteChip={[Function]}
           key="usage"
           showToolbarItem={true}
         >
           <Select
-            aria-label="t(curiosity-toolbar.category, [object Object])"
+            aria-label="t(curiosity-toolbar.category, {\\"context\\":\\"usage\\"})"
             ariaLabel="Select option"
             className=""
             id="generatedid-"
@@ -651,7 +651,7 @@ exports[`Toolbar Component should render a non-connected component: non-connecte
                 },
               ]
             }
-            placeholder="t(curiosity-toolbar.placeholder, [object Object])"
+            placeholder="t(curiosity-toolbar.placeholder, {\\"context\\":\\"usage\\"})"
             selectedOptions={Array []}
             toggleIcon={null}
             variant="single"
@@ -700,11 +700,11 @@ exports[`Toolbar Component should render filters when props are populated: props
             options={
               Array [
                 Object {
-                  "title": "t(curiosity-toolbar.category, [object Object])",
+                  "title": "t(curiosity-toolbar.category, {\\"context\\":\\"sla\\"})",
                   "value": "sla",
                 },
                 Object {
-                  "title": "t(curiosity-toolbar.category, [object Object])",
+                  "title": "t(curiosity-toolbar.category, {\\"context\\":\\"usage\\"})",
                   "value": "usage",
                 },
               ]
@@ -712,7 +712,7 @@ exports[`Toolbar Component should render filters when props are populated: props
             placeholder="t(curiosity-toolbar.placeholder)"
             selectedOptions={
               Array [
-                "t(curiosity-toolbar.category, [object Object])",
+                "t(curiosity-toolbar.category, {\\"context\\":\\"sla\\"})",
               ]
             }
             toggleIcon={
@@ -726,7 +726,7 @@ exports[`Toolbar Component should render filters when props are populated: props
           />
         </ToolbarItem>
         <ToolbarFilter
-          categoryName="t(curiosity-toolbar.category, [object Object])"
+          categoryName="t(curiosity-toolbar.category, {\\"context\\":\\"sla\\"})"
           chips={
             Array [
               "t(curiosity-toolbar.slaPremium)",
@@ -737,7 +737,7 @@ exports[`Toolbar Component should render filters when props are populated: props
           showToolbarItem={true}
         >
           <Select
-            aria-label="t(curiosity-toolbar.category, [object Object])"
+            aria-label="t(curiosity-toolbar.category, {\\"context\\":\\"sla\\"})"
             ariaLabel="Select option"
             className=""
             id="generatedid-"
@@ -765,7 +765,7 @@ exports[`Toolbar Component should render filters when props are populated: props
                 },
               ]
             }
-            placeholder="t(curiosity-toolbar.placeholder, [object Object])"
+            placeholder="t(curiosity-toolbar.placeholder, {\\"context\\":\\"sla\\"})"
             selectedOptions={
               Array [
                 "t(curiosity-toolbar.slaPremium)",
@@ -776,14 +776,14 @@ exports[`Toolbar Component should render filters when props are populated: props
           />
         </ToolbarFilter>
         <ToolbarFilter
-          categoryName="t(curiosity-toolbar.category, [object Object])"
+          categoryName="t(curiosity-toolbar.category, {\\"context\\":\\"usage\\"})"
           chips={Array []}
           deleteChip={[Function]}
           key="usage"
           showToolbarItem={false}
         >
           <Select
-            aria-label="t(curiosity-toolbar.category, [object Object])"
+            aria-label="t(curiosity-toolbar.category, {\\"context\\":\\"usage\\"})"
             ariaLabel="Select option"
             className=""
             id="generatedid-"
@@ -811,7 +811,7 @@ exports[`Toolbar Component should render filters when props are populated: props
                 },
               ]
             }
-            placeholder="t(curiosity-toolbar.placeholder, [object Object])"
+            placeholder="t(curiosity-toolbar.placeholder, {\\"context\\":\\"usage\\"})"
             selectedOptions={Array []}
             toggleIcon={null}
             variant="single"
@@ -848,14 +848,14 @@ exports[`Toolbar Component should render specific filters when the filterOptions
         variant="filter-group"
       >
         <ToolbarFilter
-          categoryName="t(curiosity-toolbar.category, [object Object])"
+          categoryName="t(curiosity-toolbar.category, {\\"context\\":\\"sla\\"})"
           chips={Array []}
           deleteChip={[Function]}
           key="sla"
           showToolbarItem={true}
         >
           <Select
-            aria-label="t(curiosity-toolbar.category, [object Object])"
+            aria-label="t(curiosity-toolbar.category, {\\"context\\":\\"sla\\"})"
             ariaLabel="Select option"
             className=""
             id="generatedid-"
@@ -883,7 +883,7 @@ exports[`Toolbar Component should render specific filters when the filterOptions
                 },
               ]
             }
-            placeholder="t(curiosity-toolbar.placeholder, [object Object])"
+            placeholder="t(curiosity-toolbar.placeholder, {\\"context\\":\\"sla\\"})"
             selectedOptions={Array []}
             toggleIcon={null}
             variant="single"

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarTypes.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarTypes.test.js.snap
@@ -10,11 +10,11 @@ exports[`ToolbarTypes should return an output for options selection: getOptionsT
 Object {
   "options": Array [
     Object {
-      "title": "t(curiosity-toolbar.category, [object Object])",
+      "title": "t(curiosity-toolbar.category, {\\"context\\":\\"sla\\"})",
       "value": "sla",
     },
     Object {
-      "title": "t(curiosity-toolbar.category, [object Object])",
+      "title": "t(curiosity-toolbar.category, {\\"context\\":\\"usage\\"})",
       "value": "usage",
     },
   ],
@@ -26,11 +26,11 @@ exports[`ToolbarTypes should return an output for options selection: getOptionsT
 Object {
   "options": Array [
     Object {
-      "title": "t(curiosity-toolbar.category, [object Object])",
+      "title": "t(curiosity-toolbar.category, {\\"context\\":\\"sla\\"})",
       "value": "sla",
     },
     Object {
-      "title": "t(curiosity-toolbar.category, [object Object])",
+      "title": "t(curiosity-toolbar.category, {\\"context\\":\\"usage\\"})",
       "value": "usage",
     },
   ],


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(openshiftView,rhelView): issues/468 header names
- fix(helpers,testing): noopTranslate, helpful test snapshots

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- Header names, this is an iterative update aimed at expanding the helpfulness of the copy used for the headers
- `noopTranslate`, simple testing update to actually render out the JSON instead of displaying `[object Object]` in snapshots


## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. Locate an account with "VMs", expand the section, the new "VM name" should display

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
  
<img width="952" alt="Screen Shot 2020-10-21 at 3 15 59 PM" src="https://user-images.githubusercontent.com/3761375/96773569-b95e3f00-13b2-11eb-9d15-2501640d7d42.png">


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
#468 
relates #389 