### PR TITLE
fix(toolbar): issues/541 state updates for filters (allow clear filters in Satellite)

### DIFF
--- a/src/components/form/__tests__/__snapshots__/textInput.test.js.snap
+++ b/src/components/form/__tests__/__snapshots__/textInput.test.js.snap
@@ -5,6 +5,7 @@ exports[`TextInput Component should handle readOnly, disabled: active 1`] = `
   aria-invalid="false"
   class="pf-c-form-control curiosity-text-input "
   id="generatedid-"
+  name="generatedid-"
   type="text"
   value=""
 />
@@ -16,6 +17,7 @@ exports[`TextInput Component should handle readOnly, disabled: disabled 1`] = `
   class="pf-c-form-control curiosity-text-input "
   disabled=""
   id="generatedid-"
+  name="generatedid-"
   type="text"
   value=""
 />
@@ -26,6 +28,7 @@ exports[`TextInput Component should handle readOnly, disabled: readOnly 1`] = `
   aria-invalid="false"
   class="pf-c-form-control curiosity-text-input "
   id="generatedid-"
+  name="generatedid-"
   readonly=""
   type="text"
   value=""
@@ -37,6 +40,7 @@ exports[`TextInput Component should render a basic component: basic component 1`
   aria-invalid="false"
   class="pf-c-form-control curiosity-text-input "
   id="generatedid-"
+  name="generatedid-"
   type="text"
   value=""
 />

--- a/src/components/form/checkbox.js
+++ b/src/components/form/checkbox.js
@@ -11,6 +11,7 @@ import { helpers } from '../../common';
  * @param {object} props
  * @param {string} props.ariaLabel
  * @param {Node} props.children
+ * @param {string} props.id
  * @param {*} props.isChecked
  * @param {boolean} props.isDisabled
  * @param {boolean} props.isReadOnly
@@ -23,6 +24,7 @@ import { helpers } from '../../common';
 const Checkbox = ({
   ariaLabel,
   children,
+  id,
   isChecked,
   isDisabled,
   isReadOnly,
@@ -34,7 +36,8 @@ const Checkbox = ({
 }) => {
   const [check, setCheck] = React.useState();
   const updatedChecked = check ?? isChecked ?? false;
-  const nameId = name || helpers.generateId();
+  const updatedName = name || helpers.generateId();
+  const updatedId = id || updatedName;
 
   /**
    * onChange event, provide restructured event.
@@ -46,8 +49,8 @@ const Checkbox = ({
   const onCheckboxChange = (checked, event) => {
     const mockEvent = {
       ...createMockEvent(event),
-      id: nameId,
-      name: nameId,
+      id: updatedId,
+      name: updatedName,
       value,
       checked
     };
@@ -60,11 +63,11 @@ const Checkbox = ({
     <PfCheckbox
       aria-label={ariaLabel || children || label}
       checked={updatedChecked}
-      id={nameId}
+      id={updatedId}
       isChecked={updatedChecked}
       isDisabled={isDisabled || false}
       label={children || label}
-      name={nameId}
+      name={updatedName}
       onChange={onCheckboxChange}
       value={value}
       readOnly={isReadOnly || false}
@@ -76,12 +79,13 @@ const Checkbox = ({
 /**
  * Prop types.
  *
- * @type {{onChange: Function, children: Node, name: string, isChecked: *, isDisabled: boolean,
- *     isReadOnly: boolean, label: string, value: *, ariaLabel: string}}
+ * @type {{isReadOnly: boolean, onChange: Function, children: Node, name: string, id: string,
+ *     isDisabled: boolean, label: string, isChecked: boolean, value: *, ariaLabel: string}}
  */
 Checkbox.propTypes = {
   ariaLabel: PropTypes.string,
   children: PropTypes.node,
+  id: PropTypes.string,
   isChecked: PropTypes.any,
   isDisabled: PropTypes.bool,
   isReadOnly: PropTypes.bool,
@@ -94,12 +98,13 @@ Checkbox.propTypes = {
 /**
  * Default props.
  *
- * @type {{onChange: Function, children: Node, name: string, isChecked: *, isDisabled: boolean,
- *     isReadOnly: boolean, label: string, value: *, ariaLabel: string}}
+ * @type {{isReadOnly: boolean, onChange: Function, children: Node, name: string, id: string,
+ *     isDisabled: boolean, label: string, isChecked: boolean, value: *, ariaLabel: string}}
  */
 Checkbox.defaultProps = {
   ariaLabel: null,
   children: null,
+  id: null,
   isChecked: false,
   isDisabled: false,
   isReadOnly: false,

--- a/src/components/form/textInput.js
+++ b/src/components/form/textInput.js
@@ -80,10 +80,12 @@ class TextInput extends React.Component {
    * @returns {Node}
    */
   render() {
-    const { name, updatedValue } = this.state;
+    const { updatedValue } = this.state;
     const {
       className,
+      id,
       isDisabled,
+      name,
       onChange,
       onClear,
       onKeyUp,
@@ -93,12 +95,13 @@ class TextInput extends React.Component {
       value,
       ...props
     } = this.props;
-    const nameId = name || helpers.generateId();
+    const updatedName = name || helpers.generateId();
+    const updatedId = id || updatedName;
 
     return (
       <PfTextInput
-        id={nameId}
-        name={nameId}
+        id={updatedId}
+        name={updatedName}
         className={`curiosity-text-input ${className}`}
         isDisabled={isDisabled || false}
         onChange={this.onChange}
@@ -117,11 +120,12 @@ class TextInput extends React.Component {
  * Prop types.
  *
  * @type {{onKeyUp: Function, isReadOnly: boolean, onChange: Function, onClear: Function,
- *     name: string, className: string, isDisabled: boolean, onMouseUp: Function, type: string,
- *     value: string}}
+ *     name: string, className: string, id: string, isDisabled: boolean, onMouseUp: Function,
+ *     type: string, value: string}}
  */
 TextInput.propTypes = {
   className: PropTypes.string,
+  id: PropTypes.string,
   isDisabled: PropTypes.bool,
   isReadOnly: PropTypes.bool,
   name: PropTypes.string,
@@ -137,11 +141,12 @@ TextInput.propTypes = {
  * Default props.
  *
  * @type {{onKeyUp: Function, isReadOnly: boolean, onChange: Function, onClear: Function,
- *     name: string, className: string, isDisabled: boolean, onMouseUp: Function, type: string,
- *     value: string}}
+ *     name: string, className: string, id: string, isDisabled: boolean, onMouseUp: Function,
+ *     type: string, value: string}}
  */
 TextInput.defaultProps = {
   className: '',
+  id: null,
   isDisabled: false,
   isReadOnly: false,
   name: null,

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldDisplayName.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldDisplayName.test.js.snap
@@ -8,7 +8,7 @@ Array [
         "type": "SET_QUERY_CLEAR_INVENTORY_LIST",
       },
       Object {
-        "display_name_contains": "",
+        "display_name_contains": null,
         "type": "SET_QUERY_RHSM_HOSTS_INVENTORY_display_name_contains",
         "viewId": "toolbarFieldDisplayName",
       },

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldDisplayName.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldDisplayName.test.js.snap
@@ -56,6 +56,7 @@ exports[`ToolbarFieldDisplayName Component should render a non-connected compone
   <TextInput
     aria-label="t(curiosity-toolbar.placeholder, {\\"context\\":\\"displayName\\"})"
     className=""
