### PR TITLE
fix(inventoryList): issues/476 show field on zero results

### DIFF
--- a/src/components/form/__tests__/__snapshots__/checkbox.test.js.snap
+++ b/src/components/form/__tests__/__snapshots__/checkbox.test.js.snap
@@ -109,6 +109,7 @@ Object {
   "checked": true,
   "currentTarget": Object {},
   "id": "generatedid-",
+  "keyCode": undefined,
   "name": "generatedid-",
   "persist": [Function],
   "target": Object {},

--- a/src/components/form/__tests__/__snapshots__/formHelpers.test.js.snap
+++ b/src/components/form/__tests__/__snapshots__/formHelpers.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`FormHelpers should have specific helpers: helpers 1`] = `
 Object {
+  "createMockEvent": [Function],
   "doesNotHaveMinimumCharacters": [Function],
 }
 `;
@@ -23,3 +24,16 @@ exports[`FormHelpers should return a boolean for not having the correct number o
 exports[`FormHelpers should return a boolean for not having the correct number of characters: string, 5 chars expect 5 1`] = `false`;
 
 exports[`FormHelpers should return a boolean for not having the correct number of characters: undefined 1`] = `true`;
+
+exports[`FormHelpers should return a mocked event object: mock event 1`] = `
+Object {
+  "checked": undefined,
+  "currentTarget": Object {},
+  "id": undefined,
+  "keyCode": undefined,
+  "name": undefined,
+  "persist": [Function],
+  "target": Object {},
+  "value": undefined,
+}
+`;

--- a/src/components/form/__tests__/__snapshots__/textInput.test.js.snap
+++ b/src/components/form/__tests__/__snapshots__/textInput.test.js.snap
@@ -44,39 +44,45 @@ exports[`TextInput Component should render a basic component: basic component 1`
 
 exports[`TextInput Component should return an emulated onChange event: emulated event, change 1`] = `
 Object {
+  "checked": undefined,
   "currentTarget": Object {
     "value": "dolor sit",
   },
   "id": undefined,
+  "keyCode": undefined,
   "name": undefined,
   "persist": [Function],
-  "target": undefined,
+  "target": Object {},
   "value": "dolor sit",
 }
 `;
 
 exports[`TextInput Component should return an emulated onClear event on escape: emulated event, esc 1`] = `
 Object {
+  "checked": undefined,
   "currentTarget": Object {
     "value": "",
   },
   "id": undefined,
+  "keyCode": 27,
   "name": undefined,
   "persist": [Function],
-  "target": undefined,
+  "target": Object {},
   "value": "",
 }
 `;
 
 exports[`TextInput Component should return an emulated onClear event on search clear: emulated event, clear 1`] = `
 Object {
+  "checked": undefined,
   "currentTarget": Object {
     "value": "",
   },
   "id": undefined,
+  "keyCode": undefined,
   "name": undefined,
   "persist": [Function],
-  "target": undefined,
+  "target": Object {},
   "value": "",
 }
 `;

--- a/src/components/form/__tests__/formHelpers.test.js
+++ b/src/components/form/__tests__/formHelpers.test.js
@@ -1,19 +1,23 @@
-import { formHelpers, doesNotHaveMinimumCharacters } from '../formHelpers';
+import { formHelpers } from '../formHelpers';
 
 describe('FormHelpers', () => {
   it('should have specific helpers', () => {
     expect(formHelpers).toMatchSnapshot('helpers');
   });
 
+  it('should return a mocked event object', () => {
+    expect(formHelpers.createMockEvent()).toMatchSnapshot('mock event');
+  });
+
   it('should return a boolean for not having the correct number of characters', () => {
-    expect(doesNotHaveMinimumCharacters(null)).toMatchSnapshot('null');
-    expect(doesNotHaveMinimumCharacters(undefined)).toMatchSnapshot('undefined');
-    expect(doesNotHaveMinimumCharacters({})).toMatchSnapshot('plain object');
-    expect(doesNotHaveMinimumCharacters([])).toMatchSnapshot('array');
-    expect(doesNotHaveMinimumCharacters('l', 1)).toMatchSnapshot('string, 1 chars expect 1');
-    expect(doesNotHaveMinimumCharacters('lo', 2)).toMatchSnapshot('string, 2 chars expect 2');
-    expect(doesNotHaveMinimumCharacters('lor', 2)).toMatchSnapshot('string, 3 chars expect 2');
-    expect(doesNotHaveMinimumCharacters('lore', 5)).toMatchSnapshot('string, 4 chars expect 5');
-    expect(doesNotHaveMinimumCharacters('lorem', 5)).toMatchSnapshot('string, 5 chars expect 5');
+    expect(formHelpers.doesNotHaveMinimumCharacters(null)).toMatchSnapshot('null');
+    expect(formHelpers.doesNotHaveMinimumCharacters(undefined)).toMatchSnapshot('undefined');
+    expect(formHelpers.doesNotHaveMinimumCharacters({})).toMatchSnapshot('plain object');
+    expect(formHelpers.doesNotHaveMinimumCharacters([])).toMatchSnapshot('array');
+    expect(formHelpers.doesNotHaveMinimumCharacters('l', 1)).toMatchSnapshot('string, 1 chars expect 1');
+    expect(formHelpers.doesNotHaveMinimumCharacters('lo', 2)).toMatchSnapshot('string, 2 chars expect 2');
+    expect(formHelpers.doesNotHaveMinimumCharacters('lor', 2)).toMatchSnapshot('string, 3 chars expect 2');
+    expect(formHelpers.doesNotHaveMinimumCharacters('lore', 5)).toMatchSnapshot('string, 4 chars expect 5');
+    expect(formHelpers.doesNotHaveMinimumCharacters('lorem', 5)).toMatchSnapshot('string, 5 chars expect 5');
   });
 });

--- a/src/components/form/checkbox.js
+++ b/src/components/form/checkbox.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Checkbox as PfCheckbox } from '@patternfly/react-core/dist/js/components/Checkbox';
+import { createMockEvent } from './formHelpers';
 import { helpers } from '../../common';
 
 /**
@@ -43,15 +44,12 @@ const Checkbox = ({
    * @param {object} event
    */
   const onCheckboxChange = (checked, event) => {
-    const { currentTarget, target } = event;
     const mockEvent = {
+      ...createMockEvent(event),
       id: nameId,
       name: nameId,
       value,
-      checked,
-      target,
-      currentTarget,
-      persist: helpers.noop
+      checked
     };
 
     setCheck(checked);

--- a/src/components/form/formHelpers.js
+++ b/src/components/form/formHelpers.js
@@ -1,3 +1,30 @@
+import { helpers } from '../../common/helpers';
+
+/**
+ * Create a consistent mock event object.
+ *
+ * @param {object} event
+ * @param {boolean} persistEvent
+ * @returns {{keyCode, currentTarget, name, id: *, persist: Function, value, target}}
+ */
+const createMockEvent = (event, persistEvent = false) => {
+  const { checked, currentTarget = {}, keyCode, persist = helpers.noop, target = {} } = { ...event };
+  if (persistEvent) {
+    persist();
+  }
+
+  return {
+    checked,
+    currentTarget,
+    keyCode,
+    id: currentTarget.id || currentTarget.name,
+    name: currentTarget.name,
+    persist,
+    value: currentTarget.value,
+    target
+  };
+};
+
 /**
  * Confirm a string has minimum length.
  *
@@ -9,7 +36,8 @@ const doesNotHaveMinimumCharacters = (value, characters = 1) =>
   (typeof value === 'string' && value.length < characters) || typeof value !== 'string';
 
 const formHelpers = {
+  createMockEvent,
   doesNotHaveMinimumCharacters
 };
 
-export { formHelpers as default, formHelpers, doesNotHaveMinimumCharacters };
+export { formHelpers as default, formHelpers, createMockEvent, doesNotHaveMinimumCharacters };

--- a/src/components/form/textInput.js
+++ b/src/components/form/textInput.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { TextInput as PfTextInput } from '@patternfly/react-core';
+import { createMockEvent } from './formHelpers';
 import { helpers } from '../../common';
 
 /**
@@ -25,24 +26,12 @@ class TextInput extends React.Component {
    */
   onKeyUp = event => {
     const { onClear, onKeyUp } = this.props;
-    const { currentTarget, keyCode, target } = { ...event };
+    const { currentTarget, keyCode } = event;
 
-    event.persist();
-    onKeyUp(event);
+    onKeyUp(createMockEvent(event, true));
 
-    if (keyCode === 27) {
-      if (currentTarget.value === '') {
-        const mockEvent = {
-          id: currentTarget.name,
-          name: currentTarget.name,
-          value: currentTarget.value,
-          target,
-          currentTarget,
-          persist: helpers.noop
-        };
-
-        onClear(mockEvent);
-      }
+    if (keyCode === 27 && currentTarget.value === '') {
+      onClear(createMockEvent(event));
     }
   };
 
@@ -54,10 +43,10 @@ class TextInput extends React.Component {
    */
   onMouseUp = event => {
     const { onClear, onMouseUp } = this.props;
-    const { currentTarget, target } = { ...event };
+    const { currentTarget } = event;
+    const clonedEvent = { ...event };
 
-    event.persist();
-    onMouseUp(event);
+    onMouseUp(createMockEvent(event, true));
 
     if (currentTarget.value === '') {
       return;
@@ -65,16 +54,7 @@ class TextInput extends React.Component {
 
     setTimeout(() => {
       if (currentTarget.value === '') {
-        const mockEvent = {
-          id: currentTarget.name,
-          name: currentTarget.name,
-          value: currentTarget.value,
-          target,
-          currentTarget,
-          persist: helpers.noop
-        };
-
-        onClear(mockEvent);
+        onClear(createMockEvent(clonedEvent));
       }
     });
   };
@@ -87,19 +67,10 @@ class TextInput extends React.Component {
    */
   onChange = (value, event) => {
     const { onChange } = this.props;
-    const { currentTarget, target } = event;
+    const clonedEvent = { ...event };
 
     this.setState({ updatedValue: value }, () => {
-      const mockEvent = {
-        id: currentTarget.name,
-        name: currentTarget.name,
-        value,
-        target,
-        currentTarget,
-        persist: helpers.noop
-      };
-
-      onChange(mockEvent);
+      onChange(createMockEvent(clonedEvent));
     });
   };
 
@@ -157,6 +128,7 @@ TextInput.propTypes = {
   onChange: PropTypes.func,
   onClear: PropTypes.func,
   onKeyUp: PropTypes.func,
+  onKeyDown: PropTypes.func,
   onMouseUp: PropTypes.func,
   type: PropTypes.string,
   value: PropTypes.string
@@ -177,6 +149,7 @@ TextInput.defaultProps = {
   onChange: helpers.noop,
   onClear: helpers.noop,
   onKeyUp: helpers.noop,
+  onKeyDown: helpers.noop,
   onMouseUp: helpers.noop,
   type: 'text',
   value: ''

--- a/src/components/inventoryList/__tests__/__snapshots__/inventoryList.test.js.snap
+++ b/src/components/inventoryList/__tests__/__snapshots__/inventoryList.test.js.snap
@@ -236,7 +236,10 @@ exports[`InventoryList Component should handle variations in data: filtered data
           viewId="inventoryList"
         />
       </CardHeaderMain>
-      <CardActions>
+      <CardActions
+        aria-hidden={false}
+        className=""
+      >
         <Pagination
           dropDirection="down"
           isCompact={true}
@@ -352,7 +355,10 @@ exports[`InventoryList Component should handle variations in data: variable data
           viewId="inventoryList"
         />
       </CardHeaderMain>
-      <CardActions>
+      <CardActions
+        aria-hidden={false}
+        className=""
+      >
         <Pagination
           dropDirection="down"
           isCompact={true}
@@ -454,8 +460,8 @@ exports[`InventoryList Component should render a non-connected component: non-co
     updateOnResize={true}
   >
     <CardHeader
-      aria-hidden={true}
-      className="transparent"
+      aria-hidden={false}
+      className=""
     >
       <CardHeaderMain>
         <ToolbarFieldDisplayName
@@ -464,7 +470,10 @@ exports[`InventoryList Component should render a non-connected component: non-co
           viewId="inventoryList"
         />
       </CardHeaderMain>
-      <CardActions>
+      <CardActions
+        aria-hidden={true}
+        className="transparent"
+      >
         <Pagination
           dropDirection="down"
           isCompact={true}

--- a/src/components/inventoryList/inventoryList.js
+++ b/src/components/inventoryList/inventoryList.js
@@ -222,14 +222,11 @@ class InventoryList extends React.Component {
     return (
       <Card className="curiosity-inventory-card">
         <MinHeight key="headerMinHeight" updateOnContent>
-          <CardHeader
-            className={(error && 'hidden') || (!itemCount && 'transparent') || ''}
-            aria-hidden={error || !itemCount || false}
-          >
+          <CardHeader className={(error && 'hidden') || ''} aria-hidden={error || false}>
             <CardHeaderMain>
               <ToolbarFieldDisplayName viewId={viewId} />
             </CardHeaderMain>
-            <CardActions>
+            <CardActions className={(!itemCount && 'transparent') || ''} aria-hidden={!itemCount || false}>
               <Pagination
                 isCompact
                 isDisabled={pending || error}

--- a/src/components/inventorySubscriptions/__tests__/__snapshots__/inventorySubscriptions.test.js.snap
+++ b/src/components/inventorySubscriptions/__tests__/__snapshots__/inventorySubscriptions.test.js.snap
@@ -122,7 +122,10 @@ exports[`InventorySubscriptions Component should handle variations in data: filt
       aria-hidden={false}
       className=""
     >
-      <CardActions>
+      <CardActions
+        aria-hidden={false}
+        className=""
+      >
         <Pagination
           dropDirection="down"
           isCompact={true}
@@ -229,7 +232,10 @@ exports[`InventorySubscriptions Component should handle variations in data: vari
       aria-hidden={false}
       className=""
     >
-      <CardActions>
+      <CardActions
+        aria-hidden={false}
+        className=""
+      >
         <Pagination
           dropDirection="down"
           isCompact={true}
@@ -329,10 +335,13 @@ exports[`InventorySubscriptions Component should render a non-connected componen
     updateOnResize={true}
   >
     <CardHeader
-      aria-hidden={true}
-      className="transparent"
+      aria-hidden={false}
+      className=""
     >
-      <CardActions>
+      <CardActions
+        aria-hidden={true}
+        className="transparent"
+      >
         <Pagination
           dropDirection="down"
           isCompact={true}

--- a/src/components/inventorySubscriptions/inventorySubscriptions.js
+++ b/src/components/inventorySubscriptions/inventorySubscriptions.js
@@ -200,11 +200,8 @@ class InventorySubscriptions extends React.Component {
     return (
       <Card className="curiosity-inventory-card">
         <MinHeight key="headerMinHeight" updateOnContent>
-          <CardHeader
-            className={(error && 'hidden') || (!itemCount && 'transparent') || ''}
-            aria-hidden={error || !itemCount || false}
-          >
-            <CardActions>
+          <CardHeader className={(error && 'hidden') || ''} aria-hidden={error || false}>
+            <CardActions className={(!itemCount && 'transparent') || ''} aria-hidden={!itemCount || false}>
               <Pagination
                 isCompact
                 isDisabled={pending || error}

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldDisplayName.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldDisplayName.test.js.snap
@@ -34,6 +34,23 @@ Array [
 ]
 `;
 
+exports[`ToolbarFieldDisplayName Component should handle updating display name using the enter key: enter display name 1`] = `
+Array [
+  Array [
+    Array [
+      Object {
+        "type": "SET_QUERY_CLEAR_INVENTORY_LIST",
+      },
+      Object {
+        "display_name_contains": "dolor sit",
+        "type": "SET_QUERY_RHSM_HOSTS_INVENTORY_display_name_contains",
+        "viewId": "toolbarFieldDisplayName",
+      },
+    ],
+  ],
+]
+`;
+
 exports[`ToolbarFieldDisplayName Component should render a non-connected component: non-connected 1`] = `
 <InputGroup>
   <TextInput
@@ -44,6 +61,7 @@ exports[`ToolbarFieldDisplayName Component should render a non-connected compone
     name={null}
     onChange={[Function]}
     onClear={[Function]}
+    onKeyDown={[Function]}
     onKeyUp={[Function]}
     onMouseUp={[Function]}
     placeholder="t(curiosity-toolbar.placeholder, {\\"context\\":\\"displayName\\"})"

--- a/src/components/toolbar/__tests__/toolbarFieldDisplayName.test.js
+++ b/src/components/toolbar/__tests__/toolbarFieldDisplayName.test.js
@@ -36,6 +36,18 @@ describe('ToolbarFieldDisplayName Component', () => {
     expect(mockDispatch.mock.calls).toMatchSnapshot('dispatch display name');
   });
 
+  it('should handle updating display name using the enter key', () => {
+    const props = {
+      value: 'lorem ipsum'
+    };
+
+    const component = mount(<ToolbarFieldDisplayName {...props} />);
+    const mockEvent = { keyCode: 13, currentTarget: { value: 'dolor sit' }, persist: helpers.noop };
+    component.find(TextInput).instance().onKeyUp(mockEvent);
+
+    expect(mockDispatch.mock.calls).toMatchSnapshot('enter display name');
+  });
+
   it('should handle clearing display name through redux state', () => {
     const props = {
       value: 'lorem ipsum'

--- a/src/components/toolbar/toolbarFieldDisplayName.js
+++ b/src/components/toolbar/toolbarFieldDisplayName.js
@@ -14,6 +14,7 @@ import { translate } from '../i18n/i18n';
  * @fires onSubmit
  * @fires onClear
  * @fires onChange
+ * @fires onKeyUp
  * @param {object} props
  * @param {string} props.value
  * @param {Function} props.t
@@ -84,12 +85,28 @@ const ToolbarFieldDisplayName = ({ value, t, viewId }) => {
     updatedValue = event.value;
   };
 
+  /**
+   * On enter, submit value. We nest the conditions to allow enter to submit onChange value updates.
+   *
+   * @event onKeyUp
+   * @param {object} event
+   */
+  const onKeyUp = event => {
+    if (event.keyCode === 13) {
+      if (event.value?.length) {
+        updatedValue = event?.value;
+      }
+      onSubmit();
+    }
+  };
+
   return (
     <InputGroup>
       <TextInput
         aria-label={t('curiosity-toolbar.placeholder', { context: 'displayName' })}
         onChange={onChange}
         onClear={onClear}
+        onKeyUp={onKeyUp}
         value={updatedValue}
         placeholder={t('curiosity-toolbar.placeholder', { context: 'displayName' })}
         type="search"


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(inventoryList): issues/476 show field on zero results
- fix(toolbarFieldDisplayName): issues/476 allow enter submit

### Notes
- based on UX/design feedback reactivates the display name field. accounts for scenarios in which zero results normally hides "paging". the new behavior is to now display paging and the display name field when there are "zero" results
- enables a user to use the enter/return key to submit the display name field
- have a question around the paging disabled state, do we want to remove the grey disabled color? @bclarhk @rblackbu 
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. login with an account having a hosts inventory
1. navigate to a RHEL architecture and enter a display name search that yields zero results, the result should be similar to the below screenshot example
   - Also confirm that switching between RHEL architectures both maintains the value in the display name field, adjusts the results based off of "all", and allows you to still edit display name

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
### Accepted solution
![Screen Shot 2021-01-21 at 11 01 08 AM](https://user-images.githubusercontent.com/3761375/105376691-016e4700-5bd8-11eb-9440-518c2fe1ee5b.png)



### NOT accepted, prior solution with paging disabled and showing
![Screen Shot 2021-01-21 at 10 13 29 AM](https://user-images.githubusercontent.com/3761375/105370628-c2d58e00-5bd1-11eb-80f2-6bb971119438.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
#476 