### PR TITLE
feat(rhelView, openshiftView): issues/490 add tour button

### DIFF
--- a/src/components/authentication/__tests__/__snapshots__/authentication.test.js.snap
+++ b/src/components/authentication/__tests__/__snapshots__/authentication.test.js.snap
@@ -68,6 +68,7 @@ exports[`Authentication Component should render a non-connected component error:
   >
     <PageLayout>
       <PageHeader
+        includeTour={false}
         key=".0"
         productLabel={null}
         t={[Function]}
@@ -77,26 +78,49 @@ exports[`Authentication Component should render a non-connected component error:
             className="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
             widget-type="InsightsPageHeader"
           >
-            <PageHeaderTitle
-              className="pf-u-mb-sm"
-              title="Subscription Watch"
+            <Flex
+              justifyContent={
+                Object {
+                  "sm": "justifyContentSpaceBetween",
+                }
+              }
             >
-              <Title
-                className="pf-u-mb-sm"
-                headingLevel="h1"
-                size="2xl"
-                widget-type="InsightsPageHeaderTitle"
+              <div
+                className="pf-l-flex pf-m-justify-content-space-between-on-sm"
               >
-                <h1
-                  className="pf-c-title pf-m-2xl pf-u-mb-sm"
-                  widget-type="InsightsPageHeaderTitle"
-                >
-                   
-                  Subscription Watch
-                   
-                </h1>
-              </Title>
-            </PageHeaderTitle>
+                <FlexItem>
+                  <div
+                    className=""
+                  >
+                    <PageHeaderTitle
+                      className="pf-u-mb-sm"
+                      title="Subscription Watch"
+                    >
+                      <Title
+                        className="pf-u-mb-sm"
+                        headingLevel="h1"
+                        size="2xl"
+                        widget-type="InsightsPageHeaderTitle"
+                      >
+                        <h1
+                          className="pf-c-title pf-m-2xl pf-u-mb-sm"
+                          widget-type="InsightsPageHeaderTitle"
+                        >
+                           
+                          Subscription Watch
+                           
+                        </h1>
+                      </Title>
+                    </PageHeaderTitle>
+                  </div>
+                </FlexItem>
+                <FlexItem>
+                  <div
+                    className=""
+                  />
+                </FlexItem>
+              </div>
+            </Flex>
           </section>
         </PageHeader>
       </PageHeader>

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -312,6 +312,10 @@ Array [
     "file": "./src/components/pageLayout/pageHeader.js",
     "keys": Array [
       Object {
+        "key": "curiosity-optin.buttonTour",
+        "match": "t('curiosity-optin.buttonTour')",
+      },
+      Object {
         "key": "curiosity-view.subtitle",
         "match": "t(\`curiosity-view.subtitle\`, { appName: helpers.UI_DISPLAY_NAME, context: productLabel }, [ <Button isInline component=\\"a\\" variant=\\"link\\" icon={<ExternalLinkAltIcon />} iconPosition=\\"right\\" target=\\"_blank\\" href={helpers.UI_LINK_LEARN_MORE} /> ])",
       },

--- a/src/components/loader/__tests__/__snapshots__/loader.test.js.snap
+++ b/src/components/loader/__tests__/__snapshots__/loader.test.js.snap
@@ -80,6 +80,7 @@ exports[`Loader Component should handle variant loader components: variant: tabl
 exports[`Loader Component should handle variant loader components: variant: title 1`] = `
 <PageLayout>
   <PageHeader
+    includeTour={false}
     productLabel={null}
     t={[Function]}
   >

--- a/src/components/messageView/__tests__/__snapshots__/messageView.test.js.snap
+++ b/src/components/messageView/__tests__/__snapshots__/messageView.test.js.snap
@@ -3,6 +3,7 @@
 exports[`MessageView Component should have fallback conditions for all props: fallback display 1`] = `
 <PageLayout>
   <PageHeader
+    includeTour={false}
     productLabel={null}
     t={[Function]}
   >
@@ -20,6 +21,7 @@ exports[`MessageView Component should have fallback conditions for all props: fa
 exports[`MessageView Component should render a non-connected component: non-connected 1`] = `
 <PageLayout>
   <PageHeader
+    includeTour={false}
     productLabel={null}
     t={[Function]}
   >
@@ -50,6 +52,7 @@ exports[`MessageView Component should render a non-connected component: non-conn
 exports[`MessageView Component should render children when provided: children display 1`] = `
 <PageLayout>
   <PageHeader
+    includeTour={false}
     productLabel={null}
     t={[Function]}
   >

--- a/src/components/openshiftView/__tests__/__snapshots__/openshiftView.test.js.snap
+++ b/src/components/openshiftView/__tests__/__snapshots__/openshiftView.test.js.snap
@@ -3,6 +3,7 @@
 exports[`OpenshiftView Component should display an alternate graph on query-string update: alternate graph 1`] = `
 <PageLayout>
   <PageHeader
+    includeTour={true}
     productLabel="OpenShift"
     t={[Function]}
   >
@@ -166,6 +167,7 @@ exports[`OpenshiftView Component should display an alternate graph on query-stri
 exports[`OpenshiftView Component should have a fallback title: title 1`] = `
 <PageLayout>
   <PageHeader
+    includeTour={true}
     productLabel="OpenShift"
     t={[Function]}
   >
@@ -748,6 +750,7 @@ Object {
 exports[`OpenshiftView Component should render a non-connected component: non-connected 1`] = `
 <PageLayout>
   <PageHeader
+    includeTour={true}
     productLabel="OpenShift"
     t={[Function]}
   >

--- a/src/components/openshiftView/openshiftView.js
+++ b/src/components/openshiftView/openshiftView.js
@@ -134,7 +134,7 @@ class OpenshiftView extends React.Component {
 
     return (
       <PageLayout>
-        <PageHeader productLabel={productLabel}>
+        <PageHeader productLabel={productLabel} includeTour>
           {t(`curiosity-view.title`, { appName: helpers.UI_DISPLAY_NAME, context: productLabel })}
         </PageHeader>
         <PageMessages>

--- a/src/components/pageLayout/__tests__/__snapshots__/pageHeader.test.js.snap
+++ b/src/components/pageLayout/__tests__/__snapshots__/pageHeader.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`PageHeader Component should render a basic component: basic 1`] = `
 <PageHeader
+  includeTour={false}
   productLabel={null}
   t={[Function]}
 >
@@ -10,36 +11,59 @@ exports[`PageHeader Component should render a basic component: basic 1`] = `
       className="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
       widget-type="InsightsPageHeader"
     >
-      <PageHeaderTitle
-        className="pf-u-mb-sm"
-        title={
-          <span
-            className="test"
-          >
-            lorem
-          </span>
+      <Flex
+        justifyContent={
+          Object {
+            "sm": "justifyContentSpaceBetween",
+          }
         }
       >
-        <Title
-          className="pf-u-mb-sm"
-          headingLevel="h1"
-          size="2xl"
-          widget-type="InsightsPageHeaderTitle"
+        <div
+          className="pf-l-flex pf-m-justify-content-space-between-on-sm"
         >
-          <h1
-            className="pf-c-title pf-m-2xl pf-u-mb-sm"
-            widget-type="InsightsPageHeaderTitle"
-          >
-             
-            <span
-              className="test"
+          <FlexItem>
+            <div
+              className=""
             >
-              lorem
-            </span>
-             
-          </h1>
-        </Title>
-      </PageHeaderTitle>
+              <PageHeaderTitle
+                className="pf-u-mb-sm"
+                title={
+                  <span
+                    className="test"
+                  >
+                    lorem
+                  </span>
+                }
+              >
+                <Title
+                  className="pf-u-mb-sm"
+                  headingLevel="h1"
+                  size="2xl"
+                  widget-type="InsightsPageHeaderTitle"
+                >
+                  <h1
+                    className="pf-c-title pf-m-2xl pf-u-mb-sm"
+                    widget-type="InsightsPageHeaderTitle"
+                  >
+                     
+                    <span
+                      className="test"
+                    >
+                      lorem
+                    </span>
+                     
+                  </h1>
+                </Title>
+              </PageHeaderTitle>
+            </div>
+          </FlexItem>
+          <FlexItem>
+            <div
+              className=""
+            />
+          </FlexItem>
+        </div>
+      </Flex>
     </section>
   </PageHeader>
 </PageHeader>
@@ -47,6 +71,7 @@ exports[`PageHeader Component should render a basic component: basic 1`] = `
 
 exports[`PageHeader Component should render string node types: string 1`] = `
 <PageHeader
+  includeTour={false}
   productLabel={null}
   t={[Function]}
 >
@@ -55,26 +80,49 @@ exports[`PageHeader Component should render string node types: string 1`] = `
       className="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
       widget-type="InsightsPageHeader"
     >
-      <PageHeaderTitle
-        className="pf-u-mb-sm"
-        title="dolor sit"
+      <Flex
+        justifyContent={
+          Object {
+            "sm": "justifyContentSpaceBetween",
+          }
+        }
       >
-        <Title
-          className="pf-u-mb-sm"
-          headingLevel="h1"
-          size="2xl"
-          widget-type="InsightsPageHeaderTitle"
+        <div
+          className="pf-l-flex pf-m-justify-content-space-between-on-sm"
         >
-          <h1
-            className="pf-c-title pf-m-2xl pf-u-mb-sm"
-            widget-type="InsightsPageHeaderTitle"
-          >
-             
-            dolor sit
-             
-          </h1>
-        </Title>
-      </PageHeaderTitle>
+          <FlexItem>
+            <div
+              className=""
+            >
+              <PageHeaderTitle
+                className="pf-u-mb-sm"
+                title="dolor sit"
+              >
+                <Title
+                  className="pf-u-mb-sm"
+                  headingLevel="h1"
+                  size="2xl"
+                  widget-type="InsightsPageHeaderTitle"
+                >
+                  <h1
+                    className="pf-c-title pf-m-2xl pf-u-mb-sm"
+                    widget-type="InsightsPageHeaderTitle"
+                  >
+                     
+                    dolor sit
+                     
+                  </h1>
+                </Title>
+              </PageHeaderTitle>
+            </div>
+          </FlexItem>
+          <FlexItem>
+            <div
+              className=""
+            />
+          </FlexItem>
+        </div>
+      </Flex>
     </section>
   </PageHeader>
 </PageHeader>
@@ -82,6 +130,7 @@ exports[`PageHeader Component should render string node types: string 1`] = `
 
 exports[`PageHeader Component should render the subtitle when viewId is provided: with subtitle 1`] = `
 <PageHeader
+  includeTour={false}
   productLabel="RHEL"
   t={[Function]}
 >
@@ -90,29 +139,143 @@ exports[`PageHeader Component should render the subtitle when viewId is provided
       className="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
       widget-type="InsightsPageHeader"
     >
-      <PageHeaderTitle
-        className="pf-u-mb-sm"
-        title="lorem"
+      <Flex
+        justifyContent={
+          Object {
+            "sm": "justifyContentSpaceBetween",
+          }
+        }
       >
-        <Title
-          className="pf-u-mb-sm"
-          headingLevel="h1"
-          size="2xl"
-          widget-type="InsightsPageHeaderTitle"
+        <div
+          className="pf-l-flex pf-m-justify-content-space-between-on-sm"
         >
-          <h1
-            className="pf-c-title pf-m-2xl pf-u-mb-sm"
-            widget-type="InsightsPageHeaderTitle"
-          >
-             
-            lorem
-             
-          </h1>
-        </Title>
-      </PageHeaderTitle>
+          <FlexItem>
+            <div
+              className=""
+            >
+              <PageHeaderTitle
+                className="pf-u-mb-sm"
+                title="lorem"
+              >
+                <Title
+                  className="pf-u-mb-sm"
+                  headingLevel="h1"
+                  size="2xl"
+                  widget-type="InsightsPageHeaderTitle"
+                >
+                  <h1
+                    className="pf-c-title pf-m-2xl pf-u-mb-sm"
+                    widget-type="InsightsPageHeaderTitle"
+                  >
+                     
+                    lorem
+                     
+                  </h1>
+                </Title>
+              </PageHeaderTitle>
+            </div>
+          </FlexItem>
+          <FlexItem>
+            <div
+              className=""
+            />
+          </FlexItem>
+        </div>
+      </Flex>
       <p>
         t(curiosity-view.subtitle, {"appName":"Subscription Watch","context":"RHEL"}, [object Object])
       </p>
+    </section>
+  </PageHeader>
+</PageHeader>
+`;
+
+exports[`PageHeader Component should render the tour button when includeTour is provided: with tour button 1`] = `
+<PageHeader
+  includeTour={true}
+  productLabel={null}
+  t={[Function]}
+>
+  <PageHeader>
+    <section
+      className="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
+      widget-type="InsightsPageHeader"
+    >
+      <Flex
+        justifyContent={
+          Object {
+            "sm": "justifyContentSpaceBetween",
+          }
+        }
+      >
+        <div
+          className="pf-l-flex pf-m-justify-content-space-between-on-sm"
+        >
+          <FlexItem>
+            <div
+              className=""
+            >
+              <PageHeaderTitle
+                className="pf-u-mb-sm"
+                title="lorem"
+              >
+                <Title
+                  className="pf-u-mb-sm"
+                  headingLevel="h1"
+                  size="2xl"
+                  widget-type="InsightsPageHeaderTitle"
+                >
+                  <h1
+                    className="pf-c-title pf-m-2xl pf-u-mb-sm"
+                    widget-type="InsightsPageHeaderTitle"
+                  >
+                     
+                    lorem
+                     
+                  </h1>
+                </Title>
+              </PageHeaderTitle>
+            </div>
+          </FlexItem>
+          <FlexItem>
+            <div
+              className=""
+            >
+              <Button
+                className="uxui-curiosity__button-tour"
+                isInline={true}
+                variant="link"
+              >
+                <button
+                  aria-disabled={false}
+                  aria-label={null}
+                  className="pf-c-button pf-m-link pf-m-inline uxui-curiosity__button-tour"
+                  data-ouia-component-id="OUIA-Generated-Button-link-1"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe={true}
+                  disabled={false}
+                  role={null}
+                  type="button"
+                >
+                  <Label
+                    color="blue"
+                  >
+                    <span
+                      className="pf-c-label pf-m-blue"
+                    >
+                      <span
+                        className="pf-c-label__content"
+                      >
+                        t(curiosity-optin.buttonTour)
+                      </span>
+                    </span>
+                  </Label>
+                </button>
+              </Button>
+            </div>
+          </FlexItem>
+        </div>
+      </Flex>
     </section>
   </PageHeader>
 </PageHeader>

--- a/src/components/pageLayout/__tests__/__snapshots__/pageLayout.test.js.snap
+++ b/src/components/pageLayout/__tests__/__snapshots__/pageLayout.test.js.snap
@@ -27,6 +27,7 @@ exports[`PageLayout Component should render a basic component: basic 1`] = `
 exports[`PageLayout Component should render header and section children: multiple children 1`] = `
 <PageLayout>
   <PageHeader
+    includeTour={false}
     key=".1"
     productLabel={null}
     t={[Function]}
@@ -36,26 +37,49 @@ exports[`PageLayout Component should render header and section children: multipl
         className="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
         widget-type="InsightsPageHeader"
       >
-        <PageHeaderTitle
-          className="pf-u-mb-sm"
-          title="lorem"
+        <Flex
+          justifyContent={
+            Object {
+              "sm": "justifyContentSpaceBetween",
+            }
+          }
         >
-          <Title
-            className="pf-u-mb-sm"
-            headingLevel="h1"
-            size="2xl"
-            widget-type="InsightsPageHeaderTitle"
+          <div
+            className="pf-l-flex pf-m-justify-content-space-between-on-sm"
           >
-            <h1
-              className="pf-c-title pf-m-2xl pf-u-mb-sm"
-              widget-type="InsightsPageHeaderTitle"
-            >
-               
-              lorem
-               
-            </h1>
-          </Title>
-        </PageHeaderTitle>
+            <FlexItem>
+              <div
+                className=""
+              >
+                <PageHeaderTitle
+                  className="pf-u-mb-sm"
+                  title="lorem"
+                >
+                  <Title
+                    className="pf-u-mb-sm"
+                    headingLevel="h1"
+                    size="2xl"
+                    widget-type="InsightsPageHeaderTitle"
+                  >
+                    <h1
+                      className="pf-c-title pf-m-2xl pf-u-mb-sm"
+                      widget-type="InsightsPageHeaderTitle"
+                    >
+                       
+                      lorem
+                       
+                    </h1>
+                  </Title>
+                </PageHeaderTitle>
+              </div>
+            </FlexItem>
+            <FlexItem>
+              <div
+                className=""
+              />
+            </FlexItem>
+          </div>
+        </Flex>
       </section>
     </PageHeader>
   </PageHeader>

--- a/src/components/pageLayout/__tests__/pageHeader.test.js
+++ b/src/components/pageLayout/__tests__/pageHeader.test.js
@@ -22,4 +22,9 @@ describe('PageHeader Component', () => {
     const component = mount(<PageHeader productLabel="RHEL">lorem</PageHeader>);
     expect(component).toMatchSnapshot('with subtitle');
   });
+
+  it('should render the tour button when includeTour is provided', () => {
+    const component = mount(<PageHeader includeTour>lorem</PageHeader>);
+    expect(component).toMatchSnapshot('with tour button');
+  });
 });

--- a/src/components/pageLayout/pageHeader.js
+++ b/src/components/pageLayout/pageHeader.js
@@ -4,7 +4,7 @@ import {
   PageHeader as RcsPageHeader,
   PageHeaderTitle
 } from '@redhat-cloud-services/frontend-components/components/cjs/PageHeader';
-import { Button } from '@patternfly/react-core';
+import { Button, Flex, FlexItem, Label as PfLabel } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { helpers } from '../../common';
 import { translate } from '../i18n/i18n';
@@ -14,13 +14,25 @@ import { translate } from '../i18n/i18n';
  *
  * @param {object} props
  * @param {Node} props.children
+ * @param {boolean} props.includeTour
  * @param {string} props.productLabel
  * @param {Function} props.t
  * @returns {Node}
  */
-const PageHeader = ({ children, t, productLabel }) => (
+const PageHeader = ({ children, includeTour, productLabel, t }) => (
   <RcsPageHeader>
-    <PageHeaderTitle title={children} className="pf-u-mb-sm" />
+    <Flex justifyContent={{ sm: 'justifyContentSpaceBetween' }}>
+      <FlexItem>
+        <PageHeaderTitle title={children} className="pf-u-mb-sm" />
+      </FlexItem>
+      <FlexItem>
+        {includeTour && (
+          <Button variant="link" className="uxui-curiosity__button-tour" isInline>
+            <PfLabel color="blue">{t('curiosity-optin.buttonTour')}</PfLabel>
+          </Button>
+        )}
+      </FlexItem>
+    </Flex>
     {productLabel && (
       <p>
         {t(`curiosity-view.subtitle`, { appName: helpers.UI_DISPLAY_NAME, context: productLabel }, [
@@ -42,10 +54,11 @@ const PageHeader = ({ children, t, productLabel }) => (
 /**
  * Prop types.
  *
- * @type {{productLabel: string, t: Function, children: Node}}
+ * @type {{children: Node, includeTour: boolean, productLabel: string, t: Function}}
  */
 PageHeader.propTypes = {
   children: PropTypes.node.isRequired,
+  includeTour: PropTypes.bool,
   productLabel: PropTypes.string,
   t: PropTypes.func
 };
@@ -53,9 +66,10 @@ PageHeader.propTypes = {
 /**
  * Default props.
  *
- * @type {{productLabel: null, t: translate}}
+ * @type {{includeTour: boolean, productLabel: null, t: translate}}
  */
 PageHeader.defaultProps = {
+  includeTour: false,
   productLabel: null,
   t: translate
 };

--- a/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
+++ b/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
@@ -3,6 +3,7 @@
 exports[`RhelView Component should display an alternate graph on query-string update: alternate graph 1`] = `
 <PageLayout>
   <PageHeader
+    includeTour={true}
     productLabel="RHEL"
     t={[Function]}
   >
@@ -151,6 +152,7 @@ exports[`RhelView Component should display an alternate graph on query-string up
 exports[`RhelView Component should have a fallback title: title 1`] = `
 <PageLayout>
   <PageHeader
+    includeTour={true}
     productLabel="RHEL"
     t={[Function]}
   >
@@ -690,6 +692,7 @@ Object {
 exports[`RhelView Component should render a non-connected component: non-connected 1`] = `
 <PageLayout>
   <PageHeader
+    includeTour={true}
     productLabel="RHEL"
     t={[Function]}
   >

--- a/src/components/rhelView/rhelView.js
+++ b/src/components/rhelView/rhelView.js
@@ -61,7 +61,7 @@ class RhelView extends React.Component {
 
     return (
       <PageLayout>
-        <PageHeader productLabel={productLabel}>
+        <PageHeader productLabel={productLabel} includeTour>
           {t(`curiosity-view.title`, { appName: helpers.UI_DISPLAY_NAME, context: productLabel })}
         </PageHeader>
         <PageMessages>

--- a/tests/__snapshots__/dist.test.js.snap
+++ b/tests/__snapshots__/dist.test.js.snap
@@ -29,8 +29,6 @@ Array [
   "./build/static/js/6*chunk.js",
   "./build/static/js/7*chunk*map",
   "./build/static/js/7*chunk.js",
-  "./build/static/js/8*chunk*map",
-  "./build/static/js/8*chunk.js",
   "./build/static/js/main*chunk*map",
   "./build/static/js/main*chunk.js",
   "./build/static/js/runtime-main*js",


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- feat(rhelView, openshiftView): issues/490 add "Take a tour" button

### Notes
A hover effect was not possible on this type of button through Patternfly.  The text of the button has an extra "a" in it from what was shown in the mockup because I reused the text from the previously existing tour button.  Both of these details were approved by UX.
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. visit /beta/subscriptions/rhel-sw/all and /beta/subscriptions/openshift-sw
1. confirm presence of tour button on both pages

<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![take_tour](https://user-images.githubusercontent.com/2515650/99317128-82553f00-2833-11eb-886c-03fda0a71296.png)


## Updates issue/story
Updates #490 
