### PR TITLE
fix(pageColumns): maintain columns on granularity change

### DIFF
--- a/src/styles/_page-layout.scss
+++ b/src/styles/_page-layout.scss
@@ -10,6 +10,7 @@
 .curiosity-page-columns > .curiosity-page-columns-column {
   margin-left: 0;
   margin-right: 0;
+  width: 100%;
 
   @media (min-width: $pf-global--breakpoint--sm) {
     flex-basis: 0;


### PR DESCRIPTION
## What's included
- fix(pageColumns): maintain columns on granularity change

### Notes
- Minor adjustment to maintain widths during granularity (or any dropdown/select change) that causes the loaders to display for inventory. Appears the minimum widths of the inventory were partially being set by content, this makes them consistently 100%
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. navigate towards the OpenShift Container product view and select any dropdown filter (we used granularity) and confirm the loading display maintains width at smaller screen sizes (< 560px)

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Relates #617 #615 