### PR TITLE
feat(inventoryList,guestsList): issues/494 fixed column widths

### DIFF
--- a/src/components/guestsList/__tests__/__snapshots__/guestsList.test.js.snap
+++ b/src/components/guestsList/__tests__/__snapshots__/guestsList.test.js.snap
@@ -19,7 +19,7 @@ exports[`GuestsList Component should handle multiple display states: fulfilled 1
       <Table
         ariaLabel={null}
         borders={false}
-        className="curiosity-inventory-list"
+        className="curiosity-guests-list"
         columnHeaders={
           Array [
             "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})",
@@ -60,6 +60,7 @@ exports[`GuestsList Component should handle multiple display states: initial pen
       Object {
         "borders": false,
         "colCount": 1,
+        "colWidth": Array [],
         "rowCount": 1,
         "variant": "compact",
       }
@@ -154,10 +155,13 @@ exports[`GuestsList Component should handle variations in data: filtered data 1`
       <Table
         ariaLabel={null}
         borders={false}
-        className="curiosity-inventory-list"
+        className="curiosity-guests-list"
         columnHeaders={
           Array [
-            "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})",
+            Object {
+              "title": "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})",
+              "transforms": Array [],
+            },
           ]
         }
         isHeader={true}
@@ -165,12 +169,16 @@ exports[`GuestsList Component should handle variations in data: filtered data 1`
           Array [
             Object {
               "cells": Array [
-                "ipsum",
+                Object {
+                  "title": "ipsum",
+                },
               ],
             },
             Object {
               "cells": Array [
-                "amet",
+                Object {
+                  "title": "amet",
+                },
               ],
             },
           ]
@@ -203,7 +211,7 @@ exports[`GuestsList Component should handle variations in data: variable data 1`
       <Table
         ariaLabel={null}
         borders={false}
-        className="curiosity-inventory-list"
+        className="curiosity-guests-list"
         columnHeaders={
           Array [
             "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})",

--- a/src/components/guestsList/guestsList.js
+++ b/src/components/guestsList/guestsList.js
@@ -148,7 +148,7 @@ class GuestsList extends React.Component {
             <Table
               borders={false}
               variant={TableVariant.compact}
-              className="curiosity-inventory-list"
+              className="curiosity-guests-list"
               columnHeaders={updatedColumnHeaders}
               rows={updatedRows}
             />
@@ -176,6 +176,7 @@ class GuestsList extends React.Component {
             tableProps={{
               borders: false,
               colCount: filterGuestsData?.length || (listData?.[0] && Object.keys(listData[0]).length) || 1,
+              colWidth: (filterGuestsData?.length && filterGuestsData.map(({ cellWidth }) => cellWidth)) || [],
               rowCount: numberOfGuests < perPageDefault ? numberOfGuests : perPageDefault,
               variant: TableVariant.compact
             }}
@@ -201,17 +202,17 @@ GuestsList.propTypes = {
       id: PropTypes.string,
       header: PropTypes.oneOfType([
         PropTypes.shape({
-          title: PropTypes.string
+          title: PropTypes.node.isRequired
         }),
         PropTypes.func,
-        PropTypes.string
+        PropTypes.node
       ]),
       cell: PropTypes.oneOfType([
         PropTypes.shape({
-          title: PropTypes.string
+          title: PropTypes.node.isRequired
         }),
         PropTypes.func,
-        PropTypes.string
+        PropTypes.node
       ])
     }).isRequired
   ),

--- a/src/components/inventoryList/__tests__/__snapshots__/inventoryList.test.js.snap
+++ b/src/components/inventoryList/__tests__/__snapshots__/inventoryList.test.js.snap
@@ -166,7 +166,10 @@ exports[`InventoryList Component should handle variations in data: filtered data
           className="curiosity-inventory-list"
           columnHeaders={
             Array [
-              "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})",
+              Object {
+                "title": "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})",
+                "transforms": Array [],
+              },
             ]
           }
           isHeader={true}
@@ -174,13 +177,17 @@ exports[`InventoryList Component should handle variations in data: filtered data
             Array [
               Object {
                 "cells": Array [
-                  "ipsum",
+                  Object {
+                    "title": "ipsum",
+                  },
                 ],
                 "expandedContent": false,
               },
               Object {
                 "cells": Array [
-                  "sit",
+                  Object {
+                    "title": "sit",
+                  },
                 ],
                 "expandedContent": false,
               },

--- a/src/components/inventoryList/__tests__/__snapshots__/inventoryListHelpers.test.js.snap
+++ b/src/components/inventoryList/__tests__/__snapshots__/inventoryListHelpers.test.js.snap
@@ -87,10 +87,15 @@ Object {
 exports[`InventoryListHelpers parseRowCellsListData should parse and return formatted/filtered table cells.: custom callback data 1`] = `
 Object {
   "cells": Array [
-    "ipsum/sit",
+    Object {
+      "title": "ipsum/sit",
+    },
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})/t(curiosity-inventory.header, {\\"context\\":\\"dolor\\"})",
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})/t(curiosity-inventory.header, {\\"context\\":\\"dolor\\"})",
+      "transforms": Array [],
+    },
   ],
   "data": Object {
     "dolor": Object {
@@ -116,7 +121,10 @@ Object {
     },
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})",
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})",
+      "transforms": Array [],
+    },
   ],
   "data": Object {
     "dolor": Object {
@@ -134,7 +142,9 @@ Object {
 exports[`InventoryListHelpers parseRowCellsListData should parse and return formatted/filtered table cells.: custom header data 1`] = `
 Object {
   "cells": Array [
-    "ipsum",
+    Object {
+      "title": "ipsum",
+    },
   ],
   "columnHeaders": Array [
     Object {
@@ -142,6 +152,7 @@ Object {
         "textCenter": true,
       },
       "title": "object, header, lorem",
+      "transforms": Array [],
     },
   ],
   "data": Object {
@@ -160,10 +171,15 @@ Object {
 exports[`InventoryListHelpers parseRowCellsListData should parse and return formatted/filtered table cells.: filtered data 1`] = `
 Object {
   "cells": Array [
-    "ipsum",
+    Object {
+      "title": "ipsum",
+    },
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})",
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})",
+      "transforms": Array [],
+    },
   ],
   "data": Object {
     "dolor": Object {

--- a/src/components/inventoryList/inventoryList.js
+++ b/src/components/inventoryList/inventoryList.js
@@ -198,6 +198,8 @@ class InventoryList extends React.Component {
                   tableProps={{
                     className: 'curiosity-inventory-list',
                     colCount: filterInventoryData?.length || (listData?.[0] && Object.keys(listData[0]).length) || 1,
+                    colWidth:
+                      (filterInventoryData?.length && filterInventoryData.map(({ cellWidth }) => cellWidth)) || [],
                     rowCount: listData?.length || updatedPerPage,
                     variant: TableVariant.compact
                   }}
@@ -242,17 +244,17 @@ InventoryList.propTypes = {
       id: PropTypes.string,
       header: PropTypes.oneOfType([
         PropTypes.shape({
-          title: PropTypes.string
+          title: PropTypes.node.isRequired
         }),
         PropTypes.func,
-        PropTypes.string
+        PropTypes.node
       ]),
       cell: PropTypes.oneOfType([
         PropTypes.shape({
-          title: PropTypes.string
+          title: PropTypes.node.isRequired
         }),
         PropTypes.func,
-        PropTypes.string
+        PropTypes.node
       ])
     }).isRequired
   ),

--- a/src/components/loader/__tests__/__snapshots__/loader.test.js.snap
+++ b/src/components/loader/__tests__/__snapshots__/loader.test.js.snap
@@ -69,6 +69,7 @@ exports[`Loader Component should handle variant loader components: variant: tabl
   borders={true}
   className={null}
   colCount={1}
+  colWidth={Array []}
   isHeader={true}
   rowCount={5}
   t={[Function]}

--- a/src/components/loader/loader.js
+++ b/src/components/loader/loader.js
@@ -65,6 +65,7 @@ Loader.propTypes = {
     borders: PropTypes.bool,
     className: PropTypes.string,
     colCount: PropTypes.number,
+    colWidth: PropTypes.array,
     rowCount: PropTypes.number,
     variant: PropTypes.oneOf([...Object.values(TableVariant)])
   }),

--- a/src/components/openshiftView/__tests__/__snapshots__/openshiftView.test.js.snap
+++ b/src/components/openshiftView/__tests__/__snapshots__/openshiftView.test.js.snap
@@ -97,10 +97,12 @@ exports[`OpenshiftView Component should display an alternate graph on query-stri
             "id": "displayName",
           },
           Object {
+            "cellWidth": 40,
             "id": "inventoryId",
           },
           Object {
             "cell": [Function],
+            "cellWidth": 15,
             "id": "lastSeen",
           },
         ]
@@ -114,16 +116,19 @@ exports[`OpenshiftView Component should display an alternate graph on query-stri
           },
           Object {
             "cell": [Function],
+            "cellWidth": 20,
             "id": "measurementType",
             "isSortable": true,
           },
           Object {
+            "cellWidth": 15,
             "id": "cores",
             "isOptional": true,
             "isSortable": true,
           },
           Object {
             "cell": [Function],
+            "cellWidth": 15,
             "id": "lastSeen",
             "isSortable": true,
           },
@@ -243,10 +248,12 @@ exports[`OpenshiftView Component should have a fallback title: title 1`] = `
             "id": "displayName",
           },
           Object {
+            "cellWidth": 40,
             "id": "inventoryId",
           },
           Object {
             "cell": [Function],
+            "cellWidth": 15,
             "id": "lastSeen",
           },
         ]
@@ -260,16 +267,19 @@ exports[`OpenshiftView Component should have a fallback title: title 1`] = `
           },
           Object {
             "cell": [Function],
+            "cellWidth": 20,
             "id": "measurementType",
             "isSortable": true,
           },
           Object {
+            "cellWidth": 15,
             "id": "cores",
             "isOptional": true,
             "isSortable": true,
           },
           Object {
             "cell": [Function],
+            "cellWidth": 15,
             "id": "lastSeen",
             "isSortable": true,
           },
@@ -295,16 +305,33 @@ exports[`OpenshiftView Component should have a fallback title: title 1`] = `
 exports[`OpenshiftView Component should have default props that set product configuration: filteredGuestsData results 1`] = `
 Object {
   "cells": Array [
-    "lorem",
-    "lorem inventory id",
+    Object {
+      "title": "lorem",
+    },
+    Object {
+      "title": "lorem inventory id",
+    },
     <DateFormat
       date="lorem date obj"
     />,
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, {\\"context\\":\\"guestsDisplayName\\"})",
-    "t(curiosity-inventory.header, {\\"context\\":\\"inventoryId\\"})",
-    "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"guestsDisplayName\\"})",
+      "transforms": Array [],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"inventoryId\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
   ],
   "data": Object {
     "displayName": Object {
@@ -343,15 +370,30 @@ Object {
     >
       lorem
     </Button>,
-    "lorem inventory id",
+    Object {
+      "title": "lorem inventory id",
+    },
     <DateFormat
       date="lorem date obj"
     />,
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, {\\"context\\":\\"guestsDisplayName\\"})",
-    "t(curiosity-inventory.header, {\\"context\\":\\"inventoryId\\"})",
-    "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"guestsDisplayName\\"})",
+      "transforms": Array [],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"inventoryId\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
   ],
   "data": Object {
     "displayName": Object {
@@ -398,11 +440,34 @@ Object {
     />,
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
-    "t(curiosity-inventory.header, {\\"context\\":\\"measurementType\\"})",
-    "t(curiosity-inventory.header, {\\"context\\":\\"sockets\\"})",
-    "t(curiosity-inventory.header, {\\"context\\":\\"cores\\"})",
-    "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
+      "transforms": Array [],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"measurementType\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"sockets\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"cores\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
   ],
   "data": Object {
     "cores": Object {
@@ -471,11 +536,34 @@ Object {
     />,
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
-    "t(curiosity-inventory.header, {\\"context\\":\\"measurementType\\"})",
-    "t(curiosity-inventory.header, {\\"context\\":\\"sockets\\"})",
-    "t(curiosity-inventory.header, {\\"context\\":\\"cores\\"})",
-    "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
+      "transforms": Array [],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"measurementType\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"sockets\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"cores\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
   ],
   "data": Object {
     "cores": Object {
@@ -551,10 +639,12 @@ Object {
       "id": "displayName",
     },
     Object {
+      "cellWidth": 40,
       "id": "inventoryId",
     },
     Object {
       "cell": [Function],
+      "cellWidth": 15,
       "id": "lastSeen",
     },
   ],
@@ -566,21 +656,25 @@ Object {
     },
     Object {
       "cell": [Function],
+      "cellWidth": 20,
       "id": "measurementType",
       "isSortable": true,
     },
     Object {
+      "cellWidth": 15,
       "id": "sockets",
       "isOptional": true,
       "isSortable": true,
     },
     Object {
+      "cellWidth": 15,
       "id": "cores",
       "isOptional": true,
       "isSortable": true,
     },
     Object {
       "cell": [Function],
+      "cellWidth": 15,
       "id": "lastSeen",
       "isSortable": true,
     },
@@ -693,10 +787,12 @@ exports[`OpenshiftView Component should render a non-connected component: non-co
             "id": "displayName",
           },
           Object {
+            "cellWidth": 40,
             "id": "inventoryId",
           },
           Object {
             "cell": [Function],
+            "cellWidth": 15,
             "id": "lastSeen",
           },
         ]
@@ -710,16 +806,19 @@ exports[`OpenshiftView Component should render a non-connected component: non-co
           },
           Object {
             "cell": [Function],
+            "cellWidth": 20,
             "id": "measurementType",
             "isSortable": true,
           },
           Object {
+            "cellWidth": 15,
             "id": "cores",
             "isOptional": true,
             "isSortable": true,
           },
           Object {
             "cell": [Function],
+            "cellWidth": 15,
             "id": "lastSeen",
             "isSortable": true,
           },

--- a/src/components/openshiftView/openshiftView.js
+++ b/src/components/openshiftView/openshiftView.js
@@ -283,11 +283,13 @@ OpenshiftView.defaultProps = {
       }
     },
     {
-      id: 'inventoryId'
+      id: 'inventoryId',
+      cellWidth: 40
     },
     {
       id: 'lastSeen',
-      cell: data => (data?.lastSeen?.value && <DateFormat date={data?.lastSeen?.value} />) || ''
+      cell: data => (data?.lastSeen?.value && <DateFormat date={data?.lastSeen?.value} />) || '',
+      cellWidth: 15
     }
   ],
   initialInventoryFilters: [
@@ -349,22 +351,26 @@ OpenshiftView.defaultProps = {
           </React.Fragment>
         );
       },
-      isSortable: true
+      isSortable: true,
+      cellWidth: 20
     },
     {
       id: 'sockets',
       isOptional: true,
-      isSortable: true
+      isSortable: true,
+      cellWidth: 15
     },
     {
       id: 'cores',
       isOptional: true,
-      isSortable: true
+      isSortable: true,
+      cellWidth: 15
     },
     {
       id: 'lastSeen',
       cell: data => (data?.lastSeen?.value && <DateFormat date={data?.lastSeen?.value} />) || '',
-      isSortable: true
+      isSortable: true,
+      cellWidth: 15
     }
   ],
   initialToolbarFilters: [

--- a/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
+++ b/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
@@ -84,10 +84,12 @@ exports[`RhelView Component should display an alternate graph on query-string up
             "id": "displayName",
           },
           Object {
+            "cellWidth": 40,
             "id": "inventoryId",
           },
           Object {
             "cell": [Function],
+            "cellWidth": 15,
             "id": "lastSeen",
           },
         ]
@@ -101,15 +103,18 @@ exports[`RhelView Component should display an alternate graph on query-string up
           },
           Object {
             "cell": [Function],
+            "cellWidth": 20,
             "id": "measurementType",
             "isSortable": true,
           },
           Object {
+            "cellWidth": 15,
             "id": "sockets",
             "isSortable": true,
           },
           Object {
             "cell": [Function],
+            "cellWidth": 15,
             "id": "lastSeen",
             "isSortable": true,
           },
@@ -215,10 +220,12 @@ exports[`RhelView Component should have a fallback title: title 1`] = `
             "id": "displayName",
           },
           Object {
+            "cellWidth": 40,
             "id": "inventoryId",
           },
           Object {
             "cell": [Function],
+            "cellWidth": 15,
             "id": "lastSeen",
           },
         ]
@@ -232,15 +239,18 @@ exports[`RhelView Component should have a fallback title: title 1`] = `
           },
           Object {
             "cell": [Function],
+            "cellWidth": 20,
             "id": "measurementType",
             "isSortable": true,
           },
           Object {
+            "cellWidth": 15,
             "id": "sockets",
             "isSortable": true,
           },
           Object {
             "cell": [Function],
+            "cellWidth": 15,
             "id": "lastSeen",
             "isSortable": true,
           },
@@ -265,16 +275,33 @@ exports[`RhelView Component should have a fallback title: title 1`] = `
 exports[`RhelView Component should have default props that set product configuration: filteredGuestsData results 1`] = `
 Object {
   "cells": Array [
-    "lorem",
-    "lorem inventory id",
+    Object {
+      "title": "lorem",
+    },
+    Object {
+      "title": "lorem inventory id",
+    },
     <DateFormat
       date="lorem date obj"
     />,
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, {\\"context\\":\\"guestsDisplayName\\"})",
-    "t(curiosity-inventory.header, {\\"context\\":\\"inventoryId\\"})",
-    "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"guestsDisplayName\\"})",
+      "transforms": Array [],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"inventoryId\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
   ],
   "data": Object {
     "displayName": Object {
@@ -313,15 +340,30 @@ Object {
     >
       lorem
     </Button>,
-    "lorem inventory id",
+    Object {
+      "title": "lorem inventory id",
+    },
     <DateFormat
       date="lorem date obj"
     />,
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, {\\"context\\":\\"guestsDisplayName\\"})",
-    "t(curiosity-inventory.header, {\\"context\\":\\"inventoryId\\"})",
-    "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"guestsDisplayName\\"})",
+      "transforms": Array [],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"inventoryId\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
   ],
   "data": Object {
     "displayName": Object {
@@ -367,10 +409,28 @@ Object {
     />,
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
-    "t(curiosity-inventory.header, {\\"context\\":\\"measurementType\\"})",
-    "t(curiosity-inventory.header, {\\"context\\":\\"sockets\\"})",
-    "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
+      "transforms": Array [],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"measurementType\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"sockets\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
   ],
   "data": Object {
     "cores": Object {
@@ -438,10 +498,28 @@ Object {
     />,
   ],
   "columnHeaders": Array [
-    "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
-    "t(curiosity-inventory.header, {\\"context\\":\\"measurementType\\"})",
-    "t(curiosity-inventory.header, {\\"context\\":\\"sockets\\"})",
-    "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"displayName\\"})",
+      "transforms": Array [],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"measurementType\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"sockets\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"lastSeen\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
   ],
   "data": Object {
     "cores": Object {
@@ -516,10 +594,12 @@ Object {
       "id": "displayName",
     },
     Object {
+      "cellWidth": 40,
       "id": "inventoryId",
     },
     Object {
       "cell": [Function],
+      "cellWidth": 15,
       "id": "lastSeen",
     },
   ],
@@ -531,15 +611,18 @@ Object {
     },
     Object {
       "cell": [Function],
+      "cellWidth": 20,
       "id": "measurementType",
       "isSortable": true,
     },
     Object {
+      "cellWidth": 15,
       "id": "sockets",
       "isSortable": true,
     },
     Object {
       "cell": [Function],
+      "cellWidth": 15,
       "id": "lastSeen",
       "isSortable": true,
     },
@@ -638,10 +721,12 @@ exports[`RhelView Component should render a non-connected component: non-connect
             "id": "displayName",
           },
           Object {
+            "cellWidth": 40,
             "id": "inventoryId",
           },
           Object {
             "cell": [Function],
+            "cellWidth": 15,
             "id": "lastSeen",
           },
         ]
@@ -655,15 +740,18 @@ exports[`RhelView Component should render a non-connected component: non-connect
           },
           Object {
             "cell": [Function],
+            "cellWidth": 20,
             "id": "measurementType",
             "isSortable": true,
           },
           Object {
+            "cellWidth": 15,
             "id": "sockets",
             "isSortable": true,
           },
           Object {
             "cell": [Function],
+            "cellWidth": 15,
             "id": "lastSeen",
             "isSortable": true,
           },

--- a/src/components/rhelView/rhelView.js
+++ b/src/components/rhelView/rhelView.js
@@ -205,11 +205,13 @@ RhelView.defaultProps = {
       }
     },
     {
-      id: 'inventoryId'
+      id: 'inventoryId',
+      cellWidth: 40
     },
     {
       id: 'lastSeen',
-      cell: data => (data?.lastSeen?.value && <DateFormat date={data?.lastSeen?.value} />) || ''
+      cell: data => (data?.lastSeen?.value && <DateFormat date={data?.lastSeen?.value} />) || '',
+      cellWidth: 15
     }
   ],
   initialInventoryFilters: [
@@ -271,16 +273,19 @@ RhelView.defaultProps = {
           </React.Fragment>
         );
       },
-      isSortable: true
+      isSortable: true,
+      cellWidth: 20
     },
     {
       id: 'sockets',
-      isSortable: true
+      isSortable: true,
+      cellWidth: 15
     },
     {
       id: 'lastSeen',
       cell: data => (data?.lastSeen?.value && <DateFormat date={data?.lastSeen?.value} />) || '',
-      isSortable: true
+      isSortable: true,
+      cellWidth: 15
     }
   ],
   initialToolbarFilters: [

--- a/src/components/table/__tests__/__snapshots__/tableSkeleton.test.js.snap
+++ b/src/components/table/__tests__/__snapshots__/tableSkeleton.test.js.snap
@@ -7,26 +7,45 @@ exports[`TableSkeleton Component should allow variations in table layout: border
   className="curiosity-skeleton-table "
   columnHeaders={
     Array [
-      <Skeleton
-        isDark={false}
-        size="md"
-      />,
-      <Skeleton
-        isDark={false}
-        size="md"
-      />,
-      <Skeleton
-        isDark={false}
-        size="md"
-      />,
-      <Skeleton
-        isDark={false}
-        size="md"
-      />,
-      <Skeleton
-        isDark={false}
-        size="md"
-      />,
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+      },
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+      },
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+        "transforms": Array [
+          [Function],
+        ],
+      },
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+        "transforms": Array [
+          [Function],
+        ],
+      },
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+        "transforms": Array [
+          [Function],
+        ],
+      },
     ]
   }
   isHeader={false}
@@ -71,26 +90,45 @@ exports[`TableSkeleton Component should allow variations in table layout: classN
   className="curiosity-skeleton-table lorem-ipsum-class"
   columnHeaders={
     Array [
-      <Skeleton
-        isDark={false}
-        size="md"
-      />,
-      <Skeleton
-        isDark={false}
-        size="md"
-      />,
-      <Skeleton
-        isDark={false}
-        size="md"
-      />,
-      <Skeleton
-        isDark={false}
-        size="md"
-      />,
-      <Skeleton
-        isDark={false}
-        size="md"
-      />,
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+      },
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+      },
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+        "transforms": Array [
+          [Function],
+        ],
+      },
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+        "transforms": Array [
+          [Function],
+        ],
+      },
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+        "transforms": Array [
+          [Function],
+        ],
+      },
     ]
   }
   isHeader={false}
@@ -135,26 +173,36 @@ exports[`TableSkeleton Component should allow variations in table layout: column
   className="curiosity-skeleton-table "
   columnHeaders={
     Array [
-      <Skeleton
-        isDark={false}
-        size="md"
-      />,
-      <Skeleton
-        isDark={false}
-        size="md"
-      />,
-      <Skeleton
-        isDark={false}
-        size="md"
-      />,
-      <Skeleton
-        isDark={false}
-        size="md"
-      />,
-      <Skeleton
-        isDark={false}
-        size="md"
-      />,
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+      },
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+      },
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+      },
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+      },
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+      },
     ]
   }
   isHeader={true}
@@ -199,26 +247,45 @@ exports[`TableSkeleton Component should allow variations in table layout: no tab
   className="curiosity-skeleton-table curiosity-skeleton-table__hidden-rows lorem-ipsum-class"
   columnHeaders={
     Array [
-      <Skeleton
-        isDark={false}
-        size="md"
-      />,
-      <Skeleton
-        isDark={false}
-        size="md"
-      />,
-      <Skeleton
-        isDark={false}
-        size="md"
-      />,
-      <Skeleton
-        isDark={false}
-        size="md"
-      />,
-      <Skeleton
-        isDark={false}
-        size="md"
-      />,
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+      },
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+      },
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+        "transforms": Array [
+          [Function],
+        ],
+      },
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+        "transforms": Array [
+          [Function],
+        ],
+      },
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+        "transforms": Array [
+          [Function],
+        ],
+      },
     ]
   }
   isHeader={false}
@@ -256,6 +323,89 @@ exports[`TableSkeleton Component should allow variations in table layout: no tab
 />
 `;
 
+exports[`TableSkeleton Component should allow variations in table layout: table column widths 1`] = `
+<Table
+  ariaLabel="t(curiosity-inventory.tableSkeletonAriaLabel)"
+  borders={true}
+  className="curiosity-skeleton-table "
+  columnHeaders={
+    Array [
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+      },
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+      },
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+        "transforms": Array [
+          [Function],
+        ],
+      },
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+        "transforms": Array [
+          [Function],
+        ],
+      },
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+        "transforms": Array [
+          [Function],
+        ],
+      },
+    ]
+  }
+  isHeader={true}
+  rows={
+    Array [
+      Object {
+        "cells": Array [
+          <Skeleton
+            isDark={false}
+            size="md"
+          />,
+          <Skeleton
+            isDark={false}
+            size="md"
+          />,
+          <Skeleton
+            isDark={false}
+            size="md"
+          />,
+          <Skeleton
+            isDark={false}
+            size="md"
+          />,
+          <Skeleton
+            isDark={false}
+            size="md"
+          />,
+        ],
+      },
+    ]
+  }
+  summary={null}
+  t={[Function]}
+  variant={null}
+/>
+`;
+
 exports[`TableSkeleton Component should allow variations in table layout: table header and zero rows 1`] = `
 <Table
   ariaLabel="t(curiosity-inventory.tableSkeletonAriaLabel)"
@@ -263,26 +413,45 @@ exports[`TableSkeleton Component should allow variations in table layout: table 
   className="curiosity-skeleton-table curiosity-skeleton-table__hidden-rows lorem-ipsum-class"
   columnHeaders={
     Array [
-      <Skeleton
-        isDark={false}
-        size="md"
-      />,
-      <Skeleton
-        isDark={false}
-        size="md"
-      />,
-      <Skeleton
-        isDark={false}
-        size="md"
-      />,
-      <Skeleton
-        isDark={false}
-        size="md"
-      />,
-      <Skeleton
-        isDark={false}
-        size="md"
-      />,
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+      },
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+      },
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+        "transforms": Array [
+          [Function],
+        ],
+      },
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+        "transforms": Array [
+          [Function],
+        ],
+      },
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+        "transforms": Array [
+          [Function],
+        ],
+      },
     ]
   }
   isHeader={true}
@@ -327,10 +496,12 @@ exports[`TableSkeleton Component should render a non-connected component: non-co
   className="curiosity-skeleton-table "
   columnHeaders={
     Array [
-      <Skeleton
-        isDark={false}
-        size="md"
-      />,
+      Object {
+        "title": <Skeleton
+          isDark={false}
+          size="md"
+        />,
+      },
     ]
   }
   isHeader={true}

--- a/src/components/table/__tests__/tableSkeleton.test.js
+++ b/src/components/table/__tests__/tableSkeleton.test.js
@@ -21,6 +21,11 @@ describe('TableSkeleton Component', () => {
     expect(component).toMatchSnapshot('column and row count ');
 
     component.setProps({
+      colWidth: [null, undefined, 30, 15, 15]
+    });
+    expect(component).toMatchSnapshot('table column widths');
+
+    component.setProps({
       borders: false,
       isHeader: false
     });

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -188,7 +188,9 @@ class Table extends React.Component {
           const { title, ...settings } = cell;
           rowObj.cells.push({ title, ...settings });
         } else {
-          rowObj.cells.push({ title: cell });
+          rowObj.cells.push({
+            title: (React.isValidElement(cell) && cell) || (typeof cell === 'object' && `${cell}`) || cell
+          });
         }
       });
     });
@@ -220,7 +222,12 @@ class Table extends React.Component {
 
         updatedColumnHeaders.push(tempColumnHeader);
       } else {
-        updatedColumnHeaders.push({ title: columnHeader });
+        updatedColumnHeaders.push({
+          title:
+            (React.isValidElement(columnHeader) && columnHeader) ||
+            (typeof columnHeader === 'object' && `${columnHeader}`) ||
+            columnHeader
+        });
       }
     });
 
@@ -321,7 +328,7 @@ Table.propTypes = {
         onSort: PropTypes.func,
         sortActive: PropTypes.bool,
         sortDirection: PropTypes.oneOf([...Object.values(SortByDirection)]),
-        title: PropTypes.node
+        title: PropTypes.node.isRequired
       })
     ])
   ).isRequired,
@@ -333,7 +340,7 @@ Table.propTypes = {
         PropTypes.oneOfType([
           PropTypes.node,
           PropTypes.shape({
-            title: PropTypes.node
+            title: PropTypes.node.isRequired
           })
         ])
       ),

--- a/src/components/table/tableSkeleton.js
+++ b/src/components/table/tableSkeleton.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { TableVariant } from '@patternfly/react-table';
+import { cellWidth, TableVariant } from '@patternfly/react-table';
 import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components/components/cjs/Skeleton';
 import Table from './table';
 import { translate } from '../i18n/i18n';
@@ -12,14 +12,24 @@ import { translate } from '../i18n/i18n';
  * @param {string} props.className
  * @param {boolean} props.borders
  * @param {number} props.colCount
+ * @param {Array} props.colWidth
  * @param {boolean} props.isHeader
  * @param {number} props.rowCount
  * @param {Function} props.t
  * @param {string} props.variant
  * @returns {Node}
  */
-const TableSkeleton = ({ className, borders, colCount, isHeader, rowCount, t, variant }) => {
-  const updatedColumnHeaders = [...new Array(colCount)].map(() => <Skeleton size={SkeletonSize.md} />);
+const TableSkeleton = ({ className, borders, colCount, colWidth, isHeader, rowCount, t, variant }) => {
+  const updatedColumnHeaders = [...new Array(colCount)].map((value, index) => {
+    const updatedHeader = { title: <Skeleton size={SkeletonSize.md} /> };
+
+    if (typeof colWidth[index] === 'number') {
+      updatedHeader.transforms = [cellWidth(colWidth[index])];
+    }
+
+    return updatedHeader;
+  });
+
   const updatedRowCount = rowCount || 1;
 
   const updatedRows = [...new Array(updatedRowCount)].map(() => ({
@@ -44,12 +54,14 @@ const TableSkeleton = ({ className, borders, colCount, isHeader, rowCount, t, va
 /**
  * Prop types.
  *
- * @type {{borders: boolean, isHeader: boolean, colCount: number, variant: string, className: string, rowCount: number}}
+ * @type {{borders: boolean, isHeader: boolean, colCount: number, colWidth: Array, variant: string,
+ *     className: string, rowCount: number}}
  */
 TableSkeleton.propTypes = {
   borders: PropTypes.bool,
   className: PropTypes.string,
   colCount: PropTypes.number,
+  colWidth: PropTypes.arrayOf(PropTypes.number),
   isHeader: PropTypes.bool,
   rowCount: PropTypes.number,
   t: PropTypes.func,
@@ -59,13 +71,14 @@ TableSkeleton.propTypes = {
 /**
  * Default props.
  *
- * @type {{t: translate, borders: boolean, isHeader: boolean, colCount: number, variant: null, className: null,
- *     rowCount: number}}
+ * @type {{t: translate, borders: boolean, isHeader: boolean, colCount: number, colWidth: Array, variant: null,
+ *     className: null, rowCount: number}}
  */
 TableSkeleton.defaultProps = {
   borders: true,
   className: null,
   colCount: 1,
+  colWidth: [],
   isHeader: true,
   rowCount: 5,
   t: translate,

--- a/src/styles/_inventory-list.scss
+++ b/src/styles/_inventory-list.scss
@@ -44,8 +44,24 @@
 
   // ToDo: reevaluate this fix, originally for non-expandable table rows to aid in alignment with heading
   .curiosity-inventory-list {
-    .pf-c-table.pf-m-compact tr:not(.pf-c-table__expandable-row) > :first-child {
-      padding-left: var(--pf-c-table--m-compact--cell--first-last-child--PaddingLeft);;
+    &.pf-c-table.pf-m-compact tr:not(.pf-c-table__expandable-row) > :first-child {
+      padding-left: var(--pf-c-table--m-compact--cell--first-last-child--PaddingLeft);
+    }
+  }
+
+  .curiosity-guests-list {
+    &.pf-c-table.pf-m-compact tr > *:last-child {
+      padding-right: var(--pf-c-table--m-compact--cell--first-last-child--PaddingRight);
+    }
+
+    @media (max-width: $pf-global--breakpoint--md) {
+      &.pf-c-table.pf-m-compact tr:not(.pf-c-table__expandable-row) > :first-child {
+        padding-left: 0;
+      }
+
+      &.pf-c-table.pf-m-compact > tbody > tr {
+        padding-top: 0;
+      }
     }
   }
 }

--- a/src/styles/_table.scss
+++ b/src/styles/_table.scss
@@ -62,5 +62,9 @@
   .curiosity-table-scroll-list__no-scroll {
     overflow-y: hidden;
     padding-bottom: inherit;
+
+    @media (max-width: $pf-global--breakpoint--md) {
+      overflow-y: auto;
+    }
   }
 }


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- feat(inventoryList,guestsList): issues/494 fixed column widths

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- Adds the ability to set fixed inventory column widths through config
   - Even though we're applying column widths there is still a potential shift in inventory paged displays that have/do not have expandable sections. The Patternfly expandable table rows add an additional table column that shift the view.
- Table skeleton should have fixed column widths applied too
- inventoryListHelpers changes are prep for #483 

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm during paging of the inventory display that columns maintain their width in a consistent manner. 

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screen Shot 2020-11-05 at 3 59 47 PM](https://user-images.githubusercontent.com/3761375/98295775-fcf2a480-1f7f-11eb-85f5-3decec979341.png)

![Screen Shot 2020-11-06 at 12 22 01 PM](https://user-images.githubusercontent.com/3761375/98395766-bad26d00-202a-11eb-9f3e-483628c5049c.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
#494 
relates #483 