### PR TITLE
fix(bannerMessages): issues/511 apply query filter 

### DIFF
--- a/public/locales/en-US.json
+++ b/public/locales/en-US.json
@@ -4,8 +4,8 @@
     "maintenanceCopy": "We are currently undergoing scheduled maintenance and will be back shortly. Thank you for your patience."
   },
   "curiosity-banner": {
-    "dataMismatchTitle": "Improve reporting accuracy",
-    "dataMismatchMessage": "Action required in order to improve {{appName}} reporting.",
+    "dataMismatchTitle": "Cloud provider mismatch",
+    "dataMismatchMessage": "There may be inconsistencies between data in the graph and your inventory display. The issue is currently being resolved.",
     "dataMismatchMessage_cloudigradeMismatch": "<0>View recommmend actions</0> to take in order to improve {{appName}} reporting."
   },
   "curiosity-graph": {

--- a/src/components/bannerMessages/bannerMessages.js
+++ b/src/components/bannerMessages/bannerMessages.js
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Alert, AlertActionCloseButton, AlertVariant, Button } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import { connect, reduxActions, reduxSelectors } from '../../redux';
+import _isEqual from 'lodash/isEqual';
+import { apiQueries, connect, reduxActions, reduxSelectors } from '../../redux';
 import { translate } from '../i18n/i18n';
 import { dateHelpers, helpers } from '../../common';
 import { RHSM_API_QUERY_GRANULARITY_TYPES as GRANULARITY_TYPES, RHSM_API_QUERY_TYPES } from '../../types/rhsmApiTypes';
@@ -20,9 +21,9 @@ class BannerMessages extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { productId } = this.props;
+    const { query, productId } = this.props;
 
-    if (productId !== prevProps.productId) {
+    if (productId !== prevProps.productId || !_isEqual(query, prevProps.query)) {
       this.onUpdateData();
     }
   }
