### PR TITLE
fix(toolbarFieldDisplayName): issues/559 remove min char check

### DIFF
--- a/src/components/toolbar/toolbarFieldDisplayName.js
+++ b/src/components/toolbar/toolbarFieldDisplayName.js
@@ -4,7 +4,6 @@ import { Button, ButtonVariant, InputGroup } from '@patternfly/react-core';
 import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';
 import { reduxTypes, store, useSelector } from '../../redux';
 import { TextInput } from '../form/textInput';
-import { formHelpers } from '../form/formHelpers';
 import { RHSM_API_QUERY_TYPES } from '../../types/rhsmApiTypes';
 import { translate } from '../i18n/i18n';
 
@@ -35,11 +34,7 @@ const ToolbarFieldDisplayName = ({ value, t, viewId }) => {
    * @event onSubmit
    * @returns {void}
    */
-  const onSubmit = () => {
-    if (formHelpers.doesNotHaveMinimumCharacters(updatedValue)) {
-      return;
-    }
-
+  const onSubmit = () =>
     store.dispatch([
       {
         type: reduxTypes.query.SET_QUERY_CLEAR_INVENTORY_LIST
@@ -50,7 +45,6 @@ const ToolbarFieldDisplayName = ({ value, t, viewId }) => {
         [RHSM_API_QUERY_TYPES.DISPLAY_NAME]: updatedValue
       }
     ]);
-  };
 
   /**
    * On clear, dispatch type.


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(toolbarFieldDisplayName): issues/559 remove min char check

### Notes
- This fix is related to those browsers that do not implement a clear for the html input type "search". The specific instance called out was around Firefox 78+/-
- We simply removed the min-character check that was set to prevent unneeded api calls based on the concept of the "search" type.
- It was noted that we might want to consider clearing this field along with the primary toolbar "clear all filters" since we do a general paging reset  @bclarhk @rblackbu . However, since "display name" doesn't appear in the primary toolbar list of filters it is recognized that may not be the best UX
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. login in, navigate to Subs Watch using Firefox 78
1. enter a display name search, then attempt to remove and submit the cleared field

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
#559 