### PR TITLE
fix(viewReducer): ent-3644 productGroups for inventory reset

### DIFF
--- a/src/components/router/__tests__/__snapshots__/routerConfig.test.js.snap
+++ b/src/components/router/__tests__/__snapshots__/routerConfig.test.js.snap
@@ -100,6 +100,32 @@ exports[`RouterConfig should return specific properties: platformLandingRedirect
 
 exports[`RouterConfig should return specific properties: platformModalRedirect 1`] = `"/?not_entitled=subscriptions"`;
 
+exports[`RouterConfig should return specific properties: productGroups 1`] = `
+Object {
+  "viewOpenShift": Array [
+    "OpenShift Container Platform",
+  ],
+  "viewOpenShift-dedicated-metrics": Array [
+    "OpenShift-dedicated-metrics",
+  ],
+  "viewOpenShiftMetric": Array [
+    "OpenShift-metrics",
+  ],
+  "viewRHEL": Array [
+    "RHEL",
+    "RHEL for ARM",
+    "RHEL for IBM Power",
+    "RHEL for IBM z",
+    "RHEL for x86",
+  ],
+  "viewSatellite": Array [
+    "Satellite",
+    "Satellite Capsule",
+    "Satellite Server",
+  ],
+}
+`;
+
 exports[`RouterConfig should return specific properties: routes 1`] = `
 Array [
   Object {

--- a/src/components/router/__tests__/routerConfig.test.js
+++ b/src/components/router/__tests__/routerConfig.test.js
@@ -1,4 +1,11 @@
-import { appName, navigation, platformLandingRedirect, platformModalRedirect, routes } from '../routerConfig';
+import {
+  appName,
+  navigation,
+  platformLandingRedirect,
+  platformModalRedirect,
+  productGroups,
+  routes
+} from '../routerConfig';
 
 describe('RouterConfig', () => {
   it('should return specific properties', () => {
@@ -6,6 +13,7 @@ describe('RouterConfig', () => {
     expect(navigation).toMatchSnapshot('navigation');
     expect(platformLandingRedirect).toMatchSnapshot('platformLandingRedirect');
     expect(platformModalRedirect).toMatchSnapshot('platformModalRedirect');
+    expect(productGroups).toMatchSnapshot('productGroups');
     expect(routes).toMatchSnapshot('routes');
   });
 

--- a/src/components/router/routerConfig.js
+++ b/src/components/router/routerConfig.js
@@ -25,6 +25,33 @@ const platformLandingRedirect = path.join(helpers.UI_DEPLOY_PATH_PREFIX, '/');
 const platformModalRedirect = path.join(helpers.UI_DEPLOY_PATH_PREFIX, '/?not_entitled=subscriptions');
 
 /**
+ * ToDo: Dynamically generate productGroups listing from navigation, possible helper
+ * In addition to the platform nav IDs, we'll need to account for viewIds that are used
+ * for both viewId and productIds, and multi-column products views. This should tie into
+ * the future blend of routing, navigation, and product configuration.
+ */
+/**
+ * Reference for products grouped by view.
+ */
+const productGroups = {
+  [`view${RHSM_API_PATH_ID_TYPES.RHEL}`]: [
+    RHSM_API_PATH_ID_TYPES.RHEL,
+    RHSM_API_PATH_ID_TYPES.RHEL_ARM,
+    RHSM_API_PATH_ID_TYPES.RHEL_IBM_POWER,
+    RHSM_API_PATH_ID_TYPES.RHEL_IBM_Z,
+    RHSM_API_PATH_ID_TYPES.RHEL_X86
+  ],
+  viewOpenShift: [RHSM_API_PATH_ID_TYPES.OPENSHIFT],
+  viewOpenShiftMetric: [RHSM_API_PATH_ID_TYPES.OPENSHIFT_METRICS],
+  [`view${RHSM_API_PATH_ID_TYPES.OPENSHIFT_DEDICATED_METRICS}`]: [RHSM_API_PATH_ID_TYPES.OPENSHIFT_DEDICATED_METRICS],
+  [`view${RHSM_API_PATH_ID_TYPES.SATELLITE}`]: [
+    RHSM_API_PATH_ID_TYPES.SATELLITE,
+    RHSM_API_PATH_ID_TYPES.SATELLITE_CAPSULE,
+    RHSM_API_PATH_ID_TYPES.SATELLITE_SERVER
+  ]
+};
+
+/**
  * Return array of objects that describes routing.
  *
  * @returns {Array}
@@ -182,6 +209,7 @@ const routerConfig = {
   navigation,
   platformLandingRedirect,
   platformModalRedirect,
+  productGroups,
   routes
 };
 
@@ -192,5 +220,6 @@ export {
   navigation,
   platformLandingRedirect,
   platformModalRedirect,
+  productGroups,
   routes
 };

--- a/src/components/toolbar/__tests__/__snapshots__/toolbar.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbar.test.js.snap
@@ -27,6 +27,7 @@ Object {
       },
       Object {
         "type": "SET_QUERY_RESET_INVENTORY_LIST",
+        "viewId": "toolbar",
       },
     ],
   ],

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldDisplayName.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldDisplayName.test.js.snap
@@ -6,6 +6,7 @@ Array [
     Array [
       Object {
         "type": "SET_QUERY_CLEAR_INVENTORY_LIST",
+        "viewId": "toolbarFieldDisplayName",
       },
       Object {
         "display_name_contains": null,
@@ -23,6 +24,7 @@ Array [
     Array [
       Object {
         "type": "SET_QUERY_CLEAR_INVENTORY_LIST",
+        "viewId": "toolbarFieldDisplayName",
       },
       Object {
         "display_name_contains": "dolor sit",
@@ -40,6 +42,7 @@ Array [
     Array [
       Object {
         "type": "SET_QUERY_CLEAR_INVENTORY_LIST",
+        "viewId": "toolbarFieldDisplayName",
       },
       Object {
         "display_name_contains": "dolor sit",

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldGranularity.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldGranularity.test.js.snap
@@ -31,6 +31,7 @@ Array [
     Array [
       Object {
         "type": "SET_QUERY_CLEAR_INVENTORY_LIST",
+        "viewId": "toolbarFieldGranularity",
       },
       Object {
         "granularity": "daily",

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldRangedMonthly.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldRangedMonthly.test.js.snap
@@ -248,6 +248,10 @@ Array [
   Array [
     Array [
       Object {
+        "type": "SET_QUERY_CLEAR_INVENTORY_LIST",
+        "viewId": "toolbarFieldRangeGranularity",
+      },
+      Object {
         "granularity": "daily",
         "type": "SET_QUERY_RHSM_granularity",
         "viewId": "toolbarFieldRangeGranularity",

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldUom.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldUom.test.js.snap
@@ -21,6 +21,7 @@ Array [
     Array [
       Object {
         "type": "SET_QUERY_RESET_INVENTORY_LIST",
+        "viewId": "toolbarFieldUom",
       },
       Object {
         "type": "SET_QUERY_RHSM_uom",

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -146,7 +146,8 @@ class Toolbar extends React.Component {
 
     if (resetPage) {
       updatedActions.push({
-        type: reduxTypes.query.SET_QUERY_RESET_INVENTORY_LIST
+        type: reduxTypes.query.SET_QUERY_RESET_INVENTORY_LIST,
+        viewId
       });
     }
 
@@ -272,7 +273,7 @@ class Toolbar extends React.Component {
  * Prop types
  *
  * @type {{viewId: string, t: Function, activeFilters: Set, hardFilterReset: boolean, query: object,
- *     currentFilter: string, isDisabled: boolean, Array}}
+ *     currentFilter: string, isDisabled: boolean, filterOptions: Array}}
  */
 Toolbar.propTypes = {
   query: PropTypes.shape({

--- a/src/components/toolbar/toolbarFieldDisplayName.js
+++ b/src/components/toolbar/toolbarFieldDisplayName.js
@@ -17,12 +17,12 @@ import { translate } from '../i18n/i18n';
  * @fires onClear
  * @fires onKeyUp
  * @param {object} props
- * @param {string} props.value
  * @param {Function} props.t
+ * @param {string} props.value
  * @param {string} props.viewId
  * @returns {Node}
  */
-const ToolbarFieldDisplayName = ({ value, t, viewId }) => {
+const ToolbarFieldDisplayName = ({ t, value, viewId }) => {
   const currentValue = useSelector(
     ({ view }) => view.inventoryHostsQuery?.[viewId]?.[RHSM_API_QUERY_TYPES.DISPLAY_NAME],
     value
@@ -38,7 +38,8 @@ const ToolbarFieldDisplayName = ({ value, t, viewId }) => {
   const onSubmit = submitValue =>
     store.dispatch([
       {
-        type: reduxTypes.query.SET_QUERY_CLEAR_INVENTORY_LIST
+        type: reduxTypes.query.SET_QUERY_CLEAR_INVENTORY_LIST,
+        viewId
       },
       {
         type: reduxTypes.query.SET_QUERY_RHSM_HOSTS_INVENTORY_TYPES[RHSM_API_QUERY_TYPES.DISPLAY_NAME],
@@ -60,7 +61,8 @@ const ToolbarFieldDisplayName = ({ value, t, viewId }) => {
 
     store.dispatch([
       {
-        type: reduxTypes.query.SET_QUERY_CLEAR_INVENTORY_LIST
+        type: reduxTypes.query.SET_QUERY_CLEAR_INVENTORY_LIST,
+        viewId
       },
       {
         type: reduxTypes.query.SET_QUERY_RHSM_HOSTS_INVENTORY_TYPES[RHSM_API_QUERY_TYPES.DISPLAY_NAME],

--- a/src/components/toolbar/toolbarFieldGranularity.js
+++ b/src/components/toolbar/toolbarFieldGranularity.js
@@ -47,7 +47,8 @@ const ToolbarFieldGranularity = ({ options, t, value, viewId }) => {
     const { startDate, endDate } = dateHelpers.getRangedDateTime(event.value);
     store.dispatch([
       {
-        type: reduxTypes.query.SET_QUERY_CLEAR_INVENTORY_LIST
+        type: reduxTypes.query.SET_QUERY_CLEAR_INVENTORY_LIST,
+        viewId
       },
       {
         type: reduxTypes.query.SET_QUERY_RHSM_TYPES[RHSM_API_QUERY_TYPES.GRANULARITY],

--- a/src/components/toolbar/toolbarFieldRangedMonthly.js
+++ b/src/components/toolbar/toolbarFieldRangedMonthly.js
@@ -46,6 +46,10 @@ const ToolbarFieldRangedMonthly = ({ options, t, value, viewId }) => {
     const { startDate, endDate } = event.value;
     store.dispatch([
       {
+        type: reduxTypes.query.SET_QUERY_CLEAR_INVENTORY_LIST,
+        viewId
+      },
+      {
         type: reduxTypes.query.SET_QUERY_RHSM_TYPES[RHSM_API_QUERY_TYPES.GRANULARITY],
         viewId,
         [RHSM_API_QUERY_TYPES.GRANULARITY]: FIELD_TYPES.DAILY

--- a/src/components/toolbar/toolbarFieldUom.js
+++ b/src/components/toolbar/toolbarFieldUom.js
@@ -42,7 +42,8 @@ const ToolbarFieldUom = ({ options, t, value, viewId }) => {
   const onSelect = event =>
     store.dispatch([
       {
-        type: reduxTypes.query.SET_QUERY_RESET_INVENTORY_LIST
+        type: reduxTypes.query.SET_QUERY_RESET_INVENTORY_LIST,
+        viewId
       },
       {
         type: reduxTypes.query.SET_QUERY_RHSM_TYPES[RHSM_API_QUERY_TYPES.UOM],

--- a/src/redux/reducers/viewReducer.js
+++ b/src/redux/reducers/viewReducer.js
@@ -1,3 +1,4 @@
+import { routerConfig } from '../../components/router/routerConfig';
 import { reduxTypes } from '../types';
 import { reduxHelpers } from '../common/reduxHelpers';
 import { RHSM_API_QUERY_TYPES } from '../../types/rhsmApiTypes';
@@ -27,29 +28,30 @@ const initialState = {
 const viewReducer = (state = initialState, action) => {
   switch (action.type) {
     case reduxTypes.query.SET_QUERY_RESET_INVENTORY_LIST:
-      const updateResetQueries = query => {
-        const tempQuery = {};
+      const updateResetQueries = (query = {}, id) => {
+        const queryIds = routerConfig.productGroups[id] || (query[id] && [id]) || [];
+        const updatedQuery = { ...query };
 
-        Object.entries(query).forEach(([key, value]) => {
-          tempQuery[key] = { ...value };
+        queryIds.forEach(queryId => {
+          const productQuery = updatedQuery[queryId] || {};
 
-          if (typeof value[RHSM_API_QUERY_TYPES.OFFSET] === 'number') {
-            tempQuery[key][RHSM_API_QUERY_TYPES.OFFSET] = 0;
+          if (typeof productQuery[RHSM_API_QUERY_TYPES.OFFSET] === 'number') {
+            productQuery[RHSM_API_QUERY_TYPES.OFFSET] = 0;
           }
 
-          delete tempQuery[key][RHSM_API_QUERY_TYPES.DIRECTION];
-          delete tempQuery[key][RHSM_API_QUERY_TYPES.SORT];
+          delete productQuery[RHSM_API_QUERY_TYPES.DIRECTION];
+          delete productQuery[RHSM_API_QUERY_TYPES.SORT];
         });
 
-        return tempQuery;
+        return updatedQuery;
       };
 
       return reduxHelpers.setStateProp(
         null,
         {
           ...state,
-          inventoryHostsQuery: updateResetQueries(state.inventoryHostsQuery),
-          inventorySubscriptionsQuery: updateResetQueries(state.inventorySubscriptionsQuery)
+          inventoryHostsQuery: updateResetQueries(state.inventoryHostsQuery, action.viewId),
+          inventorySubscriptionsQuery: updateResetQueries(state.inventorySubscriptionsQuery, action.viewId)
         },
         {
           state,
@@ -57,26 +59,27 @@ const viewReducer = (state = initialState, action) => {
         }
       );
     case reduxTypes.query.SET_QUERY_CLEAR_INVENTORY_LIST:
-      const updateClearQueries = query => {
-        const tempQuery = {};
+      const updateClearQueries = (query = {}, id) => {
+        const queryIds = routerConfig.productGroups[id] || (query[id] && [id]) || [];
+        const updatedQuery = { ...query };
 
-        Object.entries(query).forEach(([key, value]) => {
-          tempQuery[key] = { ...value };
+        queryIds.forEach(queryId => {
+          const productQuery = updatedQuery[queryId] || {};
 
-          if (typeof value[RHSM_API_QUERY_TYPES.OFFSET] === 'number') {
-            tempQuery[key][RHSM_API_QUERY_TYPES.OFFSET] = 0;
+          if (typeof productQuery[RHSM_API_QUERY_TYPES.OFFSET] === 'number') {
+            productQuery[RHSM_API_QUERY_TYPES.OFFSET] = 0;
           }
         });
 
-        return tempQuery;
+        return updatedQuery;
       };
 
       return reduxHelpers.setStateProp(
         null,
         {
           ...state,
-          inventoryHostsQuery: updateClearQueries(state.inventoryHostsQuery),
-          inventorySubscriptionsQuery: updateClearQueries(state.inventorySubscriptionsQuery)
+          inventoryHostsQuery: updateClearQueries(state.inventoryHostsQuery, action.viewId),
+          inventorySubscriptionsQuery: updateClearQueries(state.inventorySubscriptionsQuery, action.viewId)
         },
         {
           state,


### PR DESCRIPTION

## What's included
<!-- Summary of changes/additions -->
- fix(viewReducer): ent-3644 productGroups for inventory reset
   * routerConfig, productGroups, productIds grouped by viewIds
   * toolbar, viewId to inventory reset
   * toolbarFieldDisplayName, granularity, ranged, uom, apply viewId
   * viewReducer, restructure reset to apply productGroups

### Notes
- It appears we discovered a flaw/bug in how we reset the inventory displays. Originally we didn't have dual column displays so we would generically reset the inventory per view, this encompassed all productIds under a viewId. The dual column display created a scenario where we can't/shouldn't generically reset all inventory states. Now **when an inventory reset needs to happen it can no longer be generic, it has to be specific**. 
- There are two solutions we've reviewed
    - #604 Go with what we know works and apply prop drilling for the `productId` alongside the `viewId`, or
    - **THIS PR** Apply a unique solution by retaining the `viewId` and creating a dictionary for each viewId that relates all possible `productIds` contained under a `viewId` enabling us to reset state on those specific productIds
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm the inventory paging/offset is reset to the initial offset, in this case 0.
    - all products and their facets should be confirmed

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-3644