### PR TITLE
fix(routerHelpers): ent-3541 rhcloud-12690 alt for search, hash

### DIFF
--- a/config/spandx.config.js
+++ b/config/spandx.config.js
@@ -26,6 +26,24 @@ module.exports = {
     '/beta/subscriptions': {
       host: `https://${localhost}:5001`
     },
+    '/insights/subscriptions': {
+      host: `https://${localhost}:5001`
+    },
+    '/beta/insights/subscriptions': {
+      host: `https://${localhost}:5001`
+    },
+    '/rhel/subscriptions': {
+      host: `https://${localhost}:5001`
+    },
+    '/beta/rhel/subscriptions': {
+      host: `https://${localhost}:5001`
+    },
+    '/openshift/subscriptions': {
+      host: `https://${localhost}:5001`
+    },
+    '/beta/openshift/subscriptions': {
+      host: `https://${localhost}:5001`
+    },
     '/api/rhsm-subscriptions': {
       host: 'https://ci.cloud.redhat.com'
     }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "api:dev": "mock -p 5000 -w ./src/services",
     "api:docs": "node ./scripts/openapi.docs.js",
     "api:proxy-hosts": "bash ./scripts/proxy.api.sh -s",
-    "api:proxy": "bash ./scripts/proxy.api.sh -d \"https://ci.foo.redhat.com/beta/subscriptions/\" -p 443 -c \"$(pwd)/config/spandx.config.js\"",
+    "api:proxy": "bash ./scripts/proxy.api.sh -d \"https://ci.foo.redhat.com/beta/insights/subscriptions/\" -p 443 -c \"$(pwd)/config/spandx.config.js\"",
     "api:proxyClean": "bash ./scripts/proxy.api.sh -u",
     "build": "run-s -l build:pre build:js build:post test:integration",
     "build:js": "react-scripts build",

--- a/src/components/router/__tests__/routerHelpers.test.js
+++ b/src/components/router/__tests__/routerHelpers.test.js
@@ -8,10 +8,11 @@ import {
 } from '../routerHelpers';
 
 describe('RouterHelpers', () => {
-  const mockWindowLocationProp = async ({ prop, url, callback }) => {
+  const mockWindowLocation = async ({ url, callback }) => {
+    const updatedUrl = new URL(url);
     const { location } = window;
     delete window.location;
-    window.location = { [prop]: url };
+    window.location = { href: updatedUrl.href, search: updatedUrl.search, hash: updatedUrl.hash };
     await callback();
     window.location = location;
   };
@@ -136,8 +137,7 @@ describe('RouterHelpers', () => {
   });
 
   it('should handle location search and hash passthrough values', () => {
-    mockWindowLocationProp({
-      prop: 'href',
+    mockWindowLocation({
       url: 'https://ci.foo.redhat.com/subscriptions/rhel',
       callback: () => {
         expect({
@@ -146,8 +146,7 @@ describe('RouterHelpers', () => {
       }
     });
 
-    mockWindowLocationProp({
-      prop: 'href',
+    mockWindowLocation({
       url: 'https://ci.foo.redhat.com/subscriptions/rhel?dolor=sit',
       callback: () => {
         expect({
@@ -156,8 +155,7 @@ describe('RouterHelpers', () => {
       }
     });
 
-    mockWindowLocationProp({
-      prop: 'href',
+    mockWindowLocation({
       url: 'https://ci.foo.redhat.com/subscriptions/rhel#lorem',
       callback: () => {
         expect({
@@ -166,8 +164,7 @@ describe('RouterHelpers', () => {
       }
     });
 
-    mockWindowLocationProp({
-      prop: 'href',
+    mockWindowLocation({
       url: 'https://ci.foo.redhat.com/subscriptions/rhel?dolor=sit#lorem',
       callback: () => {
         expect({

--- a/src/components/router/routerHelpers.js
+++ b/src/components/router/routerHelpers.js
@@ -55,9 +55,17 @@ const getNavigationDetail = ({ id = null, pathname = null, returnDefault = false
     navigationItem = defaultItem;
   }
 
+  /**
+   * Note: have to account for carrying through location.search and location.hash, future updates
+   * Originally, we used a split on window.location.href.split(navigationItem.path) as an easy way
+   * to pull everything and maintain sequence, but there appears to be a race like condition
+   * happening on certain routes where window.location.href is updated first in some routing
+   * instances, and then in other instances requires being updated by the app/GUI.
+   */
   if (navigationItem) {
-    const [, routeHref] = window.location.href.split(navigationItem.path);
-    navigationItem.routeHref = `${navigationItem.path}${routeHref || ''}`;
+    const { search = '', hash = '' } = window.location;
+
+    navigationItem.routeHref = `${navigationItem.path}${search}${hash}`;
   }
 
   return { ...(navigationItem || {}) };

--- a/tests/__snapshots__/platform.test.js.snap
+++ b/tests/__snapshots__/platform.test.js.snap
@@ -15,6 +15,12 @@ Array [
   "'/beta/staging/subscriptions': {",
   "'/subscriptions': {",
   "'/beta/subscriptions': {",
+  "'/insights/subscriptions': {",
+  "'/beta/insights/subscriptions': {",
+  "'/rhel/subscriptions': {",
+  "'/beta/rhel/subscriptions': {",
+  "'/openshift/subscriptions': {",
+  "'/beta/openshift/subscriptions': {",
   "",
 ]
 `;


### PR DESCRIPTION

## What's included
<!-- Summary of changes/additions -->
- fix(routerHelpers): ent-3541 rhcloud-12690 alt for search, hash
   * build, update proxy, spandx config to account for left nav changes
   * routerHelpers, alt for location.href, use search and hash directly

### Notes
- Related to https://github.com/RedHatInsights/cloud-services-config/pull/456
- Corrects the dependency on window.location.href and instead directly uses `hash` and `search`. There is a race like condition that happens where sometimes window.location.href is updated before the route shift, sometimes it isn't
- This update affects all product views, OpenShift and the future views for Satellite
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. Navigate to `/beta/insights/subscriptions/rhel-arm` or any RHEL facet other than `/rhel`
1. Now attempt to navigate towards `/beta/insights/subscriptions/rhel` using the left nav ... RHEL should now appear. Prior to this update RHEL would not display.

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-3541