### PR TITLE
fix(chartArea): ent-3601 tooltip hover and clipping, x-axis

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
   },
   "dependencies": {
     "@patternfly/patternfly": "4.80.3",
-    "@patternfly/react-charts": "6.13.8",
+    "@patternfly/react-charts": "6.14.2",
     "@patternfly/react-core": "4.90.2",
     "@patternfly/react-icons": "4.8.4",
     "@patternfly/react-styles": "4.7.29",
@@ -146,7 +146,7 @@
     "redux-promise-middleware": "^6.1.2",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
-    "victory-create-container": "^35.4.8"
+    "victory-create-container": "^35.4.10"
   },
   "devDependencies": {
     "apidoc-mock": "^3.0.3",

--- a/src/components/chartArea/__tests__/__snapshots__/chartArea.test.js.snap
+++ b/src/components/chartArea/__tests__/__snapshots__/chartArea.test.js.snap
@@ -866,13 +866,31 @@ exports[`ChartArea Component should handle custom chart tooltips: custom tooltip
             "y": -10,
           }
         }
-        labelComponent={<FlyoutComponent />}
+        labelComponent={
+          <ChartCursorTooltip
+            flyout={
+              <ChartCursorFlyout
+                pathComponent={<Path />}
+                role="presentation"
+                shapeRendering="auto"
+              />
+            }
+            flyoutStyle={
+              Object {
+                "fill": "transparent",
+              }
+            }
+            labelComponent={<FlyoutComponent />}
+            renderInPortal={true}
+          />
+        }
         labels={[Function]}
+        mouseFollowTooltips={true}
         portalComponent={<Portal />}
         portalZIndex={99}
         responsive={true}
         role="img"
-        voronoiPadding={60}
+        voronoiPadding={50}
       />
     }
     domain={
@@ -1094,13 +1112,31 @@ exports[`ChartArea Component should handle custom chart tooltips: renderTooltip:
       "y": -10,
     }
   }
-  labelComponent={<FlyoutComponent />}
+  labelComponent={
+    <ChartCursorTooltip
+      flyout={
+        <ChartCursorFlyout
+          pathComponent={<Path />}
+          role="presentation"
+          shapeRendering="auto"
+        />
+      }
+      flyoutStyle={
+        Object {
+          "fill": "transparent",
+        }
+      }
+      labelComponent={<FlyoutComponent />}
+      renderInPortal={true}
+    />
+  }
   labels={[Function]}
+  mouseFollowTooltips={true}
   portalComponent={<Portal />}
   portalZIndex={99}
   responsive={true}
   role="img"
