### PR TITLE
fix(pageHeader): ent-3533 check consistent html for Pendo

### DIFF
--- a/config/cspell.config.json
+++ b/config/cspell.config.json
@@ -31,6 +31,7 @@
     "openshift",
     "optin",
     "patternfly",
+    "pendo",
     "perpage",
     "qe's",
     "random'ish",

--- a/src/components/pageLayout/__tests__/__snapshots__/pageHeader.test.js.snap
+++ b/src/components/pageLayout/__tests__/__snapshots__/pageHeader.test.js.snap
@@ -190,6 +190,50 @@ exports[`PageHeader Component should render the subtitle when viewId is provided
 </PageHeader>
 `;
 
+exports[`PageHeader Component should render the tour button when includeTour is provided: consistent html output for Pendo CSS selector 1`] = `
+<section
+  class="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
+  widget-type="InsightsPageHeader"
+>
+  <div
+    class="pf-l-flex pf-m-justify-content-space-between-on-sm"
+  >
+    <div
+      class=""
+    >
+      <h1
+        class="pf-c-title pf-m-2xl pf-u-mb-sm"
+        widget-type="InsightsPageHeaderTitle"
+      >
+         lorem 
+      </h1>
+    </div>
+    <div
+      class=""
+    >
+      <button
+        aria-disabled="false"
+        class="pf-c-button pf-m-link pf-m-inline uxui-curiosity__button-tour"
+        data-ouia-component-id="OUIA-Generated-Button-link-1"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe="true"
+        type="button"
+      >
+        <span
+          class="pf-c-label pf-m-blue"
+        >
+          <span
+            class="pf-c-label__content"
+          >
+            t(curiosity-optin.buttonTour)
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</section>
+`;
+
 exports[`PageHeader Component should render the tour button when includeTour is provided: with tour button 1`] = `
 <PageHeader
   includeTour={true}

--- a/src/components/pageLayout/__tests__/pageHeader.test.js
+++ b/src/components/pageLayout/__tests__/pageHeader.test.js
@@ -26,5 +26,6 @@ describe('PageHeader Component', () => {
   it('should render the tour button when includeTour is provided', () => {
     const component = mount(<PageHeader includeTour>lorem</PageHeader>);
     expect(component).toMatchSnapshot('with tour button');
+    expect(component.render()).toMatchSnapshot('consistent html output for Pendo CSS selector');
   });
 });


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(pageHeader): ent-3533 check consistent html for Pendo

### Notes
- renders the html output into a snapshot for future PF and platform component update diffs. Pendo is affected by a sensitive CCS selector regardless of having a dedicated CSS class name.
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm all tests pass
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-3533