### PR TITLE
issues/476 displayname field, remove tab content focus outline

### DIFF
--- a/src/components/form/textInput.js
+++ b/src/components/form/textInput.js
@@ -42,13 +42,13 @@ class TextInput extends React.Component {
    * @param {object} event
    */
   onMouseUp = event => {
-    const { onClear, onMouseUp } = this.props;
+    const { onClear, onMouseUp, type } = this.props;
     const { currentTarget } = event;
     const clonedEvent = { ...event };
 
     onMouseUp(createMockEvent(event, true));
 
-    if (currentTarget.value === '') {
+    if (type !== 'search' || currentTarget.value === '') {
       return;
     }
 
@@ -128,7 +128,6 @@ TextInput.propTypes = {
   onChange: PropTypes.func,
   onClear: PropTypes.func,
   onKeyUp: PropTypes.func,
-  onKeyDown: PropTypes.func,
   onMouseUp: PropTypes.func,
   type: PropTypes.string,
   value: PropTypes.string
@@ -149,7 +148,6 @@ TextInput.defaultProps = {
   onChange: helpers.noop,
   onClear: helpers.noop,
   onKeyUp: helpers.noop,
-  onKeyDown: helpers.noop,
   onMouseUp: helpers.noop,
   type: 'text',
   value: ''

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldDisplayName.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldDisplayName.test.js.snap
@@ -61,7 +61,6 @@ exports[`ToolbarFieldDisplayName Component should render a non-connected compone
     name={null}
     onChange={[Function]}
     onClear={[Function]}
-    onKeyDown={[Function]}
     onKeyUp={[Function]}
     onMouseUp={[Function]}
     placeholder="t(curiosity-toolbar.placeholder, {\\"context\\":\\"displayName\\"})"

--- a/src/components/toolbar/toolbarFieldDisplayName.js
+++ b/src/components/toolbar/toolbarFieldDisplayName.js
@@ -94,7 +94,7 @@ const ToolbarFieldDisplayName = ({ value, t, viewId }) => {
   const onKeyUp = event => {
     if (event.keyCode === 13) {
       if (event.value?.length) {
-        updatedValue = event?.value;
+        updatedValue = event.value;
       }
       onSubmit();
     }

--- a/src/styles/_tabs.scss
+++ b/src/styles/_tabs.scss
@@ -1,6 +1,10 @@
 .curiosity {
   .curiosity-tabs-container {
     min-height: 775px;
+
+    section.pf-c-tab-content:focus {
+      outline: none;
+    }
   }
 
   .curiosity-tabs__no-scroll {


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(textInput,toolbarFieldDisplayName): issues/476 clean up, extra props
- fix(style): remove focus outline style for tab content

<!-- ### Notes -->
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. log in and confirm the tab focus outline is no longer visible on the hosts inventory display by
   - either tabbing through the interface
   - or click next to, around, the display name field

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
### After
  
![Screen Shot 2021-01-21 at 3 07 50 PM](https://user-images.githubusercontent.com/3761375/105406472-7b172c80-5bfa-11eb-8494-b9a06ce284c2.png)

### Before
![Screen Shot 2021-01-21 at 3 07 32 PM](https://user-images.githubusercontent.com/3761375/105406591-a13ccc80-5bfa-11eb-9260-fbc31679c4af.png)



## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Relates to #476 