### PR TITLE
feat(inventoryList): issues/493 product disable guests setting

### DIFF
--- a/src/components/inventoryList/__tests__/__snapshots__/inventoryList.test.js.snap
+++ b/src/components/inventoryList/__tests__/__snapshots__/inventoryList.test.js.snap
@@ -74,6 +74,39 @@ exports[`InventoryList Component should handle expandable guests data: number of
 />
 `;
 
+exports[`InventoryList Component should handle expandable guests data: number of guests, id, and NO expandable guests display 1`] = `
+<Table
+  ariaLabel={null}
+  borders={true}
+  className="curiosity-inventory-list"
+  columnHeaders={
+    Array [
+      "t(curiosity-inventory.header, {\\"context\\":\\"lorem\\"})",
+      "t(curiosity-inventory.header, {\\"context\\":\\"dolor\\"})",
+      "t(curiosity-inventory.header, {\\"context\\":\\"numberOfGuests\\"})",
+      "t(curiosity-inventory.header, {\\"context\\":\\"subscriptionManagerId\\"})",
+    ]
+  }
+  isHeader={true}
+  rows={
+    Array [
+      Object {
+        "cells": Array [
+          "sit",
+          "amet",
+          2,
+          "loremipsum",
+        ],
+        "expandedContent": undefined,
+      },
+    ]
+  }
+  summary={null}
+  t={[Function]}
+  variant="compact"
+/>
+`;
+
 exports[`InventoryList Component should handle updating sorting through redux state: dispatch filter 1`] = `
 Array [
   Array [
@@ -183,7 +216,7 @@ exports[`InventoryList Component should handle variations in data: filtered data
                     "title": "ipsum",
                   },
                 ],
-                "expandedContent": false,
+                "expandedContent": undefined,
               },
               Object {
                 "cells": Array [
@@ -191,7 +224,7 @@ exports[`InventoryList Component should handle variations in data: filtered data
                     "title": "sit",
                   },
                 ],
-                "expandedContent": false,
+                "expandedContent": undefined,
               },
             ]
           }
@@ -287,14 +320,14 @@ exports[`InventoryList Component should handle variations in data: variable data
                   "ipsum",
                   "sit",
                 ],
-                "expandedContent": false,
+                "expandedContent": undefined,
               },
               Object {
                 "cells": Array [
                   "sit",
                   "amet",
                 ],
-                "expandedContent": false,
+                "expandedContent": undefined,
               },
             ]
           }

--- a/src/components/inventoryList/__tests__/inventoryList.test.js
+++ b/src/components/inventoryList/__tests__/inventoryList.test.js
@@ -90,6 +90,19 @@ describe('InventoryList Component', () => {
     });
 
     expect(component.find(Table)).toMatchSnapshot('number of guests, and id');
