### PR TITLE
fix(toolbarFieldRangedMonthly): ent-3748 apply position right

### DIFF
--- a/src/components/form/__tests__/__snapshots__/select.test.js.snap
+++ b/src/components/form/__tests__/__snapshots__/select.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Select Component should allow alternate array and object options: key value object 1`] = `
 <div
-  class="pf-c-select curiosity-select "
+  class="pf-c-select curiosity-select  "
   data-ouia-component-id="OUIA-Generated-Select-single-2"
   data-ouia-component-type="PF4/Select"
   data-ouia-safe="true"
@@ -47,7 +47,7 @@ exports[`Select Component should allow alternate array and object options: key v
 
 exports[`Select Component should allow alternate array and object options: string array 1`] = `
 <div
-  class="pf-c-select curiosity-select "
+  class="pf-c-select curiosity-select  "
   data-ouia-component-id="OUIA-Generated-Select-single-2"
   data-ouia-component-type="PF4/Select"
   data-ouia-safe="true"
@@ -90,12 +90,178 @@ exports[`Select Component should allow alternate array and object options: strin
 </div>
 `;
 
+exports[`Select Component should allow alternate direction and position options: direction up 1`] = `
+<Select
+  aria-label="Select option"
+  aria-labelledby=""
+  chipGroupComponent={null}
+  className="curiosity-select  "
+  clearSelectionsAriaLabel="Clear all"
+  createText="Create"
+  customBadgeText={null}
+  customContent={null}
+  direction="up"
+  favorites={Array []}
+  favoritesLabel="Favorites"
+  hasInlineFilter={false}
+  inlineFilterPlaceholderText={null}
+  inputIdPrefix=""
+  isCreatable={false}
+  isDisabled={false}
+  isGrouped={false}
+  isOpen={false}
+  isPlain={false}
+  maxHeight={null}
+  menuAppendTo="inline"
+  noResultsFoundText="No results found"
+  onClear={[Function]}
+  onCreateOption={[Function]}
+  onFilter={null}
+  onSelect={[Function]}
+  onToggle={[Function]}
+  ouiaSafe={true}
+  placeholderText="Select option"
+  removeSelectionAriaLabel="Remove"
+  selections={Array []}
+  toggleAriaLabel="Options menu"
+  toggleIcon={null}
+  toggleId={null}
+  typeAheadAriaLabel=""
+  variant="single"
+  width=""
+>
+  <SelectOption
+    className=""
+    component="button"
+    data-title="lorem"
+    data-value="lorem"
+    id="bG9yZW0tbG9yZW0="
+    index={0}
+    inputId=""
+    isChecked={false}
+    isDisabled={false}
+    isFavorite={null}
+    isNoResultsOption={false}
+    isPlaceholder={false}
+    isSelected={false}
+    key="bG9yZW0tbG9yZW0="
+    keyHandler={[Function]}
+    onClick={[Function]}
+    sendRef={[Function]}
+    value="lorem"
+  />
+  <SelectOption
+    className=""
+    component="button"
+    data-title="ipsum"
+    data-value="ipsum"
+    id="aXBzdW0taXBzdW0="
+    index={0}
+    inputId=""
+    isChecked={false}
+    isDisabled={false}
+    isFavorite={null}
+    isNoResultsOption={false}
+    isPlaceholder={false}
+    isSelected={false}
+    key="aXBzdW0taXBzdW0="
+    keyHandler={[Function]}
+    onClick={[Function]}
+    sendRef={[Function]}
+    value="ipsum"
+  />
+</Select>
+`;
+
+exports[`Select Component should allow alternate direction and position options: position right 1`] = `
+<Select
+  aria-label="Select option"
+  aria-labelledby=""
+  chipGroupComponent={null}
+  className="curiosity-select curiosity-select__position-right "
+  clearSelectionsAriaLabel="Clear all"
+  createText="Create"
+  customBadgeText={null}
+  customContent={null}
+  direction="down"
+  favorites={Array []}
+  favoritesLabel="Favorites"
+  hasInlineFilter={false}
+  inlineFilterPlaceholderText={null}
+  inputIdPrefix=""
+  isCreatable={false}
+  isDisabled={false}
+  isGrouped={false}
+  isOpen={false}
+  isPlain={false}
+  maxHeight={null}
+  menuAppendTo="inline"
+  noResultsFoundText="No results found"
+  onClear={[Function]}
+  onCreateOption={[Function]}
+  onFilter={null}
+  onSelect={[Function]}
+  onToggle={[Function]}
+  ouiaSafe={true}
+  placeholderText="Select option"
+  removeSelectionAriaLabel="Remove"
+  selections={Array []}
+  toggleAriaLabel="Options menu"
+  toggleIcon={null}
+  toggleId={null}
+  typeAheadAriaLabel=""
+  variant="single"
+  width=""
+>
+  <SelectOption
+    className=""
+    component="button"
+    data-title="lorem"
+    data-value="lorem"
+    id="bG9yZW0tbG9yZW0="
+    index={0}
+    inputId=""
+    isChecked={false}
+    isDisabled={false}
+    isFavorite={null}
+    isNoResultsOption={false}
+    isPlaceholder={false}
+    isSelected={false}
+    key="bG9yZW0tbG9yZW0="
+    keyHandler={[Function]}
+    onClick={[Function]}
+    sendRef={[Function]}
+    value="lorem"
+  />
+  <SelectOption
+    className=""
+    component="button"
+    data-title="ipsum"
+    data-value="ipsum"
+    id="aXBzdW0taXBzdW0="
+    index={0}
+    inputId=""
+    isChecked={false}
+    isDisabled={false}
+    isFavorite={null}
+    isNoResultsOption={false}
+    isPlaceholder={false}
+    isSelected={false}
+    key="aXBzdW0taXBzdW0="
+    keyHandler={[Function]}
+    onClick={[Function]}
+    sendRef={[Function]}
+    value="ipsum"
+  />
+</Select>
+`;
+
 exports[`Select Component should allow being disabled with missing options: no options 1`] = `
 <Select
   aria-label="Select option"
   aria-labelledby=""
   chipGroupComponent={null}
-  className="curiosity-select "
+  className="curiosity-select  "
   clearSelectionsAriaLabel="Clear all"
   createText="Create"
   customBadgeText={null}
@@ -137,7 +303,7 @@ exports[`Select Component should allow being disabled with missing options: opti
   aria-label="Select option"
   aria-labelledby=""
   chipGroupComponent={null}
-  className="curiosity-select "
+  className="curiosity-select  "
   clearSelectionsAriaLabel="Clear all"
   createText="Create"
   customBadgeText={null}
@@ -260,7 +426,7 @@ exports[`Select Component should allow being disabled with missing options: opti
   aria-label="Select option"
   aria-labelledby=""
   chipGroupComponent={null}
-  className="curiosity-select "
+  className="curiosity-select  "
   clearSelectionsAriaLabel="Clear all"
   createText="Create"
   customBadgeText={null}
@@ -299,7 +465,7 @@ exports[`Select Component should allow being disabled with missing options: opti
 
 exports[`Select Component should allow plain objects as values, and be able to select options based on values within the object: select when option values are objects 1`] = `
 <div
-  class="pf-c-select curiosity-select "
+  class="pf-c-select curiosity-select  "
   data-ouia-component-id="OUIA-Generated-Select-single-3"
   data-ouia-component-type="PF4/Select"
   data-ouia-safe="true"
@@ -344,7 +510,7 @@ exports[`Select Component should allow plain objects as values, and be able to s
 
 exports[`Select Component should allow selected options to match value or title: value or title match 1`] = `
 <div
-  class="pf-c-select curiosity-select "
+  class="pf-c-select curiosity-select  "
   data-ouia-component-id="OUIA-Generated-Select-checkbox-2"
   data-ouia-component-type="PF4/Select"
   data-ouia-safe="true"
@@ -400,7 +566,7 @@ exports[`Select Component should disable toggle text: disabled text 1`] = `
   aria-label="Select option"
   aria-labelledby=""
   chipGroupComponent={null}
-  className="curiosity-select__no-toggle-text "
+  className="curiosity-select__no-toggle-text  "
   clearSelectionsAriaLabel="Clear all"
   createText="Create"
   customBadgeText={null}
@@ -486,7 +652,7 @@ exports[`Select Component should disable toggle text: disabled text 1`] = `
 
 exports[`Select Component should render a basic component: basic component 1`] = `
 <div
-  class="pf-c-select curiosity-select "
+  class="pf-c-select curiosity-select  "
   data-ouia-component-id="OUIA-Generated-Select-single-1"
   data-ouia-component-type="PF4/Select"
   data-ouia-safe="true"
@@ -531,7 +697,7 @@ exports[`Select Component should render a basic component: basic component 1`] =
 
 exports[`Select Component should render a checkbox select: checkbox select 1`] = `
 <div
-  class="pf-c-select curiosity-select "
+  class="pf-c-select curiosity-select  "
   data-ouia-component-id="OUIA-Generated-Select-checkbox-1"
   data-ouia-component-type="PF4/Select"
   data-ouia-safe="true"
@@ -586,6 +752,7 @@ exports[`Select Component should render a expanded select: expanded 1`] = `
 <Select
   ariaLabel="Select option"
   className=""
+  direction="down"
   id="test"
   isDisabled={false}
   isToggleText={true}
@@ -601,6 +768,7 @@ exports[`Select Component should render a expanded select: expanded 1`] = `
     ]
   }
   placeholder="Select option"
+  position="left"
   selectedOptions={null}
   toggleIcon={null}
   variant="single"
@@ -609,7 +777,7 @@ exports[`Select Component should render a expanded select: expanded 1`] = `
     aria-label="Select option"
     aria-labelledby=""
     chipGroupComponent={null}
-    className="curiosity-select "
+    className="curiosity-select  "
     clearSelectionsAriaLabel="Clear all"
     createText="Create"
     customBadgeText={null}
@@ -648,7 +816,7 @@ exports[`Select Component should render a expanded select: expanded 1`] = `
       prefix="pf-random-id-"
     >
       <div
-        className="pf-c-select pf-m-expanded curiosity-select "
+        className="pf-c-select pf-m-expanded curiosity-select  "
         data-ouia-component-id="OUIA-Generated-Select-single-5"
         data-ouia-component-type="PF4/Select"
         data-ouia-safe={true}
@@ -741,7 +909,7 @@ exports[`Select Component should render a expanded select: expanded 1`] = `
           parentRef={
             Object {
               "current": <div
-                class="pf-c-select pf-m-expanded curiosity-select "
+                class="pf-c-select pf-m-expanded curiosity-select  "
                 data-ouia-component-id="OUIA-Generated-Select-single-5"
                 data-ouia-component-type="PF4/Select"
                 data-ouia-safe="true"

--- a/src/components/form/__tests__/select.test.js
+++ b/src/components/form/__tests__/select.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount, shallow } from 'enzyme';
 import { SelectVariant } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons';
-import Select from '../select';
+import { Select, SelectDirection, SelectPosition } from '../select';
 
 describe('Select Component', () => {
   it('should render a basic component', () => {
@@ -124,6 +124,20 @@ describe('Select Component', () => {
 
     const component = shallow(<Select {...props} />);
     expect(component).toMatchSnapshot('disabled text');
+  });
+
+  it('should allow alternate direction and position options', () => {
+    const props = {
+      id: 'test',
+      options: ['lorem', 'ipsum'],
+      direction: SelectDirection.up
+    };
+
+    const component = shallow(<Select {...props} />);
+    expect(component).toMatchSnapshot('direction up');
+
+    component.setProps({ direction: SelectDirection.down, position: SelectPosition.right });
+    expect(component).toMatchSnapshot('position right');
   });
 
   it('should allow being disabled with missing options', () => {

--- a/src/components/form/select.js
+++ b/src/components/form/select.js
@@ -1,11 +1,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Select as PfSelect, SelectOption as PfSelectOption, SelectVariant } from '@patternfly/react-core';
+import {
+  DropdownDirection,
+  DropdownPosition,
+  Select as PfSelect,
+  SelectOption as PfSelectOption,
+  SelectVariant
+} from '@patternfly/react-core';
 import _cloneDeep from 'lodash/cloneDeep';
 import _isEqual from 'lodash/isEqual';
 import _findIndex from 'lodash/findIndex';
 import _isPlainObject from 'lodash/isPlainObject';
 import { helpers } from '../../common/helpers';
+
+/**
+ * Pass direction as select component variant option.
+ *
+ * @type {DropdownDirection}
+ */
+const SelectDirection = DropdownDirection;
+
+/**
+ * Pass position as select component variant option.
+ *
+ * @type {DropdownPosition}
+ */
+const SelectPosition = DropdownPosition;
 
 /**
  * A wrapper for Patternfly Select. Provides restructured event data for onSelect callback.
@@ -190,9 +210,21 @@ class Select extends React.Component {
    */
   render() {
     const { options, selected, isExpanded } = this.state;
-    const { ariaLabel, className, isDisabled, isToggleText, maxHeight, placeholder, toggleIcon, variant } = this.props;
+    const {
+      ariaLabel,
+      className,
+      direction,
+      isDisabled,
+      isToggleText,
+      maxHeight,
+      placeholder,
+      position,
+      toggleIcon,
+      variant
+    } = this.props;
 
     const pfSelectOptions = {
+      direction,
       maxHeight
     };
 
@@ -209,7 +241,9 @@ class Select extends React.Component {
      */
     return (
       <PfSelect
-        className={`curiosity-select${(!isToggleText && '__no-toggle-text') || ''} ${className}`}
+        className={`curiosity-select${(!isToggleText && '__no-toggle-text') || ''} ${
+          (position === DropdownPosition.right && 'curiosity-select__position-right') || ''
+        } ${className}`}
         variant={variant}
         aria-label={ariaLabel}
         onToggle={this.onToggle}
@@ -242,11 +276,12 @@ class Select extends React.Component {
  * @type {{toggleIcon: (Node|Function), className: string, ariaLabel: string, onSelect: Function,
  *     isToggleText: boolean, maxHeight: number, name: string, options: (Array|object),
  *     selectedOptions: (number|string|Array), variant: string, id: string, isDisabled: boolean,
- *     placeholder: string}}
+ *     placeholder: string, position: string, direction: string}}
  */
 Select.propTypes = {
   ariaLabel: PropTypes.string,
   className: PropTypes.string,
+  direction: PropTypes.oneOf(Object.values(SelectDirection)),
   id: PropTypes.string,
   isDisabled: PropTypes.bool,
   isToggleText: PropTypes.bool,
@@ -270,6 +305,7 @@ Select.propTypes = {
     PropTypes.object
   ]),
   placeholder: PropTypes.string,
+  position: PropTypes.oneOf(Object.values(SelectPosition)),
   selectedOptions: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.string,
@@ -282,14 +318,15 @@ Select.propTypes = {
 /**
  * Default props.
  *
- * @type {{toggleIcon: (Node|Function), className: string, ariaLabel: string, onSelect: Function,
- *     isToggleText: boolean, maxHeight: number, name: string, options: (Array|object),
- *     selectedOptions: (number|string|Array), variant: SelectVariant.single, id: string,
- *     isDisabled: boolean, placeholder: string}}
+ * @type {{toggleIcon: (Node|Function), className: string, ariaLabel: string, onSelect: Function, isToggleText: boolean,
+ *     maxHeight: number, name: string, options: (Array|object), selectedOptions: (number|string|Array),
+ *     variant: SelectVariant.single, id: string, isDisabled: boolean, placeholder: string,
+ *     position: DropdownPosition.left, direction: DropdownDirection.down}}
  */
 Select.defaultProps = {
   ariaLabel: 'Select option',
   className: '',
+  direction: SelectDirection.down,
   id: helpers.generateId(),
   isDisabled: false,
   isToggleText: true,
@@ -298,9 +335,10 @@ Select.defaultProps = {
   onSelect: helpers.noop,
   options: [],
   placeholder: 'Select option',
+  position: SelectPosition.left,
   selectedOptions: null,
   toggleIcon: null,
   variant: SelectVariant.single
 };
 
-export { Select as default, Select };
+export { Select as default, Select, SelectDirection, SelectPosition };

--- a/src/components/toolbar/__tests__/__snapshots__/toolbar.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbar.test.js.snap
@@ -542,6 +542,7 @@ exports[`Toolbar Component should render a non-connected component: non-connecte
             aria-label="t(curiosity-toolbar.category)"
             ariaLabel="Select option"
             className=""
+            direction="down"
             id="generatedid-"
             isDisabled={false}
             isToggleText={true}
@@ -561,6 +562,7 @@ exports[`Toolbar Component should render a non-connected component: non-connecte
               ]
             }
             placeholder="t(curiosity-toolbar.placeholder)"
+            position="left"
             selectedOptions={
               Array [
                 "t(curiosity-toolbar.category, {\\"context\\":\\"usage\\"})",
@@ -587,6 +589,7 @@ exports[`Toolbar Component should render a non-connected component: non-connecte
             aria-label="t(curiosity-toolbar.category, {\\"context\\":\\"sla\\"})"
             ariaLabel="Select option"
             className=""
+            direction="down"
             id="generatedid-"
             isDisabled={false}
             isToggleText={true}
@@ -614,6 +617,7 @@ exports[`Toolbar Component should render a non-connected component: non-connecte
               ]
             }
             placeholder="t(curiosity-toolbar.placeholder, {\\"context\\":\\"sla\\"})"
+            position="left"
             selectedOptions={Array []}
             toggleIcon={null}
             variant="single"
@@ -630,6 +634,7 @@ exports[`Toolbar Component should render a non-connected component: non-connecte
             aria-label="t(curiosity-toolbar.category, {\\"context\\":\\"usage\\"})"
             ariaLabel="Select option"
             className=""
+            direction="down"
             id="generatedid-"
             isDisabled={false}
             isToggleText={true}
@@ -657,6 +662,7 @@ exports[`Toolbar Component should render a non-connected component: non-connecte
               ]
             }
             placeholder="t(curiosity-toolbar.placeholder, {\\"context\\":\\"usage\\"})"
+            position="left"
             selectedOptions={Array []}
             toggleIcon={null}
             variant="single"
@@ -698,6 +704,7 @@ exports[`Toolbar Component should render filters when props are populated: props
             aria-label="t(curiosity-toolbar.category)"
             ariaLabel="Select option"
             className=""
+            direction="down"
             id="generatedid-"
             isDisabled={false}
             isToggleText={true}
@@ -717,6 +724,7 @@ exports[`Toolbar Component should render filters when props are populated: props
               ]
             }
             placeholder="t(curiosity-toolbar.placeholder)"
+            position="left"
             selectedOptions={
               Array [
                 "t(curiosity-toolbar.category, {\\"context\\":\\"sla\\"})",
@@ -747,6 +755,7 @@ exports[`Toolbar Component should render filters when props are populated: props
             aria-label="t(curiosity-toolbar.category, {\\"context\\":\\"sla\\"})"
             ariaLabel="Select option"
             className=""
+            direction="down"
             id="generatedid-"
             isDisabled={false}
             isToggleText={true}
@@ -774,6 +783,7 @@ exports[`Toolbar Component should render filters when props are populated: props
               ]
             }
             placeholder="t(curiosity-toolbar.placeholder, {\\"context\\":\\"sla\\"})"
+            position="left"
             selectedOptions={
               Array [
                 "t(curiosity-toolbar.slaPremium)",
@@ -794,6 +804,7 @@ exports[`Toolbar Component should render filters when props are populated: props
             aria-label="t(curiosity-toolbar.category, {\\"context\\":\\"usage\\"})"
             ariaLabel="Select option"
             className=""
+            direction="down"
             id="generatedid-"
             isDisabled={false}
             isToggleText={true}
@@ -821,6 +832,7 @@ exports[`Toolbar Component should render filters when props are populated: props
               ]
             }
             placeholder="t(curiosity-toolbar.placeholder, {\\"context\\":\\"usage\\"})"
+            position="left"
             selectedOptions={Array []}
             toggleIcon={null}
             variant="single"
@@ -868,6 +880,7 @@ exports[`Toolbar Component should render specific filters when the filterOptions
             aria-label="t(curiosity-toolbar.category, {\\"context\\":\\"sla\\"})"
             ariaLabel="Select option"
             className=""
+            direction="down"
             id="generatedid-"
             isDisabled={false}
             isToggleText={true}
@@ -895,6 +908,7 @@ exports[`Toolbar Component should render specific filters when the filterOptions
               ]
             }
             placeholder="t(curiosity-toolbar.placeholder, {\\"context\\":\\"sla\\"})"
+            position="left"
             selectedOptions={Array []}
             toggleIcon={null}
             variant="single"

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldGranularity.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldGranularity.test.js.snap
@@ -58,6 +58,7 @@ exports[`ToolbarFieldGranularity Component should render a non-connected compone
   aria-label="t(curiosity-toolbar.placeholder, {\\"context\\":\\"granularity\\"})"
   ariaLabel="Select option"
   className=""
+  direction="down"
   id="generatedid-"
   isDisabled={false}
   isToggleText={true}
@@ -89,6 +90,7 @@ exports[`ToolbarFieldGranularity Component should render a non-connected compone
     ]
   }
   placeholder="t(curiosity-toolbar.placeholder, {\\"context\\":\\"granularity\\"})"
+  position="left"
   selectedOptions="weekly"
   toggleIcon={null}
   variant="single"

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldRangedMonthly.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldRangedMonthly.test.js.snap
@@ -118,6 +118,7 @@ exports[`ToolbarFieldGranularity Component should handle selecting an option dir
   aria-label="t(curiosity-toolbar.placeholder, {\\"context\\":\\"granularity\\"})"
   ariaLabel="Select option"
   className=""
+  direction="down"
   id="generatedid-"
   isDisabled={false}
   isToggleText={true}
@@ -237,6 +238,7 @@ exports[`ToolbarFieldGranularity Component should handle selecting an option dir
     ]
   }
   placeholder="t(curiosity-toolbar.placeholder, {\\"context\\":\\"granularity\\"})"
+  position="right"
   selectedOptions={null}
   toggleIcon={null}
   variant="single"
@@ -276,6 +278,7 @@ exports[`ToolbarFieldGranularity Component should render a non-connected compone
   aria-label="t(curiosity-toolbar.placeholder, {\\"context\\":\\"granularity\\"})"
   ariaLabel="Select option"
   className=""
+  direction="down"
   id="generatedid-"
   isDisabled={false}
   isToggleText={true}
@@ -395,6 +398,7 @@ exports[`ToolbarFieldGranularity Component should render a non-connected compone
     ]
   }
   placeholder="t(curiosity-toolbar.placeholder, {\\"context\\":\\"granularity\\"})"
+  position="right"
   selectedOptions={null}
   toggleIcon={null}
   variant="single"

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldUom.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldUom.test.js.snap
@@ -38,6 +38,7 @@ exports[`ToolbarFieldUom Component should render a non-connected component: non-
   aria-label="t(curiosity-toolbar.placeholder, {\\"context\\":\\"uom\\"})"
   ariaLabel="Select option"
   className=""
+  direction="down"
   id="generatedid-"
   isDisabled={false}
   isToggleText={true}
@@ -59,6 +60,7 @@ exports[`ToolbarFieldUom Component should render a non-connected component: non-
     ]
   }
   placeholder="t(curiosity-toolbar.placeholder, {\\"context\\":\\"uom\\"})"
+  position="left"
   selectedOptions="sockets"
   toggleIcon={null}
   variant="single"

--- a/src/components/toolbar/toolbarFieldRangedMonthly.js
+++ b/src/components/toolbar/toolbarFieldRangedMonthly.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { reduxTypes, store, useSelector } from '../../redux';
-import { Select } from '../form/select';
+import { Select, SelectPosition } from '../form/select';
 import { RHSM_API_QUERY_GRANULARITY_TYPES as FIELD_TYPES, RHSM_API_QUERY_TYPES } from '../../types/rhsmApiTypes';
 import { dateHelpers } from '../../common';
 import { translate } from '../i18n/i18n';
@@ -73,6 +73,7 @@ const ToolbarFieldRangedMonthly = ({ options, t, value, viewId }) => {
       onSelect={onSelect}
       options={updatedOptions}
       placeholder={t('curiosity-toolbar.placeholder', { context: 'granularity' })}
+      position={SelectPosition.right}
       maxHeight={250}
     />
   );

--- a/src/styles/_form.scss
+++ b/src/styles/_form.scss
@@ -7,3 +7,9 @@
     display: none;
   }
 }
+
+.curiosity-select__position-right {
+  > .pf-c-select__menu {
+    right: 0
+  }
+}


### PR DESCRIPTION


## What's included
<!-- Summary of changes/additions -->
- fix(toolbarFieldRangedMonthly): ent-3748 apply position right
   * select, expand display options, allow up down and left right
   * toolbarFieldRangedMonthly, apply position right
   * style, position right for select components

### Notes
- PF Select doesn't appear to have a position left/right. We repurposed the CSS from PF Dropdown and it appears to work!
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. open OpenShift Container or OpenShift Dedicated and confirm the monthly ranged dropdown now has its position flush right

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screen Shot 2021-04-09 at 11 02 33 AM](https://user-images.githubusercontent.com/3761375/114209314-7a09b780-992c-11eb-846f-15a7d69e6ea9.png)

![Screen Shot 2021-04-09 at 11 01 45 AM](https://user-images.githubusercontent.com/3761375/114209336-7fff9880-992c-11eb-9461-268e33f8f945.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-3748