### PR TITLE
fix(viewReducer): ent-3644 apply productId to inventory reset

### DIFF
--- a/src/components/inventoryList/__tests__/__snapshots__/inventoryList.test.js.snap
+++ b/src/components/inventoryList/__tests__/__snapshots__/inventoryList.test.js.snap
@@ -231,6 +231,7 @@ exports[`InventoryList Component should handle variations in data: filtered data
     >
       <CardHeaderMain>
         <ToolbarFieldDisplayName
+          productId="lorem"
           t={[Function]}
           value={null}
           viewId="inventoryList"
@@ -350,6 +351,7 @@ exports[`InventoryList Component should handle variations in data: variable data
     >
       <CardHeaderMain>
         <ToolbarFieldDisplayName
+          productId="lorem"
           t={[Function]}
           value={null}
           viewId="inventoryList"
@@ -465,6 +467,7 @@ exports[`InventoryList Component should render a non-connected component: non-co
     >
       <CardHeaderMain>
         <ToolbarFieldDisplayName
+          productId="lorem"
           t={[Function]}
           value={null}
           viewId="inventoryList"

--- a/src/components/inventoryList/inventoryList.js
+++ b/src/components/inventoryList/inventoryList.js
@@ -197,6 +197,7 @@ class InventoryList extends React.Component {
       listData,
       pending,
       perPageDefault,
+      productId,
       query,
       t,
       viewId
@@ -228,7 +229,7 @@ class InventoryList extends React.Component {
         <MinHeight key="headerMinHeight" updateOnContent>
           <CardHeader className={(error && 'hidden') || ''} aria-hidden={error || false}>
             <CardHeaderMain>
-              <ToolbarFieldDisplayName viewId={viewId} />
+              <ToolbarFieldDisplayName productId={productId} viewId={viewId} />
             </CardHeaderMain>
             <CardActions className={(!itemCount && 'transparent') || ''} aria-hidden={!itemCount || false}>
               <Pagination

--- a/src/components/productView/__tests__/__snapshots__/productView.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productView.test.js.snap
@@ -205,6 +205,7 @@ exports[`ProductView Component should render a non-connected component: non-conn
             },
           ]
         }
+        productId="lorem ipsum"
         t={[Function]}
         value="daily"
         viewId="dolor sit"

--- a/src/components/productView/__tests__/__snapshots__/productViewOpenShiftContainer.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productViewOpenShiftContainer.test.js.snap
@@ -81,6 +81,7 @@ exports[`ProductViewOpenShiftContainer Component should render a non-connected c
               },
             ]
           }
+          productId="OpenShift Container Platform"
           t={[Function]}
           value="cores"
           viewId="viewOpenShift"
@@ -110,6 +111,7 @@ exports[`ProductViewOpenShiftContainer Component should render a non-connected c
               },
             ]
           }
+          productId="OpenShift Container Platform"
           t={[Function]}
           value="daily"
           viewId="viewOpenShift"
@@ -373,6 +375,7 @@ exports[`ProductViewOpenShiftContainer Component should render a non-connected c
               },
             ]
           }
+          productId="OpenShift-metrics"
           t={[Function]}
           value="t(curiosity-toolbar.granularityRange, {\\"context\\":\\"current\\"})"
           viewId="viewOpenShiftMetric"

--- a/src/components/productView/__tests__/__snapshots__/productViewOpenShiftDedicated.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productViewOpenShiftDedicated.test.js.snap
@@ -171,6 +171,7 @@ exports[`ProductViewOpenShiftDedicated Component should render a non-connected c
           },
         ]
       }
+      productId="lorem ipsum"
       t={[Function]}
       value="t(curiosity-toolbar.granularityRange, {\\"context\\":\\"current\\"})"
       viewId="toolbarFieldRangeGranularity"