+
+    component.setProps({
+      ...props,
+      listData: [{ lorem: 'sit', dolor: 'amet', numberOfGuests: 2, subscriptionManagerId: 'loremipsum' }],
+      settings: {
+        hasGuests: data => {
+          const { numberOfGuests = 0, subscriptionManagerId = null } = data;
+          return numberOfGuests > 2 && subscriptionManagerId;
+        }
+      }
+    });
+
+    expect(component.find(Table)).toMatchSnapshot('number of guests, id, and NO expandable guests display');
   });
 
   it('should handle updating sorting through redux state', () => {

--- a/src/components/inventoryList/inventoryList.js
+++ b/src/components/inventoryList/inventoryList.js
@@ -99,7 +99,7 @@ class InventoryList extends React.Component {
    * @returns {Node}
    */
   renderTable() {
-    const { filterGuestsData, filterInventoryData, listData, query, session } = this.props;
+    const { filterGuestsData, filterInventoryData, listData, query, session, settings } = this.props;
     let updatedColumnHeaders = [];
 
     const updatedRows = listData.map(({ ...cellData }) => {
@@ -113,21 +113,29 @@ class InventoryList extends React.Component {
         session
       });
 
-      const hasGuests = cellData?.numberOfGuests > 0;
-      const guestsId = cellData?.subscriptionManagerId;
       updatedColumnHeaders = columnHeaders;
+
+      const guestsId = cellData?.subscriptionManagerId;
+      let hasGuests = cellData?.numberOfGuests > 0 && guestsId;
+
+      // Apply hasGuests callback, return boolean
+      if (typeof settings.hasGuests === 'function') {
+        hasGuests = settings.hasGuests({ ...cellData }, { ...session });
+      }
 
       return {
         cells,
-        expandedContent: hasGuests && guestsId && (
-          <GuestsList
-            key={guestsId}
-            filterGuestsData={filterGuestsData}
-            numberOfGuests={cellData?.numberOfGuests}
-            id={guestsId}
-            query={query}
-          />
-        )
+        expandedContent:
+          (hasGuests && (
+            <GuestsList
+              key={guestsId}
+              filterGuestsData={filterGuestsData}
+              numberOfGuests={cellData?.numberOfGuests}
+              id={guestsId}
+              query={query}
+            />
+          )) ||
+          undefined
       };
     });
 
@@ -240,7 +248,7 @@ class InventoryList extends React.Component {
 /**
  * Prop types.
  *
- * @type {{productId: string, listData: Array, session: object, pending: boolean, query: object,
+ * @type {{settings: object, productId: string, listData: Array, session: object, pending: boolean, query: object,
  *     fulfilled: boolean, getHostsInventory: Function, error: boolean, cardTitle: string, itemCount: number,
  *     viewId: string, filterInventoryData: Array, filterGuestsData: Array, perPageDefault: number,
  *     isDisabled: boolean}}
@@ -278,15 +286,18 @@ InventoryList.propTypes = {
   perPageDefault: PropTypes.number,
   query: PropTypes.object.isRequired,
   session: PropTypes.object,
+  settings: PropTypes.shape({
+    hasGuests: PropTypes.func
+  }),
   viewId: PropTypes.string
 };
 
 /**
  * Default props.
  *
- * @type {{listData: Array, session: object, pending: boolean, fulfilled: boolean, getHostsInventory: Function,
- *     error: boolean, cardTitle: null, itemCount: number, viewId: string, filterInventoryData: Array,
- *     filterGuestsData: Array, perPageDefault: number, isDisabled: boolean}}
+ * @type {{settings: object, listData: Array, session: object, pending: boolean, fulfilled: boolean,
+ *     getHostsInventory: Function, error: boolean, cardTitle: null, itemCount: number, viewId: string,
+ *     filterInventoryData: Array, filterGuestsData: Array, perPageDefault: number, isDisabled: boolean}}
  */
 InventoryList.defaultProps = {
   cardTitle: null,
@@ -301,6 +312,7 @@ InventoryList.defaultProps = {
   pending: false,
   perPageDefault: 10,
   session: {},
+  settings: {},
   viewId: 'inventoryList'
 };
 

--- a/src/components/inventoryList/inventoryList.js
+++ b/src/components/inventoryList/inventoryList.js
@@ -119,7 +119,7 @@ class InventoryList extends React.Component {
       let hasGuests = cellData?.numberOfGuests > 0 && guestsId;
 
       // Apply hasGuests callback, return boolean
-      if (typeof settings.hasGuests === 'function') {
+      if (typeof settings?.hasGuests === 'function') {
         hasGuests = settings.hasGuests({ ...cellData }, { ...session });
       }
 

--- a/src/components/openshiftView/__tests__/__snapshots__/openshiftView.test.js.snap
+++ b/src/components/openshiftView/__tests__/__snapshots__/openshiftView.test.js.snap
@@ -158,6 +158,7 @@ exports[`OpenshiftView Component should display an alternate graph on query-stri
           "uom": "cores",
         }
       }
+      settings={Object {}}
       viewId="viewOpenShift"
     />
   </PageSection>
@@ -322,6 +323,7 @@ exports[`OpenshiftView Component should have a fallback title: title 1`] = `
           "uom": "cores",
         }
       }
+      settings={Object {}}
       viewId="viewOpenShift"
     />
   </PageSection>
@@ -905,6 +907,7 @@ exports[`OpenshiftView Component should render a non-connected component: non-co
           "uom": "cores",
         }
       }
+      settings={Object {}}
       viewId="viewOpenShift"
     />
   </PageSection>

--- a/src/components/openshiftView/openshiftView.js
+++ b/src/components/openshiftView/openshiftView.js
@@ -118,6 +118,7 @@ class OpenshiftView extends React.Component {
     const {
       initialGuestsFilters,
       initialToolbarFilters,
+      initialInventorySettings,
       location,
       productLabel,
       query,
@@ -180,6 +181,7 @@ class OpenshiftView extends React.Component {
             key={routeDetail.pathParameter}
             filterGuestsData={initialGuestsFilters}
             filterInventoryData={inventoryFilters}
+            settings={initialInventorySettings}
             query={initialInventoryQuery}
             productId={routeDetail.pathParameter}
             viewId={viewId}
@@ -196,7 +198,7 @@ class OpenshiftView extends React.Component {
  *
  * @type {{productLabel: string, initialOption: string, initialToolbarFilters: Array, viewId: string,
  *     t: Function, query: object, initialGraphFilters: Array, routeDetail: object, location: object,
- *     initialGuestsFilters: Array, initialInventoryFilters: Array}}
+ *     initialGuestsFilters: Array, initialInventorySettings: object, initialInventoryFilters: Array}}
  */
 OpenshiftView.propTypes = {
   query: PropTypes.shape({
@@ -206,6 +208,9 @@ OpenshiftView.propTypes = {
   initialGraphFilters: PropTypes.array,
   initialGuestsFilters: PropTypes.array,
   initialInventoryFilters: PropTypes.array,
+  initialInventorySettings: PropTypes.shape({
+    hasGuests: PropTypes.func
+  }),
   initialToolbarFilters: PropTypes.array,
   location: PropTypes.shape({
     parsedSearch: PropTypes.objectOf(PropTypes.string)
@@ -227,7 +232,7 @@ OpenshiftView.propTypes = {
  *
  * @type {{productLabel: string, initialOption: string, initialToolbarFilters: Array, viewId: string,
  *     t: translate, query: object, initialGraphFilters: Array, initialGuestsFilters: Array,
- *     initialInventoryFilters: Array}}
+ *     initialInventorySettings: object, initialInventoryFilters: Array}}
  */
 OpenshiftView.defaultProps = {
   query: {
@@ -377,6 +382,7 @@ OpenshiftView.defaultProps = {
       cellWidth: 15
     }
   ],
+  initialInventorySettings: {},
   initialToolbarFilters: [
     {
       id: RHSM_API_QUERY_TYPES.SLA

--- a/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
+++ b/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
@@ -143,6 +143,7 @@ exports[`RhelView Component should display an alternate graph on query-string up
           "sort": "last_seen",
         }
       }
+      settings={Object {}}
       viewId="viewRHEL"
     />
   </PageSection>
@@ -292,6 +293,7 @@ exports[`RhelView Component should have a fallback title: title 1`] = `
           "sort": "last_seen",
         }
       }
+      settings={Object {}}
       viewId="viewRHEL"
     />
   </PageSection>
@@ -832,6 +834,7 @@ exports[`RhelView Component should render a non-connected component: non-connect
           "sort": "last_seen",
         }
       }
+      settings={Object {}}
       viewId="viewRHEL"
     />
   </PageSection>

--- a/src/components/rhelView/rhelView.js
+++ b/src/components/rhelView/rhelView.js
@@ -44,6 +44,7 @@ class RhelView extends React.Component {
       initialGraphFilters,
       initialGuestsFilters,
       initialInventoryFilters,
+      initialInventorySettings,
       initialToolbarFilters,
       location,
       productLabel,
@@ -103,6 +104,7 @@ class RhelView extends React.Component {
             key={routeDetail.pathParameter}
             filterGuestsData={initialGuestsFilters}
             filterInventoryData={initialInventoryFilters}
+            settings={initialInventorySettings}
             query={initialInventoryQuery}
             productId={routeDetail.pathParameter}
             viewId={viewId}
@@ -119,7 +121,7 @@ class RhelView extends React.Component {
  *
  * @type {{productLabel: string, initialToolbarFilters: Array, viewId: string, t: Function, query: object,
  *     initialGraphFilters: Array, routeDetail: object, location: object, initialGuestsFilters: Array,
- *     initialInventoryFilters: Array}}
+ *     initialInventorySettings: object, initialInventoryFilters: Array}}
  */
 RhelView.propTypes = {
   query: PropTypes.shape({
@@ -128,6 +130,9 @@ RhelView.propTypes = {
   initialGraphFilters: PropTypes.array,
   initialGuestsFilters: PropTypes.array,
   initialInventoryFilters: PropTypes.array,
+  initialInventorySettings: PropTypes.shape({
+    hasGuests: PropTypes.func
+  }),
   initialToolbarFilters: PropTypes.array,
   location: PropTypes.shape({
     parsedSearch: PropTypes.objectOf(PropTypes.string)
@@ -148,7 +153,8 @@ RhelView.propTypes = {
  * Default props.
  *
  * @type {{productLabel: string, initialToolbarFilters: Array, viewId: string, t: translate, query: object,
- *     initialGraphFilters: Array, initialGuestsFilters: Array, initialInventoryFilters: Array}}
+ *     initialGraphFilters: Array, initialGuestsFilters: Array, initialInventorySettings: object,
+ *     initialInventoryFilters: Array}}
  */
 RhelView.defaultProps = {
   query: {
@@ -291,6 +297,7 @@ RhelView.defaultProps = {
       cellWidth: 15
     }
   ],
+  initialInventorySettings: {},
   initialToolbarFilters: [
     {
       id: RHSM_API_QUERY_TYPES.SLA


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- feat(inventoryList): issues/493 product disable guests setting
   * inventoryList, hasGuests callback setting
   * openshiftView, rhelView, apply basic inventoryList settings

### Notes
- behind the scenes update, no visual changes
- applies a settings callback that replaces the `hasGuests` check in `inventoryList.js`
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm that guests/VMs **are still expandable** when "guests/VMs are greater than zero" for a listing. there should be no errors present
1. if you wish to confirm the logic works, on one of the product views you can update the `initialInventorySettings` object with the following snippet, where the "greater than one" represents how many guests it takes to disable the expandable section. After updating a view, hit refresh and you should no longer see an expandable section on the targeted row entries.
   ```
      ...
      initialInventorySettings: {
         hasGuests: data => {
            console.log(data);
            const { numberOfGuests = 0, subscriptionManagerId = null } = data;
            return numberOfGuests > 1 && subscriptionManagerId;
         }
     },
      ...
   ```

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
#493 