### PR TITLE
fix(productViewOpenShiftContainer): ent-3607 config date range

### DIFF
--- a/src/components/productView/__tests__/__snapshots__/productViewOpenShiftContainer.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productViewOpenShiftContainer.test.js.snap
@@ -247,8 +247,8 @@ exports[`ProductViewOpenShiftContainer Component should render a non-connected c
         productLabel="OpenShift Metric"
         query={
           Object {
-            "beginning": "2019-06-20T00:00:00.000Z",
-            "ending": "2019-07-20T23:59:59.999Z",
+            "beginning": "2019-07-01T00:00:00.000Z",
+            "ending": "2019-07-31T23:59:59.999Z",
             "granularity": "daily",
           }
         }

--- a/src/components/productView/productViewOpenShiftContainer.js
+++ b/src/components/productView/productViewOpenShiftContainer.js
@@ -399,10 +399,8 @@ ProductViewOpenShiftContainer.defaultProps = {
       query: {},
       graphTallyQuery: {
         [RHSM_API_QUERY_TYPES.GRANULARITY]: GRANULARITY_TYPES.DAILY,
-        [RHSM_API_QUERY_TYPES.START_DATE]: dateHelpers
-          .getRangedDateTime(GRANULARITY_TYPES.DAILY)
-          .startDate.toISOString(),
-        [RHSM_API_QUERY_TYPES.END_DATE]: dateHelpers.getRangedDateTime(GRANULARITY_TYPES.DAILY).endDate.toISOString()
+        [RHSM_API_QUERY_TYPES.START_DATE]: dateHelpers.getRangedMonthDateTime('current').value.startDate.toISOString(),
+        [RHSM_API_QUERY_TYPES.END_DATE]: dateHelpers.getRangedMonthDateTime('current').value.endDate.toISOString()
       },
       inventoryHostsQuery: {
         [RHSM_API_QUERY_TYPES.SORT]: RHSM_API_QUERY_SORT_TYPES.LAST_SEEN,


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(productViewOpenShiftContainer): ent-3607 config date range

### Notes
- Minor configuration update towards the correct date range. We double checked OpenShift dedicated as well, that config appears to be correct.
   - https://github.com/RedHatInsights/curiosity-frontend/blob/ci/src/components/productView/productViewOpenShiftDedicated.js#L66-L67
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. navigate towards `/subscriptions/openshift-sw` and confirm the date range is correct for the flexible graph x axis ticks

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
#### After
![Screen Shot 2021-03-03 at 2 00 55 PM](https://user-images.githubusercontent.com/3761375/109857674-f07a1200-7c28-11eb-86a8-941de17b0eef.png)

#### Before
  
![Screen Shot 2021-03-03 at 2 02 19 PM](https://user-images.githubusercontent.com/3761375/109857841-1bfcfc80-7c29-11eb-8be1-1f173ca5a8ab.png)



## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-3607