### PR TITLE
fix(productViews): ent-3509 remove target blank from links

### DIFF
--- a/src/components/productView/__tests__/__snapshots__/productViewRhel.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productViewRhel.test.js.snap
@@ -205,7 +205,6 @@ Object {
         component="a"
         href="/insights/inventory/lorem inventory id/"
         isInline={true}
-        target="_blank"
         variant="link"
       >
         lorem
@@ -363,7 +362,6 @@ Object {
           component="a"
           href="/insights/inventory/lorem inventory id/"
           isInline={true}
-          target="_blank"
           variant="link"
         >
           lorem

--- a/src/components/productView/__tests__/__snapshots__/productViewSatellite.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productViewSatellite.test.js.snap
@@ -205,7 +205,6 @@ Object {
         component="a"
         href="/insights/inventory/lorem inventory id/"
         isInline={true}
-        target="_blank"
         variant="link"
       >
         lorem
@@ -363,7 +362,6 @@ Object {
           component="a"
           href="/insights/inventory/lorem inventory id/"
           isInline={true}
-          target="_blank"
           variant="link"
         >
           lorem

--- a/src/components/productView/productViewOpenShiftContainer.js
+++ b/src/components/productView/productViewOpenShiftContainer.js
@@ -303,7 +303,6 @@ ProductViewOpenShiftContainer.defaultProps = {
                 isInline
                 component="a"
                 variant="link"
-                target="_blank"
                 href={`${helpers.UI_DEPLOY_PATH_PREFIX}/insights/inventory/${inventoryId.value}/`}
               >
                 {displayName.value || inventoryId.value}
@@ -340,7 +339,6 @@ ProductViewOpenShiftContainer.defaultProps = {
                   isInline
                   component="a"
                   variant="link"
-                  target="_blank"
                   href={`${helpers.UI_DEPLOY_PATH_PREFIX}/insights/inventory/${inventoryId.value}/`}
                 >
                   {displayName.value || inventoryId.value}

--- a/src/components/productView/productViewRhel.js
+++ b/src/components/productView/productViewRhel.js
@@ -116,7 +116,6 @@ ProductViewRhel.defaultProps = {
               isInline
               component="a"
               variant="link"
-              target="_blank"
               href={`${helpers.UI_DEPLOY_PATH_PREFIX}/insights/inventory/${inventoryId.value}/`}
             >
               {displayName.value || inventoryId.value}
@@ -153,7 +152,6 @@ ProductViewRhel.defaultProps = {
                 isInline
                 component="a"
                 variant="link"
-                target="_blank"
                 href={`${helpers.UI_DEPLOY_PATH_PREFIX}/insights/inventory/${inventoryId.value}/`}
               >
                 {displayName.value || inventoryId.value}

--- a/src/components/productView/productViewSatellite.js
+++ b/src/components/productView/productViewSatellite.js
@@ -116,7 +116,6 @@ ProductViewSatellite.defaultProps = {
               isInline
               component="a"
               variant="link"
-              target="_blank"
               href={`${helpers.UI_DEPLOY_PATH_PREFIX}/insights/inventory/${inventoryId.value}/`}
             >
               {displayName.value || inventoryId.value}
@@ -153,7 +152,6 @@ ProductViewSatellite.defaultProps = {
                 isInline
                 component="a"
                 variant="link"
-                target="_blank"
                 href={`${helpers.UI_DEPLOY_PATH_PREFIX}/insights/inventory/${inventoryId.value}/`}
               >
                 {displayName.value || inventoryId.value}


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(productViews): ent-3509 remove target blank from links

### Notes
- Removes the target blank from all product views; RHEL, OpenShift, and Satellite. This change is dependent on the left navigation updates.
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm the inventory links, and guest inventory links no longer open for RHEL, OpenShift, and Satellite

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
relates ent-3509 ent-3506 ent-3324 