### PR TITLE
fix(tabs): issues/491 apply tabs background color

### DIFF
--- a/src/components/authentication/__tests__/__snapshots__/authentication.test.js.snap
+++ b/src/components/authentication/__tests__/__snapshots__/authentication.test.js.snap
@@ -136,11 +136,14 @@ exports[`Authentication Component should render a non-connected component error:
           className="pf-c-page__main-section pf-m-no-padding curiosity"
         >
           <PageSection
+            className=""
             key=".1"
           >
-            <Section>
+            <Section
+              className="curiosity-page-section "
+            >
               <section
-                className=""
+                className="curiosity-page-section "
               >
                  
                 <NotAuthorized

--- a/src/components/messageView/__tests__/__snapshots__/messageView.test.js.snap
+++ b/src/components/messageView/__tests__/__snapshots__/messageView.test.js.snap
@@ -9,7 +9,9 @@ exports[`MessageView Component should have fallback conditions for all props: fa
   >
     Subscription Watch
   </PageHeader>
-  <PageSection>
+  <PageSection
+    className=""
+  >
     <EmptyState
       className="fadein"
       variant="full"
@@ -27,7 +29,9 @@ exports[`MessageView Component should render a non-connected component: non-conn
   >
     Subscription Watch
   </PageHeader>
-  <PageSection>
+  <PageSection
+    className=""
+  >
     <EmptyState
       className="fadein"
       variant="full"
@@ -58,7 +62,9 @@ exports[`MessageView Component should render children when provided: children di
   >
     Subscription Watch
   </PageHeader>
-  <PageSection>
+  <PageSection
+    className=""
+  >
     child content
   </PageSection>
 </PageLayout>

--- a/src/components/openshiftView/__tests__/__snapshots__/openshiftView.test.js.snap
+++ b/src/components/openshiftView/__tests__/__snapshots__/openshiftView.test.js.snap
@@ -42,7 +42,9 @@ exports[`OpenshiftView Component should display an alternate graph on query-stri
       viewId="viewOpenShift"
     />
   </PageToolbar>
-  <PageSection>
+  <PageSection
+    className=""
+  >
     <Connect(C3GraphCard)
       cardTitle="t(curiosity-graph.cardHeading)"
       filterGraphData={
@@ -97,7 +99,9 @@ exports[`OpenshiftView Component should display an alternate graph on query-stri
       />
     </Connect(C3GraphCard)>
   </PageSection>
-  <PageSection>
+  <PageSection
+    className=""
+  >
     <Connect(InventoryTabs)
       productId="lorem ipsum"
     >
@@ -257,7 +261,9 @@ exports[`OpenshiftView Component should have a fallback title: title 1`] = `
       viewId="viewOpenShift"
     />
   </PageToolbar>
-  <PageSection>
+  <PageSection
+    className=""
+  >
     <Connect(GraphCard)
       cardTitle="t(curiosity-graph.cardHeading)"
       filterGraphData={
@@ -312,7 +318,9 @@ exports[`OpenshiftView Component should have a fallback title: title 1`] = `
       />
     </Connect(GraphCard)>
   </PageSection>
-  <PageSection>
+  <PageSection
+    className=""
+  >
     <Connect(InventoryTabs)
       productId="lorem ipsum"
     >
@@ -886,7 +894,9 @@ exports[`OpenshiftView Component should render a non-connected component: non-co
       viewId="viewOpenShift"
     />
   </PageToolbar>
-  <PageSection>
+  <PageSection
+    className=""
+  >
     <Connect(GraphCard)
       cardTitle="t(curiosity-graph.cardHeading)"
       filterGraphData={
@@ -941,7 +951,9 @@ exports[`OpenshiftView Component should render a non-connected component: non-co
       />
     </Connect(GraphCard)>
   </PageSection>
-  <PageSection>
+  <PageSection
+    className=""
+  >
     <Connect(InventoryTabs)
       productId="lorem ipsum"
     >

--- a/src/components/pageLayout/__tests__/__snapshots__/pageLayout.test.js.snap
+++ b/src/components/pageLayout/__tests__/__snapshots__/pageLayout.test.js.snap
@@ -95,11 +95,14 @@ exports[`PageLayout Component should render header and section children: multipl
       className="pf-c-page__main-section pf-m-no-padding curiosity"
     >
       <PageSection
+        className=""
         key=".0"
       >
-        <Section>
+        <Section
+          className="curiosity-page-section "
+        >
           <section
-            className=""
+            className="curiosity-page-section "
           >
              
             ipsum

--- a/src/components/pageLayout/__tests__/__snapshots__/pageSection.test.js.snap
+++ b/src/components/pageLayout/__tests__/__snapshots__/pageSection.test.js.snap
@@ -5,10 +5,10 @@ exports[`PageSection Component should render a basic component: basic 1`] = `
   className="lorem"
 >
   <Section
-    className="lorem"
+    className="curiosity-page-section lorem"
   >
     <section
-      className="lorem"
+      className="curiosity-page-section lorem"
     >
        
       <span

--- a/src/components/pageLayout/pageSection.js
+++ b/src/components/pageLayout/pageSection.js
@@ -7,22 +7,32 @@ import { Section } from '@redhat-cloud-services/frontend-components/components/c
  *
  * @param {object} props
  * @param {Node} props.children
+ * @param {string} props.className
  * @returns {Node}
  */
-const PageSection = ({ children, ...props }) => <Section {...props}>{children}</Section>;
+const PageSection = ({ children, className, ...props }) => (
+  <Section className={`curiosity-page-section ${className}`} {...props}>
+    {children}
+  </Section>
+);
 
 /**
  * Prop types.
  *
- * @type {{children: Node}}
+ * @type {{children: Node, className: string}}
  */
 PageSection.propTypes = {
-  children: PropTypes.node.isRequired
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string
 };
 
 /**
  * Default props.
+ *
+ * @type {{className: string}}
  */
-PageSection.defaultProps = {};
+PageSection.defaultProps = {
+  className: ''
+};
 
 export { PageSection as default, PageSection };

--- a/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
+++ b/src/components/rhelView/__tests__/__snapshots__/rhelView.test.js.snap
@@ -38,7 +38,9 @@ exports[`RhelView Component should display an alternate graph on query-string up
       viewId="viewRHEL"
     />
   </PageToolbar>
-  <PageSection>
+  <PageSection
+    className=""
+  >
     <Connect(C3GraphCard)
       cardTitle="t(curiosity-graph.socketsHeading)"
       filterGraphData={
@@ -77,7 +79,9 @@ exports[`RhelView Component should display an alternate graph on query-string up
       viewId="viewRHEL"
     />
   </PageSection>
-  <PageSection>
+  <PageSection
+    className=""
+  >
     <Connect(InventoryTabs)
       productId="lorem ipsum"
     >
@@ -230,7 +234,9 @@ exports[`RhelView Component should have a fallback title: title 1`] = `
       viewId="viewRHEL"
     />
   </PageToolbar>
-  <PageSection>
+  <PageSection
+    className=""
+  >
     <Connect(GraphCard)
       cardTitle="t(curiosity-graph.socketsHeading)"
       filterGraphData={
@@ -269,7 +275,9 @@ exports[`RhelView Component should have a fallback title: title 1`] = `
       viewId="viewRHEL"
     />
   </PageSection>
-  <PageSection>
+  <PageSection
+    className=""
+  >
     <Connect(InventoryTabs)
       productId="lorem ipsum"
     >
@@ -807,7 +815,9 @@ exports[`RhelView Component should render a non-connected component: non-connect
       viewId="viewRHEL"
     />
   </PageToolbar>
-  <PageSection>
+  <PageSection
+    className=""
+  >
     <Connect(GraphCard)
       cardTitle="t(curiosity-graph.socketsHeading)"
       filterGraphData={
@@ -846,7 +856,9 @@ exports[`RhelView Component should render a non-connected component: non-connect
       viewId="viewRHEL"
     />
   </PageSection>
-  <PageSection>
+  <PageSection
+    className=""
+  >
     <Connect(InventoryTabs)
       productId="lorem ipsum"
     >

--- a/src/styles/_page-layout.scss
+++ b/src/styles/_page-layout.scss
@@ -1,4 +1,4 @@
-.curiosity, .curiosity-page-messages, .curiosity-page-toolbar {
+.curiosity, .curiosity-page-messages, .curiosity-page-toolbar, .curiosity-page-section {
   background-color: var(--pf-global--BackgroundColor--100);
   min-width: 320px;
 }


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(tabs): issues/491 apply tabs background color

### Notes
- Minor background fill. Apparently local proxy run versus the environments exposes some missing styles somewhere in our chain. It's unclear if this on the platform side or ours
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->
### Confirm CI-beta
1. log into the env
1. confirm the below screenshot "After Fix" matches the env display

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
### Before Fix
![Screen Shot 2020-12-12 at 3 18 10 AM](https://user-images.githubusercontent.com/3761375/101979175-b7816100-3c28-11eb-8620-25fdddc93f62.png)

### After Fix
![Screen Shot 2020-12-12 at 3 17 41 AM](https://user-images.githubusercontent.com/3761375/101979176-bbad7e80-3c28-11eb-9599-034f68677f3b.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
#491 