+    id={null}
     isDisabled={false}
     isReadOnly={false}
     name={null}

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -325,11 +325,16 @@ Toolbar.defaultProps = {
  *
  * @param {object} state
  * @param {object} state.toolbar
+ * @param {object} state.view
  * @param {object} props
+ * @param {string} props.query
  * @param {string} props.viewId
  * @returns {object}
  */
-const mapStateToProps = ({ toolbar }, { viewId }) => ({ ...toolbar.filters?.[viewId] });
+const mapStateToProps = ({ toolbar, view }, { query: initialQuery, viewId }) => ({
+  ...toolbar.filters?.[viewId],
+  query: view.query?.[viewId] || initialQuery
+});
 
 const ConnectedToolbar = connect(mapStateToProps)(Toolbar);
 

--- a/src/components/toolbar/toolbarFieldDisplayName.js
+++ b/src/components/toolbar/toolbarFieldDisplayName.js
@@ -64,7 +64,7 @@ const ToolbarFieldDisplayName = ({ value, t, viewId }) => {
       {
         type: reduxTypes.query.SET_QUERY_RHSM_HOSTS_INVENTORY_TYPES[RHSM_API_QUERY_TYPES.DISPLAY_NAME],
         viewId,
-        [RHSM_API_QUERY_TYPES.DISPLAY_NAME]: ''
+        [RHSM_API_QUERY_TYPES.DISPLAY_NAME]: null
       }
     ]);
   };

--- a/src/redux/selectors/inventoryListSelectors.js
+++ b/src/redux/selectors/inventoryListSelectors.js
@@ -52,7 +52,10 @@ const queryFilter = (state, props = {}) => {
       ...state.view?.query?.[props.viewId]
     },
     {
-      inventoryHostsQuery: { ...state.view?.inventoryHostsQuery?.[props.productId] }
+      inventoryHostsQuery: {
+        ...state.view?.inventoryHostsQuery?.[props.productId],
+        ...state.view?.inventoryHostsQuery?.[props.viewId]
+      }
     }
   );
 

--- a/src/redux/selectors/subscriptionsListSelectors.js
+++ b/src/redux/selectors/subscriptionsListSelectors.js
@@ -58,7 +58,10 @@ const queryFilter = (state, props = {}) => {
       ...state.view?.query?.[props.viewId]
     },
     {
-      inventorySubscriptionsQuery: { ...state.view?.inventorySubscriptionsQuery?.[props.productId] }
+      inventorySubscriptionsQuery: {
+        ...state.view?.inventorySubscriptionsQuery?.[props.productId],
+        ...state.view?.inventorySubscriptionsQuery?.[props.viewId]
+      }
     }
   );
 


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(toolbar): issues/541 state updates for filters
   * toolbar, selector update, pull query directly
   * toolbarFieldDisplayName, clear value with null
   * inventoryListSelectors,subsListSelectors, selector update, viewId
- fix(checkbox,textInput): consistent name, id attributes

### Notes
- This issue also affects the display name field, that fix is included. 
   - It has to do with turning the productView component into a function. We were (and still are'ish) drilling the query prop through subsequent child components. Now the affected components receive the query state updates initially through config, then directly from state
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. log in and navigate to the Satellite views
   - `/beta/subscriptions/satellite-sw/all` 
   - `/beta/subscriptions/satellite-sw/satellite-capsule`
   - `/beta/subscriptions/satellite-sw/satellite-server` 
1. confirm the primary toolbar filters display the toolbar filters, then allow clearing
   - also confirm "display name" search updates the inventory list in Satellite

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
#541 