### PR TITLE
fix(bannerMessages): issues/541 state updates for filters

### DIFF
--- a/src/components/productView/__tests__/__snapshots__/productView.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productView.test.js.snap
@@ -14,6 +14,7 @@ exports[`ProductView Component should render a non-connected component: non-conn
   >
     <Connect(BannerMessages)
       productId="lorem ipsum"
+      query={Object {}}
       viewId="dolor sit"
     />
   </PageMessages>

--- a/src/components/productView/productView.js
+++ b/src/components/productView/productView.js
@@ -57,10 +57,11 @@ const ProductView = ({ productConfig, routeDetail, t }) => {
   } = productConfig;
 
   const {
+    query: initialQuery,
     graphTallyQuery: initialGraphTallyQuery,
     inventoryHostsQuery: initialInventoryHostsQuery,
     inventorySubscriptionsQuery: initialInventorySubscriptionsQuery,
-    toolbarQuery
+    toolbarQuery: initialToolbarQuery
   } = apiQueries.parseRhsmQuery(query, { graphTallyQuery, inventoryHostsQuery, inventorySubscriptionsQuery });
 
   const { pathParameter: productId, productParameter: productLabel, viewParameter: viewId } = routeDetail;
@@ -75,13 +76,13 @@ const ProductView = ({ productConfig, routeDetail, t }) => {
         {t(`curiosity-view.title`, { appName: helpers.UI_DISPLAY_NAME, context: productLabel })}
       </PageHeader>
       <PageMessages>
-        <BannerMessages productId={productId} viewId={viewId} query={query} />
+        <BannerMessages productId={productId} viewId={viewId} query={initialQuery} />
       </PageMessages>
       <PageToolbar>
         <ConnectedToolbar
           filterOptions={initialToolbarFilters}
           productId={productId}
-          query={toolbarQuery}
+          query={initialToolbarQuery}
           viewId={viewId}
         />
       </PageToolbar>

--- a/src/redux/selectors/__tests__/__snapshots__/appMessagesSelectors.test.js.snap
+++ b/src/redux/selectors/__tests__/__snapshots__/appMessagesSelectors.test.js.snap
@@ -4,8 +4,8 @@ exports[`AppMessagesSelectors should map a fulfilled product ID response to an a
 Object {
   "appMessages": Object {
     "cloudigradeMismatch": true,
-    "query": Object {},
   },
+  "query": Object {},
 }
 `;
 
@@ -13,8 +13,8 @@ exports[`AppMessagesSelectors should pass minimal data on a product ID without a
 Object {
   "appMessages": Object {
     "cloudigradeMismatch": false,
-    "query": Object {},
   },
+  "query": Object {},
 }
 `;
 
@@ -22,8 +22,8 @@ exports[`AppMessagesSelectors should pass minimal data on missing a reducer resp
 Object {
   "appMessages": Object {
     "cloudigradeMismatch": false,
-    "query": Object {},
   },
+  "query": Object {},
 }
 `;
 
@@ -31,8 +31,8 @@ exports[`AppMessagesSelectors should populate data from the in memory cache: cac
 Object {
   "appMessages": Object {
     "cloudigradeMismatch": true,
-    "query": Object {},
   },
+  "query": Object {},
 }
 `;
 
@@ -40,8 +40,8 @@ exports[`AppMessagesSelectors should populate data from the in memory cache: cac
 Object {
   "appMessages": Object {
     "cloudigradeMismatch": true,
-    "query": Object {},
   },
+  "query": Object {},
 }
 `;
 
@@ -49,8 +49,8 @@ exports[`AppMessagesSelectors should populate data from the in memory cache: cac
 Object {
   "appMessages": Object {
     "cloudigradeMismatch": true,
-    "query": Object {},
   },
+  "query": Object {},
 }
 `;
 
@@ -58,8 +58,8 @@ exports[`AppMessagesSelectors should populate data on a product ID when the api 
 Object {
   "appMessages": Object {
     "cloudigradeMismatch": false,
-    "query": Object {},
   },
+  "query": Object {},
 }
 `;
 

--- a/src/redux/selectors/appMessagesSelectors.js
+++ b/src/redux/selectors/appMessagesSelectors.js
@@ -44,8 +44,7 @@ const queryFilter = (state, props = {}) => ({
 const selector = createSelector([statePropsFilter, queryFilter], (data, query = {}) => {
   const { viewId = null, productId = null, report = {} } = data || {};
   const appMessages = {
-    cloudigradeMismatch: false,
-    query
+    cloudigradeMismatch: false
   };
 
   const cache = (viewId && productId && selectorCache.data[`${viewId}_${productId}`]) || undefined;
@@ -70,7 +69,7 @@ const selector = createSelector([statePropsFilter, queryFilter], (data, query = 
     };
   }
 
-  return { appMessages };
+  return { appMessages, query };
 });
 
 /**


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(bannerMessages): issues/541 state updates for filters
   * appMessagesSelectors, adjust pass query, update components
   * productView, var/props name consistency

### Notes
- Flipping to the functional component for Satellite product views highlighted a long running issue created when #518 was implemented. The intention of #518 was to update the query based on the primary toolbar queries, which currently encompasses both `Usage` and `SLA`. The other products, RHEL and OpenShift, were able to "work around" this issue because of the component structure and prop drilling, exposing a functional Satellite component, and removing aspects of the prop drill causes the Satellite product view to not update the banner message like the other products... this PR corrects that issue.
- @ntkathole 

<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. log in with the appropriate account that has mismatched Cloud Meter data within the last 2 days based on the appropriate SLA or Usage filter selection
1. navigate to Subs Watch Satellite product view
   - `/subscriptions/satellite-sw/all`
1. confirm the banner displays upon selecting the related SLA or Usage filter

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Relates #518 #511 #502
#541 