### PR TITLE
fix(toolbar): ent-3490 clear filters copy updated

### DIFF
--- a/public/locales/en-US.json
+++ b/public/locales/en-US.json
@@ -92,6 +92,7 @@
     "category": "Filter by",
     "category_sla": "SLA",
     "category_usage": "Usage",
+    "clearFilters": "Reset filters",
     "button_displayName": "Search button for name",
     "placeholder": "Filter by",
     "placeholder_displayName": "Filter by name",

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -377,6 +377,10 @@ Array [
         "match": "t('curiosity-toolbar.placeholder', { context: field })",
       },
       Object {
+        "key": "curiosity-toolbar.clearFilters",
+        "match": "t('curiosity-toolbar.clearFilters')",
+      },
+      Object {
         "key": "curiosity-toolbar.category",
         "match": "t('curiosity-toolbar.category')",
       },

--- a/src/components/toolbar/__tests__/__snapshots__/toolbar.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbar.test.js.snap
@@ -515,6 +515,7 @@ exports[`Toolbar Component should render a non-connected component: non-connecte
 <Toolbar
   className="curiosity-toolbar pf-m-toggle-group-container ins-c-primary-toolbar"
   clearAllFilters={[Function]}
+  clearFiltersButtonText="t(curiosity-toolbar.clearFilters)"
   collapseListedFiltersBreakpoint="sm"
   id="curiosity-toolbar"
 >
@@ -667,6 +668,7 @@ exports[`Toolbar Component should render filters when props are populated: props
 <Toolbar
   className="curiosity-toolbar pf-m-toggle-group-container ins-c-primary-toolbar"
   clearAllFilters={[Function]}
+  clearFiltersButtonText="t(curiosity-toolbar.clearFilters)"
   collapseListedFiltersBreakpoint="sm"
   id="curiosity-toolbar"
 >
@@ -827,6 +829,7 @@ exports[`Toolbar Component should render specific filters when the filterOptions
 <Toolbar
   className="curiosity-toolbar pf-m-toggle-group-container ins-c-primary-toolbar"
   clearAllFilters={[Function]}
+  clearFiltersButtonText="t(curiosity-toolbar.clearFilters)"
   collapseListedFiltersBreakpoint="sm"
   id="curiosity-toolbar"
 >

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -242,6 +242,7 @@ class Toolbar extends React.Component {
         className="curiosity-toolbar pf-m-toggle-group-container ins-c-primary-toolbar"
         collapseListedFiltersBreakpoint="sm"
         clearAllFilters={this.onClear}
+        clearFiltersButtonText={t('curiosity-toolbar.clearFilters')}
       >
         <ToolbarContent>
           <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="md">


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(toolbar): ent-3490 clear filters copy updated

### Notes
- Updates copy for toolbar filters clearing from "Clear all filters" towards "Reset filters"
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. login, navigate to Subs Watch, select a filter from the primary toolbar. the copy should now read "Reset filters"

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screen Shot 2021-02-10 at 4 58 52 PM](https://user-images.githubusercontent.com/3761375/107578077-4aa32c80-6bc1-11eb-9452-a0828f3a039f.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
#573
ent-3490