### PR TITLE
fix(toolbarFieldDisplayName): issues/569 maxlength char limit

### DIFF
--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldDisplayName.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldDisplayName.test.js.snap
@@ -59,6 +59,7 @@ exports[`ToolbarFieldDisplayName Component should render a non-connected compone
     id={null}
     isDisabled={false}
     isReadOnly={false}
+    maxLength={255}
     name={null}
     onChange={[Function]}
     onClear={[Function]}

--- a/src/components/toolbar/toolbarFieldDisplayName.js
+++ b/src/components/toolbar/toolbarFieldDisplayName.js
@@ -98,6 +98,7 @@ const ToolbarFieldDisplayName = ({ value, t, viewId }) => {
     <InputGroup>
       <TextInput
         aria-label={t('curiosity-toolbar.placeholder', { context: 'displayName' })}
+        maxLength={255}
         onChange={onChange}
         onClear={onClear}
         onKeyUp={onKeyUp}

--- a/src/redux/common/__tests__/__snapshots__/reduxHelpers.test.js.snap
+++ b/src/redux/common/__tests__/__snapshots__/reduxHelpers.test.js.snap
@@ -202,6 +202,8 @@ exports[`ReduxHelpers should get a http status from a service call response: sta
 
 exports[`ReduxHelpers should get a message from a service call response: 3XX fallback message 1`] = `"Multiple Choices"`;
 
+exports[`ReduxHelpers should get a message from a service call response: 3XX, 304 fallback message 1`] = `"Not modified"`;
+
 exports[`ReduxHelpers should get a message from a service call response: 4XX fallback message 1`] = `"Bad Request"`;
 
 exports[`ReduxHelpers should get a message from a service call response: 5XX fallback message 1`] = `"Internal Server Error"`;

--- a/src/redux/common/__tests__/reduxHelpers.test.js
+++ b/src/redux/common/__tests__/reduxHelpers.test.js
@@ -148,6 +148,16 @@ describe('ReduxHelpers', () => {
     expect(
       reduxHelpers.getMessageFromResults({
         response: {
+          data: { lorem: 'ipsum', dolor: 'sit' },
+          status: 304,
+          statusText: 'Not modified'
+        }
+      })
+    ).toMatchSnapshot('3XX, 304 fallback message');
+
+    expect(
+      reduxHelpers.getMessageFromResults({
+        response: {
           status: 400,
           statusText: 'Bad Request'
         }

--- a/src/redux/common/reduxHelpers.js
+++ b/src/redux/common/reduxHelpers.js
@@ -192,7 +192,7 @@ const getMessageFromResults = results => {
     return `${formattedStatus}${dataResponse}`.trim();
   }
 
-  if (status >= 300 && _isPlainObject(dataResponse)) {
+  if (status >= 400 && _isPlainObject(dataResponse)) {
     return `${formattedStatus}${JSON.stringify(dataResponse)}`;
   }
 


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(toolbarFieldDisplayName): issues/569 maxlength char limit
- fix(reduxHelpers): response message status range 
   * reduxHelpers, avoid caching large responses on emulated 304

### Notes
- applies a 255 maxlength character attribute to display name
   - appears that parts of the platform name search also need to have this limit implemented, environment checked, ci
   - Currently there is no design associated with "field validation" on the toolbar beyond toast notifications, @bclarhk @rblackbu 
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. login, navigate to Subs Watch, attempt to enter beyond 255 characters into the display name field. The field will automatically truncate the number of characters entered

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
#569 