-  voronoiPadding={60}
+  voronoiPadding={50}
 />
 `;
 

--- a/src/redux/middleware/actionRecordMiddleware.js
+++ b/src/redux/middleware/actionRecordMiddleware.js
@@ -35,11 +35,11 @@ const sanitizeData = ({ type, payload, ...action }) => {
     const updatedPayload = {
       ...payload,
       data: {
-        ...payload.data,
+        ...payload?.data,
         user: {
-          ...payload.data.user,
+          ...payload?.data?.user,
           [platformApiTypes.PLATFORM_API_RESPONSE_USER_IDENTITY]: {
-            ...payload.data.user[platformApiTypes.PLATFORM_API_RESPONSE_USER_IDENTITY],
+            ...payload?.data?.user[platformApiTypes.PLATFORM_API_RESPONSE_USER_IDENTITY],
             [platformApiTypes.PLATFORM_API_RESPONSE_USER_IDENTITY_TYPES.USER]: {}
           }
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1634,14 +1634,19 @@
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.80.3.tgz#fa979eb34f14bbc705f8354b15c3c81df1d36340"
   integrity sha512-YLUk4L6iCBXql92YP6zHg0FdlnEkd5/3V+uz/A3UoBuuDdEoyDpx4M/Tf56R7IXmYiRaHE1mToJHPDYypIlnmw==
 
-"@patternfly/react-charts@6.13.8":
-  version "6.13.8"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-charts/-/react-charts-6.13.8.tgz#a5105c75dc23806d40eb7fb80bc1a1092bbfab25"
-  integrity sha512-IEQBtUCNMAA6JnLBcWj4RUQ5a80n/uBw3a8FzeL5x90Fp6pR6nc5wVjVH8WcO7minw3QMRwxtcu5itW/v+Ga0g==
+"@patternfly/patternfly@4.87.3":
+  version "4.87.3"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.87.3.tgz#eb2e9b22aa8f6f106580e7451bf204a06cb9949e"
+  integrity sha512-hDNMPa7B1zKD8LWFZO4SS5hC/N+yvuci2sAn8HJd+EIbAvbMAUkRsyZ0/XO3BG3RVtpSlgq7q8x1pAHC/FTFuA==
+
+"@patternfly/react-charts@6.14.2":
+  version "6.14.2"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-charts/-/react-charts-6.14.2.tgz#20d5b98af4504c2e2e38e4836088dfa54fb324cf"
+  integrity sha512-QfO+wJRCj6Wof/18KWpY0XmZKXhv4y2QsmLtjMoGtZbbjHtEUwXA+lYc4agj9k+CEpm+3xXR2GOoNSwaSZN3RA==
   dependencies:
-    "@patternfly/patternfly" "4.80.3"
-    "@patternfly/react-styles" "^4.7.29"
-    "@patternfly/react-tokens" "^4.9.26"
+    "@patternfly/patternfly" "4.87.3"
+    "@patternfly/react-styles" "^4.8.2"
+    "@patternfly/react-tokens" "^4.10.2"
     hoist-non-react-statics "^3.3.0"
     lodash "^4.17.19"
     tslib "1.13.0"
@@ -1684,6 +1689,11 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.7.29.tgz#a11cc8a9d4c4a0ac9c6bc298a47477473eaa430c"
   integrity sha512-eAO9xh2+IQHIBCihmwNuDVCeAWhGXIhbUNJEwZzvevYuH4Pnl0X8YaWoYmM2ZfL8ZdagRTLvjGW+hoZGkUyCBQ==
 
+"@patternfly/react-styles@^4.8.2":
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.8.2.tgz#4796a77b658541d75d616e2e2a00fc5d7ec42bc7"
+  integrity sha512-JLVZTUYa8LIyASLvfiAgByLgNcg+OPkuXSh8Za5KdjqrBaNVQ3Wlul+oWQGwlGjbq7KSiyDg1oWemxOuLJH1VQ==
+
 "@patternfly/react-table@4.20.15":
   version "4.20.15"
   resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-4.20.15.tgz#f40ea3eb47b7d05dbae2e7d7668209fe08c111af"
@@ -1701,6 +1711,11 @@
   version "4.9.26"
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.9.26.tgz#320759bceef71ff752d79acea278c6cdada9e51f"
   integrity sha512-SSbY6BaUb7ycXhvdBNk2yzOlteRUHnchHSYPBFvhUk+SqpsjQ7j13/ZTok6pcHXrcj3FaL9f82/ep4eTXPzmWg==
+
+"@patternfly/react-tokens@^4.10.2":
+  version "4.10.2"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.10.2.tgz#fd0054379ac81c8490b901b5b8fb408263ce91fe"
+  integrity sha512-/G1MENPxVY7X9UUuieO79yfjJ3g6KjBUBsBQVKOQplCxuvcRCF1MpmQKAxfg9Yb804MbPY+IVzVD3c4u9S3Iww==
 
 "@pmmmwh/react-refresh-webpack-plugin@0.4.3":
   version "0.4.3"
@@ -13975,6 +13990,16 @@ victory-bar@^35.4.4:
     prop-types "^15.5.8"
     victory-core "^35.4.8"
 
+victory-brush-container@^35.4.10:
+  version "35.4.10"
+  resolved "https://registry.yarnpkg.com/victory-brush-container/-/victory-brush-container-35.4.10.tgz#fc3a312c2168a63e73d258b346dd414c78900504"
+  integrity sha512-egEeYYRXMNYZiX/MqATc+Uywp8bKzirTpkHFBKdywG/7USzKVAtcfdwL+y2ppNj9OXKFK0+WqIcr3U2FXDJeTA==
+  dependencies:
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+    victory-core "^35.4.10"
+
 victory-brush-container@^35.4.8:
   version "35.4.8"
   resolved "https://registry.yarnpkg.com/victory-brush-container/-/victory-brush-container-35.4.8.tgz#de8004a19c03c9a9b00e00052f682e7dad0b6892"
@@ -13998,6 +14023,20 @@ victory-chart@^35.4.4:
     victory-polar-axis "^35.4.8"
     victory-shared-events "^35.4.8"
 
+victory-core@^35.4.10:
+  version "35.4.10"
+  resolved "https://registry.yarnpkg.com/victory-core/-/victory-core-35.4.10.tgz#dea8a7a0a763bbbc2db25d5a32a64508a19b7576"
+  integrity sha512-OlAnFsl0WHIPMqSIKzVZKNEieHgN9HjSiYbfVWxJxX3FkzH8pP7m5HPSkYZW8v1tm31p392ib9GhE2GmJee2Gg==
+  dependencies:
+    d3-ease "^1.0.0"
+    d3-interpolate "^1.1.1"
+    d3-scale "^1.0.0"
+    d3-shape "^1.2.0"
+    d3-timer "^1.0.0"
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+
 victory-core@^35.4.4, victory-core@^35.4.8:
   version "35.4.8"
   resolved "https://registry.yarnpkg.com/victory-core/-/victory-core-35.4.8.tgz#c62a6a28b8aa8ad6bbff36e7fbe8945215ddfaf0"
@@ -14012,7 +14051,20 @@ victory-core@^35.4.4, victory-core@^35.4.8:
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
 
-victory-create-container@^35.4.4, victory-create-container@^35.4.8:
+victory-create-container@^35.4.10:
+  version "35.4.10"
+  resolved "https://registry.yarnpkg.com/victory-create-container/-/victory-create-container-35.4.10.tgz#7fbbc068fac2e6960bf1abf1bcedb0be931b381b"
+  integrity sha512-9EVZLLvtE193mrZ1yRgGUnC/9UCYVO372XC5d6Wzy2PcRKhtXvi6WFnD/793PwsmlEaY70WWzg5tCgcTOZUrfw==
+  dependencies:
+    lodash "^4.17.19"
+    victory-brush-container "^35.4.10"
+    victory-core "^35.4.10"
+    victory-cursor-container "^35.4.10"
+    victory-selection-container "^35.4.10"
+    victory-voronoi-container "^35.4.10"
+    victory-zoom-container "^35.4.10"
+
+victory-create-container@^35.4.4:
   version "35.4.8"
   resolved "https://registry.yarnpkg.com/victory-create-container/-/victory-create-container-35.4.8.tgz#d0f5d2b6d664bc29399899db15c01e59b56a3b43"
   integrity sha512-1qYRi+npvvWurDjdrC2IthxvTWeKcP1nw8bw2OpL+oG21k/mQBrPGT2GtAmUBGp3e8LDr6BwrCx32FGd01PWYw==
@@ -14024,6 +14076,15 @@ victory-create-container@^35.4.4, victory-create-container@^35.4.8:
     victory-selection-container "^35.4.8"
     victory-voronoi-container "^35.4.8"
     victory-zoom-container "^35.4.8"
+
+victory-cursor-container@^35.4.10:
+  version "35.4.10"
+  resolved "https://registry.yarnpkg.com/victory-cursor-container/-/victory-cursor-container-35.4.10.tgz#b0d4ffa3ad743899daf12bbe5ef7074095321f20"
+  integrity sha512-s6j71Tr6lpCmE0ygY3XaehoSVfsrbXLTcgBn5hP3A4DLAClwzLXcu4pRI8xFsqhrqYGuHw1rd8x32xQ1H1vDDA==
+  dependencies:
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    victory-core "^35.4.10"
 
 victory-cursor-container@^35.4.8:
   version "35.4.8"
@@ -14092,6 +14153,15 @@ victory-scatter@^35.4.4:
     prop-types "^15.5.8"
     victory-core "^35.4.8"
 
+victory-selection-container@^35.4.10:
+  version "35.4.10"
+  resolved "https://registry.yarnpkg.com/victory-selection-container/-/victory-selection-container-35.4.10.tgz#f3994fe9b121ecb6a9144f9fdedcdd14cb95479e"
+  integrity sha512-cnbA3zHav82w6FpZ5z5yIYL9KSfTN5Fx4Gae0IklMPwDbJKtS1V/1VycrHlpzb2L4QyenDQkchFenvAZzMtcNQ==
+  dependencies:
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    victory-core "^35.4.10"
+
 victory-selection-container@^35.4.8:
   version "35.4.8"
   resolved "https://registry.yarnpkg.com/victory-selection-container/-/victory-selection-container-35.4.8.tgz#e356700230b731b015a0f3a8820e7c62b86c6ab7"
@@ -14123,6 +14193,15 @@ victory-stack@^35.4.4:
     victory-core "^35.4.8"
     victory-shared-events "^35.4.8"
 
+victory-tooltip@^35.4.10:
+  version "35.4.10"
+  resolved "https://registry.yarnpkg.com/victory-tooltip/-/victory-tooltip-35.4.10.tgz#2c8bd60cfca8b8ff46d971d936392b99600a4a3f"
+  integrity sha512-hXAtyBbhCgoikSe5CVplpDGqPm0SAHn0XRf4Qvdax9wXZLGDNYbmJrakPS/pi1bh0F0X8r3ruVmw3c9TyNCROw==
+  dependencies:
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    victory-core "^35.4.10"
+
 victory-tooltip@^35.4.4, victory-tooltip@^35.4.8:
   version "35.4.8"
   resolved "https://registry.yarnpkg.com/victory-tooltip/-/victory-tooltip-35.4.8.tgz#0d29276d3717cfbf500dd3d571c2087cd7c7a4c8"
@@ -14131,6 +14210,18 @@ victory-tooltip@^35.4.4, victory-tooltip@^35.4.8:
     lodash "^4.17.19"
     prop-types "^15.5.8"
     victory-core "^35.4.8"
+
+victory-voronoi-container@^35.4.10:
+  version "35.4.10"
+  resolved "https://registry.yarnpkg.com/victory-voronoi-container/-/victory-voronoi-container-35.4.10.tgz#93fae011b0ffad317268a71f8ff813b4cb3c0c7a"
+  integrity sha512-WbY0qZtgP3PAdGC7i7k0URbrSLvOMhfAxwocEgXaaj/s97ATqrUnxH5b1Euut6uFmwa4XBIFv6kLPUcKzsO8LQ==
+  dependencies:
+    delaunay-find "0.0.5"
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+    victory-core "^35.4.10"
+    victory-tooltip "^35.4.10"
 
 victory-voronoi-container@^35.4.4, victory-voronoi-container@^35.4.8:
   version "35.4.8"
@@ -14143,6 +14234,15 @@ victory-voronoi-container@^35.4.4, victory-voronoi-container@^35.4.8:
     react-fast-compare "^2.0.0"
     victory-core "^35.4.8"
     victory-tooltip "^35.4.8"
+
+victory-zoom-container@^35.4.10:
+  version "35.4.10"
+  resolved "https://registry.yarnpkg.com/victory-zoom-container/-/victory-zoom-container-35.4.10.tgz#8c3537dda5c350ceabbea70dc45f65449a34cc07"
+  integrity sha512-TUXoWp55xgH2GgQ/j3UcSrx1ZeIrTUh8tnX7BOjvlif6pMH9uEw+LH3vRv4TGzq2azb5UtQvmNMv+bMHLyQGYw==
+  dependencies:
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    victory-core "^35.4.10"
 
 victory-zoom-container@^35.4.4, victory-zoom-container@^35.4.8:
   version "35.4.8"


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(chartArea): ent-3601 tooltip hover and clipping, x-axis
- fix(actionRecordMiddleware): optional chaining for testing

### Notes
- we switched to utilizing more of the PF React wrappers for Victory. 
   - There is some quirky behavior around the x coordinate positioning for the tooltip that becomes more noticeable on the dual graph displays. The quirk appears as more space between the vertical cursor line and the left aligned tooltip in the far right graph. We'll need to address this issue in the future, but for now the benefits of non-clipped tooltips takes priority
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. navigate towards the new OpenShift Container Platform layout at `/beta/subscriptions/openshift-sw` and confirm the graph display
   - ...for the flexible capacity, is able to show the last day of the month tooltip, ent-3606
   - ... for all graphs, across all products, the tooltip flash/jump is no longer present, ent-3601
   - ... for all graphs, across all products, that tooltips no longer get clipped in general, but instead reposition themselves
      - the platform's left navigation may still cause issues due to the way the CSS is handled for its show/hide ability. Cost Management handles it by hooking into a platform navigation event. However upon looking at said event and the upcoming Chrome updates said event has the appearance of being "retired"

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
relates ent-3606
ent-3601