@@ -33,17 +34,19 @@ class BannerMessages extends React.Component {
    * @event onUpdateGraphData
    */
   onUpdateData = () => {
-    const { getMessageReports, productId } = this.props;
+    const { getMessageReports, productId, query } = this.props;
+    const { graphQuery } = apiQueries.parseRhsmQuery(query);
 
     if (productId) {
       const { startDate, endDate } = dateHelpers.getRangedDateTime('CURRENT');
-      const query = {
+      const updatedGraphQuery = {
+        ...graphQuery,
         [RHSM_API_QUERY_TYPES.GRANULARITY]: GRANULARITY_TYPES.DAILY,
         [RHSM_API_QUERY_TYPES.START_DATE]: startDate.toISOString(),
         [RHSM_API_QUERY_TYPES.END_DATE]: endDate.toISOString()
       };
 
-      getMessageReports(productId, query, { cancel: false });
+      getMessageReports(productId, updatedGraphQuery);
     }
   };
 
@@ -102,11 +105,12 @@ class BannerMessages extends React.Component {
 /**
  * Prop types.
  *
- * @type {{appMessages: object, productId: string, messages: Array, getMessageReports: Function}}
+ * @type {{appMessages: object, productId: string, getMessageReports: Function, query: object, messages: Array}}
  */
 BannerMessages.propTypes = {
   appMessages: PropTypes.object.isRequired,
   getMessageReports: PropTypes.func,
+  query: PropTypes.object,
   messages: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,
@@ -121,10 +125,11 @@ BannerMessages.propTypes = {
 /**
  * Default props.
  *
- * @type {{messages: Array, getMessageReports: Function}}
+ * @type {{getMessageReports: Function, query: object, messages: Array}}
  */
 BannerMessages.defaultProps = {
   getMessageReports: helpers.noop,
+  query: {},
   messages: [
     {
       id: 'cloudigradeMismatch',

--- a/src/components/openshiftView/__tests__/__snapshots__/openshiftView.test.js.snap
+++ b/src/components/openshiftView/__tests__/__snapshots__/openshiftView.test.js.snap
@@ -13,6 +13,16 @@ exports[`OpenshiftView Component should display an alternate graph on query-stri
   >
     <Connect(BannerMessages)
       productId="lorem ipsum"
+      query={
+        Object {
+          "dir": "desc",
+          "granularity": "daily",
+          "limit": 100,
+          "offset": 0,
+          "sort": "last_seen",
+          "uom": "cores",
+        }
+      }
       viewId="viewOpenShift"
     />
   </PageMessages>
@@ -176,6 +186,16 @@ exports[`OpenshiftView Component should have a fallback title: title 1`] = `
   >
     <Connect(BannerMessages)
       productId="lorem ipsum"
+      query={
+        Object {
+          "dir": "desc",
+          "granularity": "daily",
+          "limit": 100,
+          "offset": 0,
+          "sort": "last_seen",
+          "uom": "cores",
+        }
+      }
       viewId="viewOpenShift"
     />
   </PageMessages>
@@ -758,6 +778,16 @@ exports[`OpenshiftView Component should render a non-connected component: non-co
   >
     <Connect(BannerMessages)
       productId="lorem ipsum"
+      query={
+        Object {
+          "dir": "desc",
+          "granularity": "daily",
+          "limit": 100,
+          "offset": 0,
+          "sort": "last_seen",
+          "uom": "cores",
+        }
+      }
       viewId="viewOpenShift"
     />
   </PageMessages>

--- a/src/components/openshiftView/openshiftView.js
+++ b/src/components/openshiftView/openshiftView.js
@@ -138,7 +138,7 @@ class OpenshiftView extends React.Component {
           {t(`curiosity-view.title`, { appName: helpers.UI_DISPLAY_NAME, context: productLabel })}
         </PageHeader>
         <PageMessages>
-          <BannerMessages productId={routeDetail.pathParameter} viewId={viewId} />
+          <BannerMessages productId={routeDetail.pathParameter} viewId={viewId} query={query} />
         </PageMessages>
         <PageToolbar>
           <Toolbar

--- a/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
+++ b/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
@@ -13,6 +13,15 @@ exports[`RhelView Component should display an alternate graph on query-string up
   >
     <Connect(BannerMessages)
       productId="lorem ipsum"
+      query={
+        Object {
+          "dir": "desc",
+          "granularity": "daily",
+          "limit": 100,
+          "offset": 0,
+          "sort": "last_seen",
+        }
+      }
       viewId="viewRHEL"
     />
   </PageMessages>
@@ -161,6 +170,15 @@ exports[`RhelView Component should have a fallback title: title 1`] = `
   >
     <Connect(BannerMessages)
       productId="lorem ipsum"
+      query={
+        Object {
+          "dir": "desc",
+          "granularity": "daily",
+          "limit": 100,
+          "offset": 0,
+          "sort": "last_seen",
+        }
+      }
       viewId="viewRHEL"
     />
   </PageMessages>
@@ -700,6 +718,15 @@ exports[`RhelView Component should render a non-connected component: non-connect
   >
     <Connect(BannerMessages)
       productId="lorem ipsum"
+      query={
+        Object {
+          "dir": "desc",
+          "granularity": "daily",
+          "limit": 100,
+          "offset": 0,
+          "sort": "last_seen",
+        }
+      }
       viewId="viewRHEL"
     />
   </PageMessages>

--- a/src/components/rhelView/rhelView.js
+++ b/src/components/rhelView/rhelView.js
@@ -65,7 +65,7 @@ class RhelView extends React.Component {
           {t(`curiosity-view.title`, { appName: helpers.UI_DISPLAY_NAME, context: productLabel })}
         </PageHeader>
         <PageMessages>
-          <BannerMessages productId={routeDetail.pathParameter} viewId={viewId} />
+          <BannerMessages productId={routeDetail.pathParameter} viewId={viewId} query={query} />
         </PageMessages>
         <PageToolbar>
           <Toolbar

--- a/src/redux/selectors/__tests__/__snapshots__/appMessagesSelectors.test.js.snap
+++ b/src/redux/selectors/__tests__/__snapshots__/appMessagesSelectors.test.js.snap
@@ -4,6 +4,7 @@ exports[`AppMessagesSelectors should map a fulfilled product ID response to an a
 Object {
   "appMessages": Object {
     "cloudigradeMismatch": true,
+    "query": Object {},
   },
 }
 `;
@@ -12,6 +13,7 @@ exports[`AppMessagesSelectors should pass minimal data on a product ID without a
 Object {
   "appMessages": Object {
     "cloudigradeMismatch": false,
+    "query": Object {},
   },
 }
 `;
@@ -20,6 +22,7 @@ exports[`AppMessagesSelectors should pass minimal data on missing a reducer resp
 Object {
   "appMessages": Object {
     "cloudigradeMismatch": false,
+    "query": Object {},
   },
 }
 `;
@@ -28,6 +31,7 @@ exports[`AppMessagesSelectors should populate data from the in memory cache: cac
 Object {
   "appMessages": Object {
     "cloudigradeMismatch": true,
+    "query": Object {},
   },
 }
 `;
@@ -36,6 +40,7 @@ exports[`AppMessagesSelectors should populate data from the in memory cache: cac
 Object {
   "appMessages": Object {
     "cloudigradeMismatch": true,
+    "query": Object {},
   },
 }
 `;
@@ -44,6 +49,7 @@ exports[`AppMessagesSelectors should populate data from the in memory cache: cac
 Object {
   "appMessages": Object {
     "cloudigradeMismatch": true,
+    "query": Object {},
   },
 }
 `;
@@ -52,6 +58,7 @@ exports[`AppMessagesSelectors should populate data on a product ID when the api 
 Object {
   "appMessages": Object {
     "cloudigradeMismatch": false,
+    "query": Object {},
   },
 }
 `;

--- a/src/redux/selectors/appMessagesSelectors.js
+++ b/src/redux/selectors/appMessagesSelectors.js
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect';
 import { rhsmApiTypes } from '../../types';
+
 /**
  * Selector cache.
  *
@@ -23,14 +24,28 @@ const statePropsFilter = (state, props = {}) => ({
 });
 
 /**
+ * Return a combined query object.
+ *
+ * @param {object} state
+ * @param {object} props
+ * @returns {object}
+ */
+const queryFilter = (state, props = {}) => ({
+  ...props.query,
+  ...state.view?.query?.[props.productId],
+  ...state.view?.query?.[props.viewId]
+});
+
+/**
  * Create selector, transform combined state, props into a consumable object.
  *
  * @type {{appMessages: {cloudigradeMismatch: boolean}}}
  */
-const selector = createSelector([statePropsFilter], data => {
+const selector = createSelector([statePropsFilter, queryFilter], (data, query = {}) => {
   const { viewId = null, productId = null, report = {} } = data || {};
   const appMessages = {
-    cloudigradeMismatch: false
+    cloudigradeMismatch: false,
+    query
   };
 
   const cache = (viewId && productId && selectorCache.data[`${viewId}_${productId}`]) || undefined;


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(bannerMessages): issues/511 copy update
- fix(bannerMessages): issues/511 apply query filter 
   * bannerMessages, query updates for banner display
   * openshiftView, rhelView, pass query to banner
   * appMessageSelectors, query pass-through

### Notes
- Applies the query filter to the banner. This in turn adds an additional API call that fires on filter update.
   - The initial request was around the SLA filter... this should apply all graph related filters inclusive of UOM, and the exception of NO user applied granularity is set towards the banner message.
- Minor copy adjustment per UX
- @ntkathole 
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. log in with the appropriate account that has mismatched Cloud Meter data within the last 2 days based on the appropriate SLA or Usage filter selection
1. with the banner message not initially displaying... confirm that when selecting the SLA or Usage filters the banner message now appears 

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
#### Copy update
![Screen Shot 2020-11-30 at 3 50 22 PM](https://user-images.githubusercontent.com/3761375/100668915-a3855780-332a-11eb-8e37-63c85bf121b7.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
#511 