### PR TITLE
fix(inventoryList): issues/476 hide field on zero results

### DIFF
--- a/src/components/inventoryList/__tests__/__snapshots__/inventoryList.test.js.snap
+++ b/src/components/inventoryList/__tests__/__snapshots__/inventoryList.test.js.snap
@@ -226,7 +226,8 @@ exports[`InventoryList Component should handle variations in data: filtered data
     updateOnResize={true}
   >
     <CardHeader
-      className="transparent"
+      aria-hidden={false}
+      className=""
     >
       <CardHeaderMain>
         <ToolbarFieldDisplayName
@@ -240,7 +241,7 @@ exports[`InventoryList Component should handle variations in data: filtered data
           dropDirection="down"
           isCompact={true}
           isDisabled={false}
-          itemCount={0}
+          itemCount={2}
           offset={0}
           onPage={[Function]}
           onPerPage={[Function]}
@@ -307,6 +308,7 @@ exports[`InventoryList Component should handle variations in data: filtered data
     updateOnResize={true}
   >
     <CardFooter
+      aria-hidden={false}
       className=""
     >
       <TableToolbar
@@ -316,7 +318,7 @@ exports[`InventoryList Component should handle variations in data: filtered data
           dropDirection="up"
           isCompact={false}
           isDisabled={false}
-          itemCount={0}
+          itemCount={2}
           offset={0}
           onPage={[Function]}
           onPerPage={[Function]}
@@ -340,7 +342,8 @@ exports[`InventoryList Component should handle variations in data: variable data
     updateOnResize={true}
   >
     <CardHeader
-      className="transparent"
+      aria-hidden={false}
+      className=""
     >
       <CardHeaderMain>
         <ToolbarFieldDisplayName
@@ -354,7 +357,7 @@ exports[`InventoryList Component should handle variations in data: variable data
           dropDirection="down"
           isCompact={true}
           isDisabled={false}
-          itemCount={0}
+          itemCount={2}
           offset={0}
           onPage={[Function]}
           onPerPage={[Function]}
@@ -417,6 +420,7 @@ exports[`InventoryList Component should handle variations in data: variable data
     updateOnResize={true}
   >
     <CardFooter
+      aria-hidden={false}
       className=""
     >
       <TableToolbar
@@ -426,7 +430,7 @@ exports[`InventoryList Component should handle variations in data: variable data
           dropDirection="up"
           isCompact={false}
           isDisabled={false}
-          itemCount={0}
+          itemCount={2}
           offset={0}
           onPage={[Function]}
           onPerPage={[Function]}
@@ -450,6 +454,7 @@ exports[`InventoryList Component should render a non-connected component: non-co
     updateOnResize={true}
   >
     <CardHeader
+      aria-hidden={true}
       className="transparent"
     >
       <CardHeaderMain>
@@ -505,7 +510,8 @@ exports[`InventoryList Component should render a non-connected component: non-co
     updateOnResize={true}
   >
     <CardFooter
-      className=""
+      aria-hidden={true}
+      className="transparent"
     >
       <TableToolbar
         isFooter={true}

--- a/src/components/inventoryList/__tests__/__snapshots__/inventoryList.test.js.snap
+++ b/src/components/inventoryList/__tests__/__snapshots__/inventoryList.test.js.snap
@@ -226,7 +226,7 @@ exports[`InventoryList Component should handle variations in data: filtered data
     updateOnResize={true}
   >
     <CardHeader
-      className=""
+      className="transparent"
     >
       <CardHeaderMain>
         <ToolbarFieldDisplayName
@@ -340,7 +340,7 @@ exports[`InventoryList Component should handle variations in data: variable data
     updateOnResize={true}
   >
     <CardHeader
-      className=""
+      className="transparent"
     >
       <CardHeaderMain>
         <ToolbarFieldDisplayName
@@ -450,7 +450,7 @@ exports[`InventoryList Component should render a non-connected component: non-co
     updateOnResize={true}
   >
     <CardHeader
-      className=""
+      className="transparent"
     >
       <CardHeaderMain>
         <ToolbarFieldDisplayName

--- a/src/components/inventoryList/__tests__/inventoryList.test.js
+++ b/src/components/inventoryList/__tests__/inventoryList.test.js
@@ -41,6 +41,7 @@ describe('InventoryList Component', () => {
         { lorem: 'ipsum', dolor: 'sit' },
         { lorem: 'sit', dolor: 'amet' }
       ],
+      itemCount: 2,
       isDisabled: true
     };
     const component = shallow(<InventoryList {...props} />);
@@ -58,7 +59,8 @@ describe('InventoryList Component', () => {
       listData: [
         { lorem: 'ipsum', dolor: 'sit' },
         { lorem: 'sit', dolor: 'amet' }
-      ]
+      ],
+      itemCount: 2
     };
 
     const component = shallow(<InventoryList {...props} />);
@@ -78,7 +80,8 @@ describe('InventoryList Component', () => {
         [RHSM_API_QUERY_TYPES.OFFSET]: 0
       },
       productId: 'lorem',
-      listData: [{ lorem: 'sit', dolor: 'amet', numberOfGuests: 1 }]
+      listData: [{ lorem: 'sit', dolor: 'amet', numberOfGuests: 1 }],
+      itemCount: 1
     };
 
     const component = shallow(<InventoryList {...props} />);
@@ -115,7 +118,8 @@ describe('InventoryList Component', () => {
       listData: [
         { lorem: 'ipsum', dolor: 'sit' },
         { lorem: 'sit', dolor: 'amet' }
-      ]
+      ],
+      itemCount: 2
     };
 
     const component = shallow(<InventoryList {...props} />);

--- a/src/components/inventoryList/inventoryList.js
+++ b/src/components/inventoryList/inventoryList.js
@@ -222,7 +222,7 @@ class InventoryList extends React.Component {
     return (
       <Card className="curiosity-inventory-card">
         <MinHeight key="headerMinHeight" updateOnContent>
-          <CardHeader className={(error && 'hidden') || ''}>
+          <CardHeader className={(error && 'hidden') || (!itemCount && 'transparent') || ''}>
             <CardHeaderMain>
               <ToolbarFieldDisplayName viewId={viewId} />
             </CardHeaderMain>

--- a/src/components/inventoryList/inventoryList.js
+++ b/src/components/inventoryList/inventoryList.js
@@ -222,7 +222,10 @@ class InventoryList extends React.Component {
     return (
       <Card className="curiosity-inventory-card">
         <MinHeight key="headerMinHeight" updateOnContent>
-          <CardHeader className={(error && 'hidden') || (!itemCount && 'transparent') || ''}>
+          <CardHeader
+            className={(error && 'hidden') || (!itemCount && 'transparent') || ''}
+            aria-hidden={error || !itemCount || false}
+          >
             <CardHeaderMain>
               <ToolbarFieldDisplayName viewId={viewId} />
             </CardHeaderMain>
@@ -260,7 +263,10 @@ class InventoryList extends React.Component {
           </CardBody>
         </MinHeight>
         <MinHeight key="footerMinHeight" updateOnContent>
-          <CardFooter className={(error && 'blur') || ''}>
+          <CardFooter
+            className={(error && 'hidden') || (!itemCount && 'transparent') || ''}
+            aria-hidden={error || !itemCount || false}
+          >
             <TableToolbar isFooter>
               <Pagination
                 dropDirection="up"

--- a/src/components/inventorySubscriptions/__tests__/__snapshots__/inventorySubscriptions.test.js.snap
+++ b/src/components/inventorySubscriptions/__tests__/__snapshots__/inventorySubscriptions.test.js.snap
@@ -118,15 +118,16 @@ exports[`InventorySubscriptions Component should handle variations in data: filt
     updateOnContent={true}
     updateOnResize={true}
   >
-    <CardHeader>
-      <CardActions
-        className=""
-      >
+    <CardHeader
+      aria-hidden={false}
+      className=""
+    >
+      <CardActions>
         <Pagination
           dropDirection="down"
           isCompact={true}
           isDisabled={false}
-          itemCount={0}
+          itemCount={2}
           offset={0}
           onPage={[Function]}
           onPerPage={[Function]}
@@ -191,6 +192,7 @@ exports[`InventorySubscriptions Component should handle variations in data: filt
     updateOnResize={true}
   >
     <CardFooter
+      aria-hidden={false}
       className=""
     >
       <TableToolbar
@@ -200,7 +202,7 @@ exports[`InventorySubscriptions Component should handle variations in data: filt
           dropDirection="up"
           isCompact={false}
           isDisabled={false}
-          itemCount={0}
+          itemCount={2}
           offset={0}
           onPage={[Function]}
           onPerPage={[Function]}
@@ -223,15 +225,16 @@ exports[`InventorySubscriptions Component should handle variations in data: vari
     updateOnContent={true}
     updateOnResize={true}
   >
-    <CardHeader>
-      <CardActions
-        className=""
-      >
+    <CardHeader
+      aria-hidden={false}
+      className=""
+    >
+      <CardActions>
         <Pagination
           dropDirection="down"
           isCompact={true}
           isDisabled={false}
-          itemCount={0}
+          itemCount={2}
           offset={0}
           onPage={[Function]}
           onPerPage={[Function]}
@@ -292,6 +295,7 @@ exports[`InventorySubscriptions Component should handle variations in data: vari
     updateOnResize={true}
   >
     <CardFooter
+      aria-hidden={false}
       className=""
     >
       <TableToolbar
@@ -301,7 +305,7 @@ exports[`InventorySubscriptions Component should handle variations in data: vari
           dropDirection="up"
           isCompact={false}
           isDisabled={false}
-          itemCount={0}
+          itemCount={2}
           offset={0}
           onPage={[Function]}
           onPerPage={[Function]}
@@ -324,10 +328,11 @@ exports[`InventorySubscriptions Component should render a non-connected componen
     updateOnContent={true}
     updateOnResize={true}
   >
-    <CardHeader>
-      <CardActions
-        className=""
-      >
+    <CardHeader
+      aria-hidden={true}
+      className="transparent"
+    >
+      <CardActions>
         <Pagination
           dropDirection="down"
           isCompact={true}
@@ -373,7 +378,8 @@ exports[`InventorySubscriptions Component should render a non-connected componen
     updateOnResize={true}
   >
     <CardFooter
-      className=""
+      aria-hidden={true}
+      className="transparent"
     >
       <TableToolbar
         isFooter={true}

--- a/src/components/inventorySubscriptions/__tests__/inventorySubscriptions.test.js
+++ b/src/components/inventorySubscriptions/__tests__/inventorySubscriptions.test.js
@@ -40,6 +40,7 @@ describe('InventorySubscriptions Component', () => {
         { lorem: 'ipsum', dolor: 'sit' },
         { lorem: 'sit', dolor: 'amet' }
       ],
+      itemCount: 2,
       isDisabled: true
     };
     const component = shallow(<InventorySubscriptions {...props} />);
@@ -57,7 +58,8 @@ describe('InventorySubscriptions Component', () => {
       listData: [
         { lorem: 'ipsum', dolor: 'sit' },
         { lorem: 'sit', dolor: 'amet' }
-      ]
+      ],
+      itemCount: 2
     };
 
     const component = shallow(<InventorySubscriptions {...props} />);
@@ -80,7 +82,8 @@ describe('InventorySubscriptions Component', () => {
       listData: [
         { lorem: 'ipsum', dolor: 'sit' },
         { lorem: 'sit', dolor: 'amet' }
-      ]
+      ],
+      itemCount: 2
     };
 
     const component = shallow(<InventorySubscriptions {...props} />);

--- a/src/components/inventorySubscriptions/inventorySubscriptions.js
+++ b/src/components/inventorySubscriptions/inventorySubscriptions.js
@@ -200,8 +200,11 @@ class InventorySubscriptions extends React.Component {
     return (
       <Card className="curiosity-inventory-card">
         <MinHeight key="headerMinHeight" updateOnContent>
-          <CardHeader>
-            <CardActions className={(error && 'blur') || ''}>
+          <CardHeader
+            className={(error && 'hidden') || (!itemCount && 'transparent') || ''}
+            aria-hidden={error || !itemCount || false}
+          >
+            <CardActions>
               <Pagination
                 isCompact
                 isDisabled={pending || error}
@@ -235,7 +238,10 @@ class InventorySubscriptions extends React.Component {
           </CardBody>
         </MinHeight>
         <MinHeight key="footerMinHeight" updateOnContent>
-          <CardFooter className={(error && 'blur') || ''}>
+          <CardFooter
+            className={(error && 'hidden') || (!itemCount && 'transparent') || ''}
+            aria-hidden={error || !itemCount || false}
+          >
             <TableToolbar isFooter>
               <Pagination
                 dropDirection="up"

--- a/src/components/pagination/__tests__/__snapshots__/pagination.test.js.snap
+++ b/src/components/pagination/__tests__/__snapshots__/pagination.test.js.snap
@@ -18,7 +18,7 @@ Object {
 
 exports[`Pagination Component should render a non-connected component: non-connected 1`] = `
 <Pagination
-  className="hidden"
+  className=""
   defaultToFullPage={false}
   dropDirection="down"
   firstPage={1}

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -41,7 +41,6 @@ const Pagination = ({
   variant
 }) => (
   <PfPagination
-    className={(!itemCount && 'hidden') || ''}
     dropDirection={dropDirection}
     isCompact={isCompact}
     isDisabled={isDisabled || !itemCount}

--- a/src/styles/_fade.scss
+++ b/src/styles/_fade.scss
@@ -31,4 +31,8 @@
     height:1px;
     overflow:hidden;
   }
+
+  .transparent {
+    opacity: 0;
+  }
 }


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(inventoryList): issues/476 hide field on zero results
- fix(inventoryList): consistent hide, aria-hidden attributes 
   * inventoryList, subsInventoryList, consistent hide, aria-hidden
   * pagination, consistent hide, aria-hidden

### Notes
- minor UX adjustment, hide the display name search when there are no results
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. log in with an account known to have zero results for one of its host inventory displays
1. upon see no results confirm the display name field is hidden

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
#### with
![Screen Shot 2021-01-19 at 5 50 39 PM](https://user-images.githubusercontent.com/3761375/105103636-e6d48a80-5a7e-11eb-8a75-39c831ce21a3.png)

#### without
![Screen Shot 2021-01-19 at 5 50 23 PM](https://user-images.githubusercontent.com/3761375/105103656-ed630200-5a7e-11eb-8749-61771e6439f5.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
#476 