### PR TITLE
fix(actionRecordMiddleware): issues/52 limit and data adjustment

### DIFF
--- a/src/redux/middleware/actionRecordMiddleware.js
+++ b/src/redux/middleware/actionRecordMiddleware.js
@@ -1,18 +1,50 @@
+import { platformApiTypes } from '../../types';
+import { userTypes } from '../types/userTypes';
+
 /**
- * Modify actions for privacy.
+ * Modify actions' payload for privacy.
  *
  * @param {object} action
- * @param {string} action.type
  * @param {object} action.payload
  * @returns {object}
  */
-const sanitizeActionHeaders = ({ type, payload, ...action }) => {
+const sanitizeActionHeaders = ({ payload, ...action }) => {
   if (payload) {
     let updatedPayload = { ...payload, headers: {} };
 
     if (Array.isArray(payload)) {
       updatedPayload = payload.map(({ headers, ...obj }) => ({ ...obj, headers: {} }));
     }
+
+    return { payload: updatedPayload, ...action };
+  }
+
+  return { ...action };
+};
+
+/**
+ * Modify actions' payload data for privacy.
+ *
+ * @param {object} action
+ * @param {string} action.type
+ * @param {object} action.payload
+ * @returns {object}
+ */
+const sanitizeData = ({ type, payload, ...action }) => {
+  if (payload && new RegExp(userTypes.USER_AUTH).test(type)) {
+    const updatedPayload = {
+      ...payload,
+      data: {
+        ...payload.data,
+        user: {
+          ...payload.data.user,
+          [platformApiTypes.PLATFORM_API_RESPONSE_USER_IDENTITY]: {
+            ...payload.data.user[platformApiTypes.PLATFORM_API_RESPONSE_USER_IDENTITY],
+            [platformApiTypes.PLATFORM_API_RESPONSE_USER_IDENTITY_TYPES.USER]: {}
+          }
+        }
+      }
+    };
 
     return { type, payload: updatedPayload, ...action };
   }
@@ -30,7 +62,7 @@ const sanitizeActionHeaders = ({ type, payload, ...action }) => {
 const getActions = (id, limit) => {
   const { sessionStorage } = window;
   const item = sessionStorage.getItem(id);
-  let parsedItems = (item && (JSON.parse(item) || {})?.actions) || null;
+  let parsedItems = (item && (JSON.parse(item) || {})?.actions) || [];
 
   if (parsedItems?.length && limit > 0) {
     parsedItems = parsedItems.slice(limit * -1);
@@ -51,7 +83,7 @@ const recordAction = (action, { id, limit, ...config }) => {
   const { navigator, sessionStorage } = window;
   const items = getActions(id, limit) || [];
   const priorItem = items[items.length - 1];
-  const updatedAction = sanitizeActionHeaders(action);
+  const updatedAction = sanitizeData(sanitizeActionHeaders(action));
   const actionObj = {
     diff: 0,
     timestamp: Date.now(),
@@ -67,7 +99,7 @@ const recordAction = (action, { id, limit, ...config }) => {
     id,
     JSON.stringify({
       browser: navigator.userAgent,
-      timestamp: new Date(),
+      timestamp: new Date().toLocaleString(),
       ...config,
       actions: items
     })
@@ -84,7 +116,7 @@ const actionRecordMiddleware = (config = {}) => {
   return () => next => action => {
     recordAction(action, {
       id: 'actionRecordMiddleware/v1',
-      limitResults: 100,
+      limit: 100,
       ...config
     });
 


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(actionRecordMiddleware): issues/52 limit and data adjustment

### Notes
- Sanitize identifying user data, generic
- Correct the output limit for reporting, variable name correction
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with $ yarn
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. login and navigate to Subscription Watch
1. Open the browser dev console and type $ curiosity.debugLog(), hit enter and a JSON debug log should download. You may have to "allow" the download action.
   - You should see a file with similar output to the below screenshot

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screen Shot 2021-01-25 at 3 45 20 PM](https://user-images.githubusercontent.com/3761375/105764009-68676500-5f24-11eb-8209-e3a5f4b91978.png)

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
#52 