### PR TITLE
fix(toolbarFieldDisplayName): issues/476 search-as-type

### DIFF
--- a/src/components/form/__tests__/__snapshots__/textInput.test.js.snap
+++ b/src/components/form/__tests__/__snapshots__/textInput.test.js.snap
@@ -61,6 +61,21 @@ Object {
 }
 `;
 
+exports[`TextInput Component should return an emulated onClear event on escape with type search: emulated event, esc, type search 1`] = `
+Object {
+  "checked": undefined,
+  "currentTarget": Object {
+    "value": "",
+  },
+  "id": undefined,
+  "keyCode": 27,
+  "name": undefined,
+  "persist": [Function],
+  "target": Object {},
+  "value": "",
+}
+`;
+
 exports[`TextInput Component should return an emulated onClear event on escape: emulated event, esc 1`] = `
 Object {
   "checked": undefined,

--- a/src/components/form/__tests__/textInput.test.js
+++ b/src/components/form/__tests__/textInput.test.js
@@ -51,12 +51,27 @@ describe('TextInput Component', () => {
 
   it('should return an emulated onClear event on escape', done => {
     const props = {
+      value: 'lorem ipsum'
+    };
+
+    props.onClear = event => {
+      expect(event).toMatchSnapshot('emulated event, esc');
+      done();
+    };
+
+    const component = shallow(<TextInput {...props} />);
+    const mockEvent = { keyCode: 27, currentTarget: { value: '' }, persist: helpers.noop };
+    component.instance().onKeyUp(mockEvent);
+  });
+
+  it('should return an emulated onClear event on escape with type search', done => {
+    const props = {
       value: 'lorem ipsum',
       type: 'search'
     };
 
     props.onClear = event => {
-      expect(event).toMatchSnapshot('emulated event, esc');
+      expect(event).toMatchSnapshot('emulated event, esc, type search');
       done();
     };
 

--- a/src/components/form/textInput.js
+++ b/src/components/form/textInput.js
@@ -25,13 +25,22 @@ class TextInput extends React.Component {
    * @param {object} event
    */
   onKeyUp = event => {
-    const { onClear, onKeyUp } = this.props;
+    const { onClear, onKeyUp, type } = this.props;
     const { currentTarget, keyCode } = event;
+    const clonedEvent = { ...event };
 
     onKeyUp(createMockEvent(event, true));
 
-    if (keyCode === 27 && currentTarget.value === '') {
-      onClear(createMockEvent(event));
+    if (keyCode === 27) {
+      if (type === 'search' && currentTarget.value === '') {
+        onClear(createMockEvent(clonedEvent));
+      } else {
+        this.setState({ updatedValue: '' }, () => {
+          onClear(
+            createMockEvent({ ...clonedEvent, ...{ currentTarget: { ...clonedEvent.currentTarget, value: '' } } })
+          );
+        });
+      }
     }
   };
 

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -397,10 +397,6 @@ Array [
         "key": "curiosity-toolbar.placeholder",
         "match": "t('curiosity-toolbar.placeholder', { context: 'displayName' })",
       },
-      Object {
-        "key": "curiosity-toolbar.button",
-        "match": "t('curiosity-toolbar.button', { context: 'displayName' })",
-      },
     ],
   },
   Object {
@@ -551,10 +547,6 @@ Array [
   Object {
     "file": "./src/components/rhelView/rhelView.js",
     "key": "curiosity-inventory.label",
-  },
-  Object {
-    "file": "./src/components/toolbar/toolbarFieldDisplayName.js",
-    "key": "curiosity-toolbar.button",
   },
   Object {
     "file": "./src/components/toolbar/toolbarFieldGranularity.js",

--- a/src/components/i18n/__tests__/i18n.test.js
+++ b/src/components/i18n/__tests__/i18n.test.js
@@ -8,11 +8,6 @@ import { I18n, translate, translateComponent } from '../i18n';
 import enLocales from '../../../../public/locales/en-US';
 
 /**
- * Emulate for component render checks
- */
-jest.mock('i18next');
-
-/**
  * Get translation keys.
  *
  * @param {object} params

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldDisplayName.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldDisplayName.test.js.snap
@@ -55,7 +55,8 @@ exports[`ToolbarFieldDisplayName Component should render a non-connected compone
 <InputGroup>
   <TextInput
     aria-label="t(curiosity-toolbar.placeholder, {\\"context\\":\\"displayName\\"})"
-    className=""
+    className="curiosity-input__display-name"
+    iconVariant="search"
     id={null}
     isDisabled={false}
     isReadOnly={false}
@@ -66,19 +67,8 @@ exports[`ToolbarFieldDisplayName Component should render a non-connected compone
     onKeyUp={[Function]}
     onMouseUp={[Function]}
     placeholder="t(curiosity-toolbar.placeholder, {\\"context\\":\\"displayName\\"})"
-    type="search"
+    type="text"
     value={null}
   />
-  <Button
-    aria-label="t(curiosity-toolbar.button, {\\"context\\":\\"displayName\\"})"
-    onClick={[Function]}
-    variant="control"
-  >
-    <SearchIcon
-      color="currentColor"
-      noVerticalAlign={false}
-      size="sm"
-    />
-  </Button>
 </InputGroup>
 `;

--- a/src/components/toolbar/__tests__/toolbarFieldDisplayName.test.js
+++ b/src/components/toolbar/__tests__/toolbarFieldDisplayName.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
-import { Button } from '@patternfly/react-core';
 import { ToolbarFieldDisplayName } from '../toolbarFieldDisplayName';
 import { store } from '../../../redux/store';
 import { TextInput } from '../../form/textInput';
@@ -31,7 +30,7 @@ describe('ToolbarFieldDisplayName Component', () => {
 
     const component = shallow(<ToolbarFieldDisplayName {...props} />);
     component.find(TextInput).simulate('change', { value: 'dolor sit' });
-    component.find(Button).simulate('click');
+    component.find(TextInput).simulate('keyUp', {});
 
     expect(mockDispatch.mock.calls).toMatchSnapshot('dispatch display name');
   });

--- a/src/services/rhsmServices.js
+++ b/src/services/rhsmServices.js
@@ -53,7 +53,7 @@ const getApiVersion = (options = {}) => {
 };
 
 /**
- * @apiMock {DelayResponse} 2000
+ * @apiMock {DelayResponse} 250
  * @apiMock {RandomSuccess}
  * @api {get} /api/rhsm-subscriptions/v1/tally/products/:product_id Get RHSM graph data
  * @apiDescription Retrieve graph data.
@@ -957,7 +957,7 @@ const getGraphCapacity = (id, params = {}, options = {}) => {
 };
 
 /**
- * @apiMock {DelayResponse} 1000
+ * @apiMock {DelayResponse} 500
  * @api {get} /api/rhsm-subscriptions/v1/hosts/products/:product_id Get RHSM hosts/systems table/inventory data
  * @apiDescription Retrieve hosts/systems table/inventory data.
  *
@@ -1154,7 +1154,7 @@ const getHostsInventory = (id, params = {}, options = {}) => {
 };
 
 /**
- * @apiMock {DelayResponse} 2000
+ * @apiMock {DelayResponse} 250
  * @api {get} /api/rhsm-subscriptions/v1/hosts/:hypervisor_uuid/guests Get RHSM hosts/systems table/inventory guests data
  * @apiDescription Retrieve hosts/systems table/inventory guests data.
  *
@@ -1282,7 +1282,7 @@ const getHostsInventoryGuests = (id, params = {}, options = {}) => {
 };
 
 /**
- * @apiMock {DelayResponse} 1000
+ * @apiMock {DelayResponse} 250
  * @api {get} /api/rhsm-subscriptions/v1/subscriptions/products/:product_id Get RHSM subscriptions table/inventory data
  * @apiDescription Retrieve subscriptions table/inventory data.
  *

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -6,6 +6,11 @@ import * as pfReactChartComponents from '@patternfly/react-charts';
 configure({ adapter: new Adapter() });
 
 /**
+ * Emulate for component checks
+ */
+jest.mock('lodash/debounce', () => jest.fn);
+
+/**
  * FixMe: Use of arrow functions removes the usefulness of the "displayName" when shallow rendering
  * PF appears to have updated components with a "displayName". Because we potentially have internal
  * components, and other resources that are missing "displayName". We're leaving this test helper active.

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -8,6 +8,7 @@ configure({ adapter: new Adapter() });
 /**
  * Emulate for component checks
  */
+jest.mock('i18next');
 jest.mock('lodash/debounce', () => jest.fn);
 
 /**

--- a/src/styles/_form.scss
+++ b/src/styles/_form.scss
@@ -7,3 +7,10 @@
     display: none;
   }
 }
+
+.curiosity-input__display-name {
+  &.pf-c-form-control.pf-m-search {
+    padding-left: var(--pf-global--spacer--sm);
+    background-position: var(--pf-c-form-control--m-icon--BackgroundPositionX) var(--pf-c-form-control--m-icon--BackgroundPositionY);
+  }
+}

--- a/tests/__snapshots__/code.test.js.snap
+++ b/tests/__snapshots__/code.test.js.snap
@@ -4,6 +4,6 @@ exports[`General code checks should only have specific console.[warn|log|info|er
 Array [
   "redux/common/reduxHelpers.js:250:    console.error(\`Error: Property \${prop} does not exist within the passed state.\`, state);",
   "redux/common/reduxHelpers.js:254:    console.warn(\`Warning: Property \${prop} does not exist within the passed initialState.\`, initialState);",
-  "setupTests.js:61:  console.error = (message, ...args) => {",
+  "setupTests.js:66:  console.error = (message, ...args) => {",
 ]
 `;

--- a/tests/__snapshots__/code.test.js.snap
+++ b/tests/__snapshots__/code.test.js.snap
@@ -4,6 +4,6 @@ exports[`General code checks should only have specific console.[warn|log|info|er
 Array [
   "redux/common/reduxHelpers.js:250:    console.error(\`Error: Property \${prop} does not exist within the passed state.\`, state);",
   "redux/common/reduxHelpers.js:254:    console.warn(\`Warning: Property \${prop} does not exist within the passed initialState.\`, initialState);",
-  "setupTests.js:66:  console.error = (message, ...args) => {",
+  "setupTests.js:67:  console.error = (message, ...args) => {",
 ]
 `;


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(toolbarFieldDisplayName): issues/476 search-as-type
   * testing, mock for debounce
   * textInput, emulate onClear for non-search types
   * toolbarFieldDisplayName, debounce on keyup, style adjustment
   * rhsmServices, adjust emulated API delays to reflect environments
- fix(i18n): consistent mock emulation

### Notes
- applies a "search as you type" to the display name filter
- we use a similar 800 ms delay on the input field similar to the platform's inventory search. what this means is that there is a noticeable delay after typing. we can attempt to adjust this timer, but the current adjustment makes allowances for persons typing at varying speeds
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. login, navigate to Subs Watch, confirm the display name search field functions

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
#### Updated
![Screen Shot 2021-02-02 at 12 28 57 PM](https://user-images.githubusercontent.com/3761375/106638792-3ec8c200-6552-11eb-8487-0dd44a5a59af.png)


#### Current
![Screen Shot 2021-02-02 at 12 30 18 PM](https://user-images.githubusercontent.com/3761375/106638965-70da2400-6552-11eb-93fa-cb3a347fa01f.png)



## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
#476 