### PR TITLE
fix(toolbarFieldGranularity): ent-3644 reset inventory offset

### DIFF
--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldGranularity.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldGranularity.test.js.snap
@@ -30,6 +30,9 @@ Array [
   Array [
     Array [
       Object {
+        "type": "SET_QUERY_CLEAR_INVENTORY_LIST",
+      },
+      Object {
         "granularity": "daily",
         "type": "SET_QUERY_RHSM_granularity",
         "viewId": "toolbarFieldGranularity",

--- a/src/components/toolbar/toolbarFieldGranularity.js
+++ b/src/components/toolbar/toolbarFieldGranularity.js
@@ -47,6 +47,9 @@ const ToolbarFieldGranularity = ({ options, t, value, viewId }) => {
     const { startDate, endDate } = dateHelpers.getRangedDateTime(event.value);
     store.dispatch([
       {
+        type: reduxTypes.query.SET_QUERY_CLEAR_INVENTORY_LIST
+      },
+      {
         type: reduxTypes.query.SET_QUERY_RHSM_TYPES[RHSM_API_QUERY_TYPES.GRANULARITY],
         viewId,
         [RHSM_API_QUERY_TYPES.GRANULARITY]: event.value


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(toolbarFieldGranularity): ent-3644 reset inventory offset

### Notes
- resets inventory paging on granularity selection
- this reset will apply to all granularity selections across all products
- initial fix, still evaluating how best to capture this test, appearing as e2e or integration would be better suited since we do technically capture the state updates for inventory in unit tests already
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm the inventory paging/offset is reset to the initial offset, in this case `0`.

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-3644