### PR TITLE
perf(openshiftView): issues/407 update uom field

### DIFF
--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -133,14 +133,6 @@ Array [
     "file": "./src/components/openshiftView/openshiftView.js",
     "keys": Array [
       Object {
-        "key": "curiosity-toolbar.uom",
-        "match": "t('curiosity-toolbar.uom', { context: RHSM_API_QUERY_UOM_TYPES.CORES })",
-      },
-      Object {
-        "key": "curiosity-toolbar.uom",
-        "match": "t('curiosity-toolbar.uom', { context: RHSM_API_QUERY_UOM_TYPES.SOCKETS })",
-      },
-      Object {
         "key": "curiosity-view.title",
         "match": "t(\`curiosity-view.title\`, { appName: helpers.UI_DISPLAY_NAME, context: productLabel })",
       },
@@ -506,14 +498,6 @@ Array [
   Object {
     "file": "./src/components/inventorySubscriptions/inventorySubscriptions.js",
     "key": "curiosity-inventory.tab",
-  },
-  Object {
-    "file": "./src/components/openshiftView/openshiftView.js",
-    "key": "curiosity-toolbar.uom",
-  },
-  Object {
-    "file": "./src/components/openshiftView/openshiftView.js",
-    "key": "curiosity-toolbar.uom",
   },
   Object {
     "file": "./src/components/openshiftView/openshiftView.js",

--- a/src/components/openshiftView/__tests__/__snapshots__/openshiftView.test.js.snap
+++ b/src/components/openshiftView/__tests__/__snapshots__/openshiftView.test.js.snap
@@ -72,30 +72,24 @@ exports[`OpenshiftView Component should display an alternate graph on query-stri
       }
       viewId="viewOpenShift"
     >
-      <Select
-        ariaLabel="Select option"
-        className=""
-        id="generatedid-"
-        isDisabled={false}
-        isToggleText={true}
-        name={null}
-        onSelect={[Function]}
+      <ToolbarFieldUom
         options={
           Array [
             Object {
+              "selected": false,
               "title": "t(curiosity-toolbar.uom, {\\"context\\":\\"cores\\"})",
               "value": "cores",
             },
             Object {
+              "selected": false,
               "title": "t(curiosity-toolbar.uom, {\\"context\\":\\"sockets\\"})",
               "value": "sockets",
             },
           ]
         }
-        placeholder="Select option"
-        selectedOptions="cores"
-        toggleIcon={null}
-        variant="single"
+        t={[Function]}
+        value="cores"
+        viewId="viewOpenShift"
       />
     </Connect(GraphCard)>
   </PageSection>
@@ -291,30 +285,24 @@ exports[`OpenshiftView Component should have a fallback title: title 1`] = `
       }
       viewId="viewOpenShift"
     >
-      <Select
-        ariaLabel="Select option"
-        className=""
-        id="generatedid-"
-        isDisabled={false}
-        isToggleText={true}
-        name={null}
-        onSelect={[Function]}
+      <ToolbarFieldUom
         options={
           Array [
             Object {
+              "selected": false,
               "title": "t(curiosity-toolbar.uom, {\\"context\\":\\"cores\\"})",
               "value": "cores",
             },
             Object {
+              "selected": false,
               "title": "t(curiosity-toolbar.uom, {\\"context\\":\\"sockets\\"})",
               "value": "sockets",
             },
           ]
         }
-        placeholder="Select option"
-        selectedOptions="cores"
-        toggleIcon={null}
-        variant="single"
+        t={[Function]}
+        value="cores"
+        viewId="viewOpenShift"
       />
     </Connect(GraphCard)>
   </PageSection>
@@ -924,30 +912,24 @@ exports[`OpenshiftView Component should render a non-connected component: non-co
       }
       viewId="viewOpenShift"
     >
-      <Select
-        ariaLabel="Select option"
-        className=""
-        id="generatedid-"
-        isDisabled={false}
-        isToggleText={true}
-        name={null}
-        onSelect={[Function]}
+      <ToolbarFieldUom
         options={
           Array [
             Object {
+              "selected": false,
               "title": "t(curiosity-toolbar.uom, {\\"context\\":\\"cores\\"})",
               "value": "cores",
             },
             Object {
+              "selected": false,
               "title": "t(curiosity-toolbar.uom, {\\"context\\":\\"sockets\\"})",
               "value": "sockets",
             },
           ]
         }
-        placeholder="Select option"
-        selectedOptions="cores"
-        toggleIcon={null}
-        variant="single"
+        t={[Function]}
+        value="cores"
+        viewId="viewOpenShift"
       />
     </Connect(GraphCard)>
   </PageSection>

--- a/src/components/openshiftView/openshiftView.js
+++ b/src/components/openshiftView/openshiftView.js
@@ -16,9 +16,9 @@ import {
   RHSM_API_QUERY_SORT_TYPES,
   RHSM_API_QUERY_SUBSCRIPTIONS_SORT_TYPES
 } from '../../types/rhsmApiTypes';
-import { apiQueries, connect, reduxSelectors, reduxTypes, store } from '../../redux';
+import { apiQueries, connect, reduxSelectors } from '../../redux';
 import GraphCard from '../graphCard/graphCard';
-import { Select } from '../form/select';
+import { ToolbarFieldUom } from '../toolbar/toolbarFieldUom';
 import Toolbar from '../toolbar/toolbar';
 import InventoryList from '../inventoryList/inventoryList';
 import InventorySubscriptions from '../inventorySubscriptions/inventorySubscriptions';
@@ -34,85 +34,7 @@ import { translate } from '../i18n/i18n';
  * @fires onSelect
  */
 class OpenshiftView extends React.Component {
-  state = {
-    option: null,
-    graphFilters: [],
-    inventoryFilters: [],
-    subscriptionsInventoryFilters: []
-  };
-
-  componentDidMount() {
-    const { initialOption } = this.props;
-    this.onSelect({ value: initialOption });
-  }
-
-  /**
-   * Apply a selected filtered value.
-   *
-   * @event onSelect
-   * @param {object} event
-   */
-  onSelect = (event = {}) => {
-    const { option } = this.state;
-    const { initialGraphFilters, initialInventoryFilters, initialSubscriptionsInventoryFilters, viewId } = this.props;
-    const { value } = event;
-
-    if (value !== option) {
-      const filter = ({ id, isOptional }) => {
-        if (!isOptional) {
-          return true;
-        }
-        return new RegExp(value, 'i').test(id);
-      };
-
-      const graphFilters = initialGraphFilters.filter(filter);
-      const inventoryFilters = initialInventoryFilters.filter(filter);
-      const subscriptionsInventoryFilters = initialSubscriptionsInventoryFilters.filter(filter);
-
-      this.setState(
-        {
-          option,
-          graphFilters,
-          inventoryFilters,
-          subscriptionsInventoryFilters
-        },
-        () => {
-          store.dispatch([
-            {
-              type: reduxTypes.query.SET_QUERY_CLEAR_INVENTORY_LIST
-            },
-            {
-              type: reduxTypes.query.SET_QUERY_RHSM_TYPES[RHSM_API_QUERY_TYPES.UOM],
-              viewId,
-              [RHSM_API_QUERY_TYPES.UOM]: value
-            }
-          ]);
-        }
-      );
-    }
-  };
-
-  /**
-   * Render a select/dropdown list.
-   *
-   * @returns {Node}
-   */
-  renderSelect() {
-    const { option } = this.state;
-    const { initialOption, t } = this.props;
-    const options = [
-      {
-        title: t('curiosity-toolbar.uom', { context: RHSM_API_QUERY_UOM_TYPES.CORES }),
-        value: RHSM_API_QUERY_UOM_TYPES.CORES
-      },
-      {
-        title: t('curiosity-toolbar.uom', { context: RHSM_API_QUERY_UOM_TYPES.SOCKETS }),
-        value: RHSM_API_QUERY_UOM_TYPES.SOCKETS
-      }
-    ];
-
-    return <Select onSelect={this.onSelect} options={options} selectedOptions={option || initialOption} />;
-  }
+  componentDidMount() {}
 
   /**
    * Render an OpenShift view.
@@ -120,11 +42,14 @@ class OpenshiftView extends React.Component {
    * @returns {Node}
    */
   render() {
-    const { graphFilters, inventoryFilters, subscriptionsInventoryFilters } = this.state;
     const {
       initialGuestsFilters,
       initialToolbarFilters,
       initialInventorySettings,
+      initialGraphFilters,
+      initialInventoryFilters,
+      initialSubscriptionsInventoryFilters,
+      initialOption,
       productLabel,
       query,
       graphTallyQuery,
@@ -140,6 +65,17 @@ class OpenshiftView extends React.Component {
       inventorySubscriptionsQuery: initialInventorySubscriptionsQuery,
       toolbarQuery
     } = apiQueries.parseRhsmQuery(query, { graphTallyQuery, inventoryHostsQuery, inventorySubscriptionsQuery });
+
+    const filter = ({ id, isOptional }) => {
+      if (!isOptional) {
+        return true;
+      }
+      return new RegExp(query[RHSM_API_QUERY_TYPES.UOM] || initialOption, 'i').test(id);
+    };
+
+    const graphFilters = initialGraphFilters.filter(filter);
+    const inventoryFilters = initialInventoryFilters.filter(filter);
+    const subscriptionsInventoryFilters = initialSubscriptionsInventoryFilters.filter(filter);
 
     return (
       <PageLayout>
@@ -167,7 +103,7 @@ class OpenshiftView extends React.Component {
             cardTitle={t('curiosity-graph.cardHeading')}
             productLabel={productLabel}
           >
-            {this.renderSelect()}
+            <ToolbarFieldUom value={initialOption} viewId={viewId} />
           </GraphCard>
         </PageSection>
         <PageSection>


### PR DESCRIPTION


## What's included
<!-- Summary of changes/additions -->
- perf(openshiftView): issues/407 update uom field
   * openshiftView, replace uom field with independent comp

### Notes
- Updating towards displayName filtering highlighted optimizations around using Redux hooks and existing components. This is a set of updates in prep for displayName and a possible toolbar restructure.
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. navigate to the Openshift product
1. select the UMO options and confirm the graph and inventory update accordingly, without error

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
#407 
Relates #476 