--- a/src/components/productView/productView.js
+++ b/src/components/productView/productView.js
@@ -105,6 +105,7 @@ const ProductView = ({ productConfig, routeDetail, t, toolbarGraph, toolbarProdu
           {(React.isValidElement(toolbarGraph) && toolbarGraph) ||
             (toolbarGraph !== false && (
               <ToolbarFieldGranularity
+                productId={productId}
                 viewId={viewId}
                 value={initialGraphTallyQuery[RHSM_API_QUERY_TYPES.GRANULARITY]}
               />

--- a/src/components/productView/productViewOpenShiftContainer.js
+++ b/src/components/productView/productViewOpenShiftContainer.js
@@ -109,12 +109,18 @@ const ProductViewOpenShiftContainer = ({ productConfig, routeDetail, t }) => {
             productLabel={productLabel}
           >
             {productId === RHSM_API_PATH_ID_TYPES.OPENSHIFT && uomFilter && (
-              <ToolbarFieldUom value={uomFilter} viewId={viewId} />
+              <ToolbarFieldUom productId={productId} value={uomFilter} viewId={viewId} />
             )}
             {productId === RHSM_API_PATH_ID_TYPES.OPENSHIFT && (
-              <ToolbarFieldGranularity value={graphTallyQuery[RHSM_API_QUERY_TYPES.GRANULARITY]} viewId={viewId} />
+              <ToolbarFieldGranularity
+                productId={productId}
+                value={graphTallyQuery[RHSM_API_QUERY_TYPES.GRANULARITY]}
+                viewId={viewId}
+              />
             )}
-            {productId === RHSM_API_PATH_ID_TYPES.OPENSHIFT_METRICS && <ToolbarFieldRangedMonthly viewId={viewId} />}
+            {productId === RHSM_API_PATH_ID_TYPES.OPENSHIFT_METRICS && (
+              <ToolbarFieldRangedMonthly productId={productId} viewId={viewId} />
+            )}
           </GraphCard>
         </PageSection>
         <PageSection>

--- a/src/components/productView/productViewOpenShiftDedicated.js
+++ b/src/components/productView/productViewOpenShiftDedicated.js
@@ -26,7 +26,7 @@ import { ToolbarFieldRangedMonthly } from '../toolbar/toolbarFieldRangedMonthly'
  * @returns {Node}
  */
 const ProductViewOpenShiftDedicated = ({ productConfig, routeDetail }) => {
-  const { viewParameter: viewId } = routeDetail;
+  const { pathParameter: productId, viewParameter: viewId } = routeDetail;
   const { [RHSM_API_QUERY_TYPES.START_DATE]: startDate } = productConfig.graphTallyQuery;
 
   return (
@@ -34,7 +34,7 @@ const ProductViewOpenShiftDedicated = ({ productConfig, routeDetail }) => {
       routeDetail={routeDetail}
       productConfig={productConfig}
       toolbarProduct={false}
-      toolbarGraph={<ToolbarFieldRangedMonthly value={startDate} viewId={viewId} />}
+      toolbarGraph={<ToolbarFieldRangedMonthly productId={productId} value={startDate} viewId={viewId} />}
     />
   );
 };

--- a/src/components/toolbar/__tests__/__snapshots__/toolbar.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbar.test.js.snap
@@ -27,6 +27,7 @@ Object {
       },
       Object {
         "type": "SET_QUERY_RESET_INVENTORY_LIST",
+        "viewId": "lorem",
       },
     ],
   ],

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldDisplayName.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldDisplayName.test.js.snap
@@ -6,6 +6,7 @@ Array [
     Array [
       Object {
         "type": "SET_QUERY_CLEAR_INVENTORY_LIST",
+        "viewId": "toolbarFieldDisplayName",
       },
       Object {
         "display_name_contains": null,
@@ -23,6 +24,7 @@ Array [
     Array [
       Object {
         "type": "SET_QUERY_CLEAR_INVENTORY_LIST",
+        "viewId": "toolbarFieldDisplayName",
       },
       Object {
         "display_name_contains": "dolor sit",
@@ -40,6 +42,7 @@ Array [
     Array [
       Object {
         "type": "SET_QUERY_CLEAR_INVENTORY_LIST",
+        "viewId": "toolbarFieldDisplayName",
       },
       Object {
         "display_name_contains": "dolor sit",

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldGranularity.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldGranularity.test.js.snap
@@ -31,6 +31,7 @@ Array [
     Array [
       Object {
         "type": "SET_QUERY_CLEAR_INVENTORY_LIST",
+        "viewId": "toolbarFieldGranularity",
       },
       Object {
         "granularity": "daily",

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldRangedMonthly.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldRangedMonthly.test.js.snap
@@ -248,6 +248,10 @@ Array [
   Array [
     Array [
       Object {
+        "type": "SET_QUERY_CLEAR_INVENTORY_LIST",
+        "viewId": "toolbarFieldRangeGranularity",
+      },
+      Object {
         "granularity": "daily",
         "type": "SET_QUERY_RHSM_granularity",
         "viewId": "toolbarFieldRangeGranularity",

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldUom.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldUom.test.js.snap
@@ -21,6 +21,7 @@ Array [
     Array [
       Object {
         "type": "SET_QUERY_RESET_INVENTORY_LIST",
+        "viewId": "toolbarFieldUom",
       },
       Object {
         "type": "SET_QUERY_RHSM_uom",

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -137,7 +137,7 @@ class Toolbar extends React.Component {
    * @param {boolean} resetPage
    */
   setDispatch(actions, resetPage = false) {
-    const { viewId } = this.props;
+    const { productId, viewId } = this.props;
     const updatedActions = ((Array.isArray(actions) && actions) || [actions]).map(({ type, data }) => ({
       type,
       viewId,
@@ -146,7 +146,8 @@ class Toolbar extends React.Component {
 
     if (resetPage) {
       updatedActions.push({
-        type: reduxTypes.query.SET_QUERY_RESET_INVENTORY_LIST
+        type: reduxTypes.query.SET_QUERY_RESET_INVENTORY_LIST,
+        viewId: productId
       });
     }
 
@@ -271,8 +272,8 @@ class Toolbar extends React.Component {
 /**
  * Prop types
  *
- * @type {{viewId: string, t: Function, activeFilters: Set, hardFilterReset: boolean, query: object,
- *     currentFilter: string, isDisabled: boolean, Array}}
+ * @type {{viewId: string, productId: string, t: Function, activeFilters: Set, hardFilterReset: boolean, query: object,
+ *     currentFilter: string, isDisabled: boolean, filterOptions: Array}}
  */
 Toolbar.propTypes = {
   query: PropTypes.shape({
@@ -290,6 +291,7 @@ Toolbar.propTypes = {
   ),
   hardFilterReset: PropTypes.bool,
   isDisabled: PropTypes.bool,
+  productId: PropTypes.string,
   t: PropTypes.func,
   viewId: PropTypes.string
 };
@@ -297,7 +299,7 @@ Toolbar.propTypes = {
 /**
  * Default props.
  *
- * @type {{viewId: string, t: translate, activeFilters: Set, hardFilterReset: boolean, query: object,
+ * @type {{viewId: string, productId: string, t: translate, activeFilters: Set, hardFilterReset: boolean, query: object,
  *     currentFilter: string, isDisabled: boolean, filterOptions: Array}}
  */
 Toolbar.defaultProps = {
@@ -317,6 +319,7 @@ Toolbar.defaultProps = {
   ],
   hardFilterReset: false,
   isDisabled: helpers.UI_DISABLED_TOOLBAR,
+  productId: 'toolbar',
   t: translate,
   viewId: 'toolbar'
 };

--- a/src/components/toolbar/toolbarFieldDisplayName.js
+++ b/src/components/toolbar/toolbarFieldDisplayName.js
@@ -17,12 +17,13 @@ import { translate } from '../i18n/i18n';
  * @fires onClear
  * @fires onKeyUp
  * @param {object} props
- * @param {string} props.value
+ * @param {string} props.productId
  * @param {Function} props.t
+ * @param {string} props.value
  * @param {string} props.viewId
  * @returns {Node}
  */
-const ToolbarFieldDisplayName = ({ value, t, viewId }) => {
+const ToolbarFieldDisplayName = ({ productId, t, value, viewId }) => {
   const currentValue = useSelector(
     ({ view }) => view.inventoryHostsQuery?.[viewId]?.[RHSM_API_QUERY_TYPES.DISPLAY_NAME],
     value
@@ -38,7 +39,8 @@ const ToolbarFieldDisplayName = ({ value, t, viewId }) => {
   const onSubmit = submitValue =>
     store.dispatch([
       {
-        type: reduxTypes.query.SET_QUERY_CLEAR_INVENTORY_LIST
+        type: reduxTypes.query.SET_QUERY_CLEAR_INVENTORY_LIST,
+        viewId: productId
       },
       {
         type: reduxTypes.query.SET_QUERY_RHSM_HOSTS_INVENTORY_TYPES[RHSM_API_QUERY_TYPES.DISPLAY_NAME],
@@ -60,7 +62,8 @@ const ToolbarFieldDisplayName = ({ value, t, viewId }) => {
 
     store.dispatch([
       {
-        type: reduxTypes.query.SET_QUERY_CLEAR_INVENTORY_LIST
+        type: reduxTypes.query.SET_QUERY_CLEAR_INVENTORY_LIST,
+        viewId: productId
       },
       {
         type: reduxTypes.query.SET_QUERY_RHSM_HOSTS_INVENTORY_TYPES[RHSM_API_QUERY_TYPES.DISPLAY_NAME],
@@ -113,9 +116,10 @@ const ToolbarFieldDisplayName = ({ value, t, viewId }) => {
 /**
  * Prop types.
  *
- * @type {{viewId: string, t: Function, value: string}}
+ * @type {{viewId: string, productId: string, t: Function, value: string}}
  */
 ToolbarFieldDisplayName.propTypes = {
+  productId: PropTypes.string,
   t: PropTypes.func,
   value: PropTypes.string,
   viewId: PropTypes.string
@@ -124,9 +128,10 @@ ToolbarFieldDisplayName.propTypes = {
 /**
  * Default props.
  *
- * @type {{viewId: string, t: translate, value: string}}
+ * @type {{viewId: string, productId: string, t: translate, value: string}}
  */
 ToolbarFieldDisplayName.defaultProps = {
+  productId: 'toolbarFieldDisplayName',
   t: translate,
   value: null,
   viewId: 'toolbarFieldDisplayName'

--- a/src/components/toolbar/toolbarFieldGranularity.js
+++ b/src/components/toolbar/toolbarFieldGranularity.js
@@ -23,12 +23,13 @@ const toolbarFieldOptions = Object.values(FIELD_TYPES).map(type => ({
  * @fires onSelect
  * @param {object} props
  * @param {Array} props.options
+ * @param {string} props.productId
  * @param {Function} props.t
  * @param {string} props.value
  * @param {string} props.viewId
  * @returns {Node}
  */
-const ToolbarFieldGranularity = ({ options, t, value, viewId }) => {
+const ToolbarFieldGranularity = ({ options, productId, t, value, viewId }) => {
   const updatedValue = useSelector(
     ({ view }) => view.graphTallyQuery?.[viewId]?.[RHSM_API_QUERY_TYPES.GRANULARITY],
     value
@@ -47,7 +48,8 @@ const ToolbarFieldGranularity = ({ options, t, value, viewId }) => {
     const { startDate, endDate } = dateHelpers.getRangedDateTime(event.value);
     store.dispatch([
       {
-        type: reduxTypes.query.SET_QUERY_CLEAR_INVENTORY_LIST
+        type: reduxTypes.query.SET_QUERY_CLEAR_INVENTORY_LIST,
+        viewId: productId
       },
       {
         type: reduxTypes.query.SET_QUERY_RHSM_TYPES[RHSM_API_QUERY_TYPES.GRANULARITY],
@@ -81,7 +83,7 @@ const ToolbarFieldGranularity = ({ options, t, value, viewId }) => {
 /**
  * Prop types.
  *
- * @type {{viewId: string, t: Function, options: Array, value: string}}
+ * @type {{viewId: string, productId: string, t: Function, options: Array, value: string}}
  */
 ToolbarFieldGranularity.propTypes = {
   options: PropTypes.arrayOf(
@@ -91,6 +93,7 @@ ToolbarFieldGranularity.propTypes = {
       selected: PropTypes.bool
     })
   ),
+  productId: PropTypes.string,
   t: PropTypes.func,
   value: PropTypes.oneOf([...Object.values(FIELD_TYPES)]),
   viewId: PropTypes.string
@@ -99,10 +102,11 @@ ToolbarFieldGranularity.propTypes = {
 /**
  * Default props.
  *
- * @type {{viewId: string, t: translate, options: Array, value: string}}
+ * @type {{viewId: string, productId: string, t: translate, options: Array, value: string}}
  */
 ToolbarFieldGranularity.defaultProps = {
   options: toolbarFieldOptions,
+  productId: 'toolbarFieldGranularity',
   t: translate,
   value: FIELD_TYPES.DAILY,
   viewId: 'toolbarFieldGranularity'

--- a/src/components/toolbar/toolbarFieldRangedMonthly.js
+++ b/src/components/toolbar/toolbarFieldRangedMonthly.js
@@ -22,12 +22,13 @@ const toolbarFieldOptions = dateHelpers.getRangedMonthDateTime().listDateTimeRan
  * @fires onSelect
  * @param {object} props
  * @param {Array} props.options
+ * @param {string} props.productId
  * @param {Function} props.t
  * @param {string} props.value
  * @param {string} props.viewId
  * @returns {Node}
  */
-const ToolbarFieldRangedMonthly = ({ options, t, value, viewId }) => {
+const ToolbarFieldRangedMonthly = ({ options, productId, t, value, viewId }) => {
   const updatedValue = useSelector(({ view }) => view.query?.[viewId]?.[RHSM_API_QUERY_TYPES.START_DATE], value);
 
   const updatedOptions = options.map(option => ({
@@ -45,6 +46,10 @@ const ToolbarFieldRangedMonthly = ({ options, t, value, viewId }) => {
   const onSelect = event => {
     const { startDate, endDate } = event.value;
     store.dispatch([
+      {
+        type: reduxTypes.query.SET_QUERY_CLEAR_INVENTORY_LIST,
+        viewId: productId
+      },
       {
         type: reduxTypes.query.SET_QUERY_RHSM_TYPES[RHSM_API_QUERY_TYPES.GRANULARITY],
         viewId,
@@ -77,7 +82,7 @@ const ToolbarFieldRangedMonthly = ({ options, t, value, viewId }) => {
 /**
  * Prop types.
  *
- * @type {{viewId: string, t: Function, options: Array, value: string}}
+ * @type {{viewId: string, productId: string, t: Function, options: Array, value: string}}
  */
 ToolbarFieldRangedMonthly.propTypes = {
   options: PropTypes.arrayOf(
@@ -87,6 +92,7 @@ ToolbarFieldRangedMonthly.propTypes = {
       selected: PropTypes.bool
     })
   ),
+  productId: PropTypes.string,
   t: PropTypes.func,
   value: PropTypes.string,
   viewId: PropTypes.string
@@ -95,10 +101,11 @@ ToolbarFieldRangedMonthly.propTypes = {
 /**
  * Default props.
  *
- * @type {{viewId: string, t: translate, options: Array, value: string}}
+ * @type {{viewId: string, productId: string, t: translate, options: Array, value: string}}
  */
 ToolbarFieldRangedMonthly.defaultProps = {
   options: toolbarFieldOptions,
+  productId: 'toolbarFieldRangeGranularity',
   t: translate,
   value: translate('curiosity-toolbar.granularityRange', { context: 'current' }),
   viewId: 'toolbarFieldRangeGranularity'

--- a/src/components/toolbar/toolbarFieldUom.js
+++ b/src/components/toolbar/toolbarFieldUom.js
@@ -22,12 +22,13 @@ const toolbarFieldOptions = Object.values(FIELD_TYPES).map(type => ({
  * @fires onSelect
  * @param {object} props
  * @param {Array} props.options
+ * @param {string} props.productId
  * @param {Function} props.t
  * @param {string} props.value
  * @param {string} props.viewId
  * @returns {Node}
  */
-const ToolbarFieldUom = ({ options, t, value, viewId }) => {
+const ToolbarFieldUom = ({ options, productId, t, value, viewId }) => {
   const updatedValue = useSelector(({ view }) => view.query?.[viewId]?.[RHSM_API_QUERY_TYPES.UOM], value);
 
   const updatedOptions = options.map(option => ({ ...option, selected: option.value === updatedValue }));
@@ -42,7 +43,8 @@ const ToolbarFieldUom = ({ options, t, value, viewId }) => {
   const onSelect = event =>
     store.dispatch([
       {
-        type: reduxTypes.query.SET_QUERY_RESET_INVENTORY_LIST
+        type: reduxTypes.query.SET_QUERY_RESET_INVENTORY_LIST,
+        viewId: productId
       },
       {
         type: reduxTypes.query.SET_QUERY_RHSM_TYPES[RHSM_API_QUERY_TYPES.UOM],
@@ -65,7 +67,7 @@ const ToolbarFieldUom = ({ options, t, value, viewId }) => {
 /**
  * Prop types.
  *
- * @type {{viewId: string, t: Function, options: Array, value: string}}
+ * @type {{viewId: string, productId: string, t: Function, options: Array, value: string}}
  */
 ToolbarFieldUom.propTypes = {
   options: PropTypes.arrayOf(
@@ -75,6 +77,7 @@ ToolbarFieldUom.propTypes = {
       selected: PropTypes.bool
     })
   ),
+  productId: PropTypes.string,
   t: PropTypes.func,
   value: PropTypes.oneOf([...Object.values(FIELD_TYPES)]),
   viewId: PropTypes.string
@@ -83,10 +86,11 @@ ToolbarFieldUom.propTypes = {
 /**
  * Default props.
  *
- * @type {{viewId: string, t: translate, options: Array, value: string}}
+ * @type {{viewId: string, productId: string, t: translate, options: Array, value: string}}
  */
 ToolbarFieldUom.defaultProps = {
   options: toolbarFieldOptions,
+  productId: 'toolbarFieldUom',
   t: translate,
   value: FIELD_TYPES.CORES,
   viewId: 'toolbarFieldUom'

--- a/src/redux/reducers/viewReducer.js
+++ b/src/redux/reducers/viewReducer.js
@@ -27,29 +27,25 @@ const initialState = {
 const viewReducer = (state = initialState, action) => {
   switch (action.type) {
     case reduxTypes.query.SET_QUERY_RESET_INVENTORY_LIST:
-      const updateResetQueries = query => {
-        const tempQuery = {};
+      const updateResetQueries = (query = {}, id) => {
+        const updatedQuery = { ...query[id] };
 
-        Object.entries(query).forEach(([key, value]) => {
-          tempQuery[key] = { ...value };
+        if (typeof updatedQuery[RHSM_API_QUERY_TYPES.OFFSET] === 'number') {
+          updatedQuery[RHSM_API_QUERY_TYPES.OFFSET] = 0;
+        }
 
-          if (typeof value[RHSM_API_QUERY_TYPES.OFFSET] === 'number') {
-            tempQuery[key][RHSM_API_QUERY_TYPES.OFFSET] = 0;
-          }
+        delete updatedQuery[RHSM_API_QUERY_TYPES.DIRECTION];
+        delete updatedQuery[RHSM_API_QUERY_TYPES.SORT];
 
-          delete tempQuery[key][RHSM_API_QUERY_TYPES.DIRECTION];
-          delete tempQuery[key][RHSM_API_QUERY_TYPES.SORT];
-        });
-
-        return tempQuery;
+        return { ...query, ...{ [id]: updatedQuery } };
       };
 
       return reduxHelpers.setStateProp(
         null,
         {
           ...state,
-          inventoryHostsQuery: updateResetQueries(state.inventoryHostsQuery),
-          inventorySubscriptionsQuery: updateResetQueries(state.inventorySubscriptionsQuery)
+          inventoryHostsQuery: updateResetQueries(state.inventoryHostsQuery, action.viewId),
+          inventorySubscriptionsQuery: updateResetQueries(state.inventorySubscriptionsQuery, action.viewId)
         },
         {
           state,
@@ -57,26 +53,22 @@ const viewReducer = (state = initialState, action) => {
         }
       );
     case reduxTypes.query.SET_QUERY_CLEAR_INVENTORY_LIST:
-      const updateClearQueries = query => {
-        const tempQuery = {};
+      const updateClearQueries = (query = {}, id) => {
+        const updatedQuery = { ...query[id] };
 
-        Object.entries(query).forEach(([key, value]) => {
-          tempQuery[key] = { ...value };
+        if (typeof updatedQuery[RHSM_API_QUERY_TYPES.OFFSET] === 'number') {
+          updatedQuery[RHSM_API_QUERY_TYPES.OFFSET] = 0;
+        }
 
-          if (typeof value[RHSM_API_QUERY_TYPES.OFFSET] === 'number') {
-            tempQuery[key][RHSM_API_QUERY_TYPES.OFFSET] = 0;
-          }
-        });
-
-        return tempQuery;
+        return { ...query, ...{ [id]: updatedQuery } };
       };
 
       return reduxHelpers.setStateProp(
         null,
         {
           ...state,
-          inventoryHostsQuery: updateClearQueries(state.inventoryHostsQuery),
-          inventorySubscriptionsQuery: updateClearQueries(state.inventorySubscriptionsQuery)
+          inventoryHostsQuery: updateClearQueries(state.inventoryHostsQuery, action.viewId),
+          inventorySubscriptionsQuery: updateClearQueries(state.inventorySubscriptionsQuery, action.viewId)
         },
         {
           state,


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(viewReducer): ent-3644 apply productId to inventory reset
   * inventoryList, productId to displayName
   * productView, OpenShiftContainer,Dedicated, productId to granularity
   * toolbar, productId to inventory reset
   * toolbarFieldDisplayName, granularity, ranged, uom, apply productId
   * viewReducer, restructure reset to apply specific productId

### Notes
- It appears we discovered a flaw/bug in how we reset the inventory displays. Originally we didn't have dual column displays so we would generically reset the inventory per view, this encompassed all productIds under a viewId. The dual column display created a scenario where we can't/shouldn't generically reset all inventory states. Now **when an inventory reset needs to happen it can no longer be generic, it has to be specific**. 
- There are two solutions we've reviewed
    - **THIS PR** Go with what we know works and apply prop drilling for the `productId` alongside the `viewId`, or
    - #606 Apply a unique solution by retaining the `viewId` and creating a dictionary for each viewId that relates all possible `productIds` contained under a `viewId` enabling us to reset state on those specific productIds
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm the inventory paging/offset is reset to the initial offset, in this case 0.
    - all products and their facets should be confirmed

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-3644