### PR TITLE
feat(pageColumns): ent-3504 allow page columns

### DIFF
--- a/src/components/pageLayout/__tests__/__snapshots__/pageColumns.test.js.snap
+++ b/src/components/pageLayout/__tests__/__snapshots__/pageColumns.test.js.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PageColumns Component should render a basic component: basic 1`] = `
+<PageColumns
+  className="lorem"
+>
+  <Flex
+    className="curiosity-page-columns lorem"
+    spaceItems={
+      Object {
+        "sm": "spaceItemsNone",
+      }
+    }
+  >
+    <div
+      className="pf-l-flex pf-m-space-items-none-on-sm curiosity-page-columns lorem"
+    >
+      <FlexItem
+        className="curiosity-page-columns-column"
+        grow={
+          Object {
+            "sm": "grow",
+          }
+        }
+        key="generatedid-"
+        style={
+          Object {
+            "flexBasis": 0,
+          }
+        }
+      >
+        <div
+          className="pf-m-grow-on-sm curiosity-page-columns-column"
+          style={
+            Object {
+              "flexBasis": 0,
+            }
+          }
+        >
+          <span
+            className="dolor"
+            key=".0"
+          >
+            lorem
+          </span>
+        </div>
+      </FlexItem>
+      <FlexItem
+        className="curiosity-page-columns-column"
+        grow={
+          Object {
+            "sm": "grow",
+          }
+        }
+        key="generatedid-"
+        style={
+          Object {
+            "flexBasis": 0,
+          }
+        }
+      >
+        <div
+          className="pf-m-grow-on-sm curiosity-page-columns-column"
+          style={
+            Object {
+              "flexBasis": 0,
+            }
+          }
+        >
+          <span
+            className="sit"
+            key=".1"
+          >
+            ipsum
+          </span>
+        </div>
+      </FlexItem>
+    </div>
+  </Flex>
+</PageColumns>
+`;

--- a/src/components/pageLayout/__tests__/pageColumns.test.js
+++ b/src/components/pageLayout/__tests__/pageColumns.test.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { PageColumns } from '../pageColumns';
+
+describe('PageColumns Component', () => {
+  it('should render a basic component', () => {
+    const props = {
+      className: 'lorem'
+    };
+    const component = mount(
+      <PageColumns {...props}>
+        <span className="dolor">lorem</span>
+        <span className="sit">ipsum</span>
+      </PageColumns>
+    );
+
+    expect(component).toMatchSnapshot('basic');
+  });
+});

--- a/src/components/pageLayout/pageColumns.js
+++ b/src/components/pageLayout/pageColumns.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Flex, FlexItem } from '@patternfly/react-core';
+import { helpers } from '../../common';
+
+/**
+ * Render page columns based on children.
+ *
+ * @param {object} props
+ * @param {Node} props.children
+ * @param {string} props.className
+ * @returns {Node}
+ */
+const PageColumns = ({ children, className }) => (
+  <Flex spaceItems={{ sm: 'spaceItemsNone' }} className={`curiosity-page-columns ${className}`}>
+    {React.Children.toArray(children)
+      .filter(child => React.isValidElement(child))
+      .map(child => (
+        <FlexItem
+          key={helpers.generateId()}
+          style={{ flexBasis: 0 }}
+          grow={{ sm: 'grow' }}
+          className="curiosity-page-columns-column"
+        >
+          {child}
+        </FlexItem>
+      ))}
+  </Flex>
+);
+
+/**
+ * Prop types.
+ *
+ * @type {{children: Node, className: string}}
+ */
+PageColumns.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string
+};
+
+/**
+ * Default props.
+ *
+ * @type {{className: string}}
+ */
+PageColumns.defaultProps = {
+  className: ''
+};
+
+export { PageColumns as default, PageColumns };

--- a/src/styles/_page-layout.scss
+++ b/src/styles/_page-layout.scss
@@ -1,4 +1,16 @@
-.curiosity, .curiosity-page-messages, .curiosity-page-toolbar, .curiosity-page-section {
+.curiosity,
+.curiosity-page-messages,
+.curiosity-page-toolbar,
+.curiosity-page-section,
+.curiosity-page-columns,
+.curiosity-page-columns-column {
   background-color: var(--pf-global--BackgroundColor--100);
   min-width: 320px;
+}
+
+.curiosity-page-columns-column {
+  margin-left: var(--pf-global--spacer--sm);
+  margin-right: var(--pf-global--spacer--sm);
+  padding-left: var(--pf-global--spacer--sm);
+  padding-right: var(--pf-global--spacer--sm)
 }


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- feat(pageColumns): ent-3504 allow page columns

### Notes
- base page layout for columns
- no visible changes
- **this PR only provides the base component, it does not activate the 2 column view in OpenShift**
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests complete without error

<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
#### Initial testing with existing OpenShift components to confirm functionality
![Untitled](https://user-images.githubusercontent.com/3761375/107570298-54279700-6bb7-11eb-89db-14ad67402341.png)

![Screen Shot 2021-02-10 at 3 16 17 PM](https://user-images.githubusercontent.com/3761375/107570367-6acdee00-6bb7-11eb-8e17-1e91e66bc769.png)



## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-3504