### PR TITLE
chore(build): patch local dev run, without proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,18 @@
   "insights": {
     "appname": "subscriptions"
   },
-  "browserslist": [],
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
   "jest": {
     "coverageThreshold": {
       "global": {

--- a/scripts/dev.chrome.sh
+++ b/scripts/dev.chrome.sh
@@ -91,6 +91,13 @@ buildChrome()
     printf "\n${GREEN}Build SUCCESS${NOCOLOR}"
   fi
 
+  if [ ! -d $DIR_REPO/build ]; then
+    printf "\n${YELLOW}Build output failed, confirm recent chroming updates didn't alter the output directory.${NOCOLOR}\n"
+    exit 0
+  else
+    printf "\n${GREEN}Build SUCCESS${NOCOLOR}"
+  fi
+
   printf "\n${YELLOW}Setting up local chrome ...${NOCOLOR}"
 
   mkdir -p $DIR_PUBLIC

--- a/src/components/guestsList/__tests__/__snapshots__/guestsList.test.js.snap
+++ b/src/components/guestsList/__tests__/__snapshots__/guestsList.test.js.snap
@@ -99,6 +99,7 @@ exports[`GuestsList Component should handle multiple display states: paged pendi
             Object {
               "borders": false,
               "colCount": 1,
+              "colWidth": Array [],
               "rowCount": 0,
               "variant": "compact",
             }

--- a/src/components/guestsList/guestsList.js
+++ b/src/components/guestsList/guestsList.js
@@ -93,6 +93,7 @@ class GuestsList extends React.Component {
           tableProps={{
             borders: false,
             colCount: filterGuestsData?.length || (listData?.[0] && Object.keys(listData[0]).length) || 1,
+            colWidth: (filterGuestsData?.length && filterGuestsData.map(({ cellWidth }) => cellWidth)) || [],
             rowCount: 0,
             variant: TableVariant.compact
           }}

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -184,7 +184,7 @@ class Table extends React.Component {
       }
 
       cells.forEach(cell => {
-        if (cell.title !== undefined) {
+        if (cell?.title !== undefined) {
           const { title, ...settings } = cell;
           rowObj.cells.push({ title, ...settings });
         } else {
@@ -196,7 +196,7 @@ class Table extends React.Component {
     });
 
     columnHeaders.forEach((columnHeader, index) => {
-      if (columnHeader.title !== undefined) {
+      if (columnHeader?.title !== undefined) {
         const { onSort, sortActive, sortDirection, title, ...settings } = columnHeader;
         const tempColumnHeader = {
           title,
@@ -339,8 +339,9 @@ Table.propTypes = {
       cells: PropTypes.arrayOf(
         PropTypes.oneOfType([
           PropTypes.node,
+          PropTypes.instanceOf(Date),
           PropTypes.shape({
-            title: PropTypes.node.isRequired
+            title: PropTypes.oneOfType([PropTypes.node, PropTypes.instanceOf(Date)]).isRequired
           })
         ])
       ),


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(guestsList): column widths for loader
- fix(table): additional cell content type
- chore(build): patch local dev run, without proxy 
   * build, chrome2 setup melts if browserslist malformed in package.json

### Notes
- Chrome 2 updates are affected by a malformed package.json "browserlist" prop. We checked in the base browserlist setup from CRA and added an error message if the Chrome 2 build fails.
   - In the future the Chrome may stop working entirely with our current setup. In that event we have a fallback solution of just using placeholder code along with the base platform styles
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests pass

<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->

### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. confirm integration tests pass


## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Ongoing