### PR TITLE
feat(productViewMissing): ent-3753 missing product view

### DIFF
--- a/config/cspell.config.json
+++ b/config/cspell.config.json
@@ -17,6 +17,7 @@
     "flyout",
     "generatedid",
     "HHmmss",
+    "hoverable",
     "ibmpower",
     "ibmz",
     "ipsum",

--- a/public/locales/en-US.json
+++ b/public/locales/en-US.json
@@ -171,12 +171,22 @@
   "curiosity-view": {
     "title": "{{appName}}",
     "subtitle": "Monitor your usage based on your subscription terms. <0>Learn more about {{appName}} reporting</0>",
+    "description": "Monitor your usage based on your subscription terms.",
     "title_OpenShift Container Platform": "OpenShift Container Platform",
     "subtitle_OpenShift Container Platform": "Monitor your OpenShift Container Platform usage for both Annual and On-Demand subscriptions. <0>Learn more about {{appName}} reporting</0>",
+    "description_OpenShift Container Platform": "Monitor your OpenShift Container Platform usage for both Annual and On-Demand subscriptions.",
     "title_OpenShift-dedicated-metrics": "OpenShift Dedicated",
     "subtitle_OpenShift-dedicated-metrics": "Monitor your OpenShift Dedicated usage for On-Demand subscriptions. <0>Learn more about {{appName}} reporting</0>",
+    "description_OpenShift-dedicated-metrics": "Monitor your OpenShift Dedicated usage for On-Demand subscriptions.",
     "title_RHEL": "Red Hat Enterprise Linux",
     "subtitle_RHEL": "Monitor your Red Hat Enterprise Linux usage by physical, virtual, and public cloud sockets. <0>Learn more about {{appName}} reporting</0>",
-    "title_Satellite": "Red Hat Satellite"
+    "description_RHEL": "Monitor your Red Hat Enterprise Linux usage by physical, virtual, and public cloud sockets.",
+    "title_RHEL for ARM": "Red Hat Enterprise Linux for ARM",
+    "title_RHEL for IBM Power": "Red Hat Enterprise Linux for IBM Power",
+    "title_RHEL for IBM z": "Red Hat Enterprise Linux for IBM z",
+    "title_RHEL for x86": "Red Hat Enterprise Linux for x86",
+    "title_Satellite": "Red Hat Satellite",
+    "title_Satellite Capsule": "Red Hat Satellite Capsule",
+    "title_Satellite Server": "Red Hat Satellite Server"
   }
 }

--- a/src/components/authentication/__tests__/__snapshots__/authentication.test.js.snap
+++ b/src/components/authentication/__tests__/__snapshots__/authentication.test.js.snap
@@ -66,7 +66,9 @@ exports[`Authentication Component should render a non-connected component error:
     pageTitle={null}
     title={null}
   >
-    <PageLayout>
+    <PageLayout
+      className=""
+    >
       <PageHeader
         includeTour={false}
         key=".0"
@@ -125,7 +127,7 @@ exports[`Authentication Component should render a non-connected component error:
         </PageHeader>
       </PageHeader>
       <PageSection
-        className="curiosity"
+        className="curiosity "
         padding={
           Object {
             "default": "noPadding",
@@ -133,7 +135,7 @@ exports[`Authentication Component should render a non-connected component error:
         }
       >
         <section
-          className="pf-c-page__main-section pf-m-no-padding curiosity"
+          className="pf-c-page__main-section pf-m-no-padding curiosity "
         >
           <PageSection
             className=""

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -258,6 +258,23 @@ Array [
     ],
   },
   Object {
+    "file": "./src/components/productView/productViewMissing.js",
+    "keys": Array [
+      Object {
+        "key": "curiosity-view.title",
+        "match": "t(\`curiosity-view.title\`, { appName: helpers.UI_DISPLAY_NAME })",
+      },
+      Object {
+        "key": "curiosity-view.title",
+        "match": "t('curiosity-view.title', { appName: helpers.UI_DISPLAY_NAME, context: product.pathParameter })",
+      },
+      Object {
+        "key": "curiosity-view.description",
+        "match": "t('curiosity-view.description', { appName: helpers.UI_DISPLAY_NAME, context: product.productParameter })",
+      },
+    ],
+  },
+  Object {
     "file": "./src/components/productView/productViewOpenShiftContainer.js",
     "keys": Array [
       Object {

--- a/src/components/loader/__tests__/__snapshots__/loader.test.js.snap
+++ b/src/components/loader/__tests__/__snapshots__/loader.test.js.snap
@@ -78,7 +78,9 @@ exports[`Loader Component should handle variant loader components: variant: tabl
 `;
 
 exports[`Loader Component should handle variant loader components: variant: title 1`] = `
-<PageLayout>
+<PageLayout
+  className=""
+>
   <PageHeader
     includeTour={false}
     productLabel={null}

--- a/src/components/messageView/__tests__/__snapshots__/messageView.test.js.snap
+++ b/src/components/messageView/__tests__/__snapshots__/messageView.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MessageView Component should have fallback conditions for all props: fallback display 1`] = `
-<PageLayout>
+<PageLayout
+  className=""
+>
   <PageHeader
     includeTour={false}
     productLabel={null}
@@ -21,7 +23,9 @@ exports[`MessageView Component should have fallback conditions for all props: fa
 `;
 
 exports[`MessageView Component should render a non-connected component: non-connected 1`] = `
-<PageLayout>
+<PageLayout
+  className=""
+>
   <PageHeader
     includeTour={false}
     productLabel={null}
@@ -54,7 +58,9 @@ exports[`MessageView Component should render a non-connected component: non-conn
 `;
 
 exports[`MessageView Component should render children when provided: children display 1`] = `
-<PageLayout>
+<PageLayout
+  className=""
+>
   <PageHeader
     includeTour={false}
     productLabel={null}

--- a/src/components/optinView/__tests__/__snapshots__/optinView.test.js.snap
+++ b/src/components/optinView/__tests__/__snapshots__/optinView.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OptinView Component should render a non-connected component: non-connected 1`] = `
-<PageLayout>
+<PageLayout
+  className=""
+>
   <Card>
     <Flex>
       <Flex
@@ -244,7 +246,9 @@ exports[`OptinView Component should render an API state driven view: fulfilled v
 `;
 
 exports[`OptinView Component should render an API state driven view: initial view 1`] = `
-<PageLayout>
+<PageLayout
+  className=""
+>
   <Card>
     <Flex>
       <Flex

--- a/src/components/pageLayout/__tests__/__snapshots__/pageLayout.test.js.snap
+++ b/src/components/pageLayout/__tests__/__snapshots__/pageLayout.test.js.snap
@@ -1,9 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PageLayout Component should render a basic component: basic 1`] = `
-<PageLayout>
+<PageLayout
+  className=""
+>
   <PageSection
-    className="curiosity"
+    className="curiosity "
     padding={
       Object {
         "default": "noPadding",
@@ -11,7 +13,7 @@ exports[`PageLayout Component should render a basic component: basic 1`] = `
     }
   >
     <section
-      className="pf-c-page__main-section pf-m-no-padding curiosity"
+      className="pf-c-page__main-section pf-m-no-padding curiosity "
     >
       <span
         className="test"
@@ -25,7 +27,9 @@ exports[`PageLayout Component should render a basic component: basic 1`] = `
 `;
 
 exports[`PageLayout Component should render header and section children: multiple children 1`] = `
-<PageLayout>
+<PageLayout
+  className=""
+>
   <PageHeader
     includeTour={false}
     key=".1"
@@ -84,7 +88,7 @@ exports[`PageLayout Component should render header and section children: multipl
     </PageHeader>
   </PageHeader>
   <PageSection
-    className="curiosity"
+    className="curiosity "
     padding={
       Object {
         "default": "noPadding",
@@ -92,7 +96,7 @@ exports[`PageLayout Component should render header and section children: multipl
     }
   >
     <section
-      className="pf-c-page__main-section pf-m-no-padding curiosity"
+      className="pf-c-page__main-section pf-m-no-padding curiosity "
     >
       <PageSection
         className=""

--- a/src/components/pageLayout/pageLayout.js
+++ b/src/components/pageLayout/pageLayout.js
@@ -16,14 +16,15 @@ import { PageToolbar } from './pageToolbar';
  *
  * @param {object} props
  * @param {Node} props.children
+ * @param {string} props.className
  * @returns {Node}
  */
-const PageLayout = ({ children }) => (
+const PageLayout = ({ children, className }) => (
   <React.Fragment>
     {React.Children.toArray(children).filter(child => React.isValidElement(child) && child.type === PageHeader)}
     {React.Children.toArray(children).filter(child => React.isValidElement(child) && child.type === PageMessages)}
     {React.Children.toArray(children).filter(child => React.isValidElement(child) && child.type === PageToolbar)}
-    <Main padding={{ default: 'noPadding' }} className="curiosity">
+    <Main padding={{ default: 'noPadding' }} className={`curiosity ${className}`}>
       {React.Children.toArray(children).filter(
         child => child.type !== PageHeader && child.type !== PageMessages && child.type !== PageToolbar
       )}
@@ -34,15 +35,20 @@ const PageLayout = ({ children }) => (
 /**
  * Prop types.
  *
- * @type {{children: Node}}
+ * @type {{children: Node, className: string}}
  */
 PageLayout.propTypes = {
-  children: PropTypes.node.isRequired
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string
 };
 
 /**
  * Default props.
+ *
+ * @type {{className: string}}
  */
-PageLayout.defaultProps = {};
+PageLayout.defaultProps = {
+  className: ''
+};
 
 export { PageLayout as default, PageLayout, PageColumns, PageHeader, PageMessages, PageSection, PageToolbar };

--- a/src/components/productView/__tests__/__snapshots__/productView.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productView.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ProductView Component should allow custom product views: custom graphCard, descriptions 1`] = `
-<PageLayout>
+<PageLayout
+  className=""
+>
   <PageHeader
     includeTour={true}
     productLabel="lorem ipsum product label"
@@ -132,7 +134,9 @@ exports[`ProductView Component should allow custom product views: custom graphCa
 `;
 
 exports[`ProductView Component should allow custom product views: custom toolbar, toolbarGraph 1`] = `
-<PageLayout>
+<PageLayout
+  className=""
+>
   <PageHeader
     includeTour={true}
     productLabel="lorem ipsum product label"
@@ -207,7 +211,9 @@ exports[`ProductView Component should allow custom product views: custom toolbar
 `;
 
 exports[`ProductView Component should allow custom product views: custom toolbar, toolbarProduct 1`] = `
-<PageLayout>
+<PageLayout
+  className=""
+>
   <PageHeader
     includeTour={true}
     productLabel="lorem ipsum product label"
@@ -282,7 +288,9 @@ exports[`ProductView Component should allow custom product views: custom toolbar
 `;
 
 exports[`ProductView Component should render a non-connected component: non-connected 1`] = `
-<PageLayout>
+<PageLayout
+  className=""
+>
   <PageHeader
     includeTour={true}
     productLabel="lorem ipsum product label"

--- a/src/components/productView/__tests__/__snapshots__/productViewMissing.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productViewMissing.test.js.snap
@@ -1,0 +1,225 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProductViewMissing Component should render a non-connected component: non-connected 1`] = `
+<PageLayout
+  className="curiosity-missing-view"
+>
+  <PageHeader
+    includeTour={true}
+    productLabel="missing"
+    t={[Function]}
+  >
+    t(curiosity-view.title, {"appName":"Subscriptions"})
+  </PageHeader>
+  <PageSection
+    isFilled={true}
+  >
+    <Gallery
+      hasGutter={true}
+    >
+      <Card
+        isHoverable={true}
+        key="rhel"
+        onClick={[Function]}
+      >
+        <CardTitle>
+          <Title
+            headingLevel="h2"
+            size="lg"
+          >
+            t(curiosity-view.title, {"appName":"Subscriptions","context":"RHEL"})
+          </Title>
+        </CardTitle>
+        <CardBody
+          className="curiosity-missing-view__card-description"
+        >
+          t(curiosity-view.description, {"appName":"Subscriptions","context":"RHEL"})
+        </CardBody>
+        <CardFooter>
+          <Button
+            icon={
+              <ArrowRightIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+              />
+            }
+            iconPosition="right"
+            isInline={true}
+            onClick={[Function]}
+            variant="link"
+          >
+            Open
+          </Button>
+        </CardFooter>
+      </Card>
+      <Card
+        isHoverable={true}
+        key="openshift-container"
+        onClick={[Function]}
+      >
+        <CardTitle>
+          <Title
+            headingLevel="h2"
+            size="lg"
+          >
+            t(curiosity-view.title, {"appName":"Subscriptions","context":"OpenShift Container Platform"})
+          </Title>
+        </CardTitle>
+        <CardBody
+          className="curiosity-missing-view__card-description"
+        >
+          t(curiosity-view.description, {"appName":"Subscriptions","context":"OpenShift Container Platform"})
+        </CardBody>
+        <CardFooter>
+          <Button
+            icon={
+              <ArrowRightIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+              />
+            }
+            iconPosition="right"
+            isInline={true}
+            onClick={[Function]}
+            variant="link"
+          >
+            Open
+          </Button>
+        </CardFooter>
+      </Card>
+      <Card
+        isHoverable={true}
+        key="openshift-dedicated"
+        onClick={[Function]}
+      >
+        <CardTitle>
+          <Title
+            headingLevel="h2"
+            size="lg"
+          >
+            t(curiosity-view.title, {"appName":"Subscriptions","context":"OpenShift-dedicated-metrics"})
+          </Title>
+        </CardTitle>
+        <CardBody
+          className="curiosity-missing-view__card-description"
+        >
+          t(curiosity-view.description, {"appName":"Subscriptions","context":"OpenShift-dedicated-metrics"})
+        </CardBody>
+        <CardFooter>
+          <Button
+            icon={
+              <ArrowRightIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+              />
+            }
+            iconPosition="right"
+            isInline={true}
+            onClick={[Function]}
+            variant="link"
+          >
+            Open
+          </Button>
+        </CardFooter>
+      </Card>
+    </Gallery>
+  </PageSection>
+</PageLayout>
+`;
+
+exports[`ProductViewMissing Component should render a predictable set of product cards: non-connected 1`] = `
+<PageLayout
+  className="curiosity-missing-view"
+>
+  <PageHeader
+    includeTour={true}
+    productLabel="missing"
+    t={[Function]}
+  >
+    t(curiosity-view.title, {"appName":"Subscriptions"})
+  </PageHeader>
+  <PageSection
+    isFilled={true}
+  >
+    <Gallery
+      hasGutter={true}
+    >
+      <Card
+        isHoverable={true}
+        key="test 001"
+        onClick={[Function]}
+      >
+        <CardTitle>
+          <Title
+            headingLevel="h2"
+            size="lg"
+          >
+            t(curiosity-view.title, {"appName":"Subscriptions"})
+          </Title>
+        </CardTitle>
+        <CardBody
+          className="curiosity-missing-view__card-description"
+        >
+          t(curiosity-view.description, {"appName":"Subscriptions","context":"loremIpsum"})
+        </CardBody>
+        <CardFooter>
+          <Button
+            icon={
+              <ArrowRightIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+              />
+            }
+            iconPosition="right"
+            isInline={true}
+            onClick={[Function]}
+            variant="link"
+          >
+            Open
+          </Button>
+        </CardFooter>
+      </Card>
+      <Card
+        isHoverable={true}
+        key="test 002"
+        onClick={[Function]}
+      >
+        <CardTitle>
+          <Title
+            headingLevel="h2"
+            size="lg"
+          >
+            t(curiosity-view.title, {"appName":"Subscriptions"})
+          </Title>
+        </CardTitle>
+        <CardBody
+          className="curiosity-missing-view__card-description"
+        >
+          t(curiosity-view.description, {"appName":"Subscriptions","context":"dolorSit"})
+        </CardBody>
+        <CardFooter>
+          <Button
+            icon={
+              <ArrowRightIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+              />
+            }
+            iconPosition="right"
+            isInline={true}
+            onClick={[Function]}
+            variant="link"
+          >
+            Open
+          </Button>
+        </CardFooter>
+      </Card>
+    </Gallery>
+  </PageSection>
+</PageLayout>
+`;

--- a/src/components/productView/__tests__/__snapshots__/productViewOpenShiftContainer.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productViewOpenShiftContainer.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ProductViewOpenShiftContainer Component should render a non-connected component: non-connected 1`] = `
-<PageLayout>
+<PageLayout
+  className=""
+>
   <PageHeader
     includeTour={true}
     productLabel="dolor sit"

--- a/src/components/productView/__tests__/productViewMissing.test.js
+++ b/src/components/productView/__tests__/productViewMissing.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { ProductViewMissing } from '../productViewMissing';
+
+describe('ProductViewMissing Component', () => {
+  it('should render a non-connected component', () => {
+    const props = {};
+    const component = shallow(<ProductViewMissing {...props} />);
+    expect(component).toMatchSnapshot('non-connected');
+  });
+
+  it('should render a predictable set of product cards', () => {
+    const props = {
+      basePath: '/loremIpsum/dolorSit/',
+      products: [
+        {
+          id: 'test 001',
+          isSearchable: true,
+          path: '/loremIpsum',
+          productParameter: 'loremIpsum'
+        },
+        {
+          id: 'test 002',
+          isSearchable: true,
+          path: '/dolorSit',
+          productParameter: 'dolorSit'
+        },
+        {
+          id: 'test 003',
+          isSearchable: false,
+          path: '/test003',
+          productParameter: 'test003'
+        }
+      ]
+    };
+    const component = shallow(<ProductViewMissing {...props} />);
+    expect(component).toMatchSnapshot('non-connected');
+  });
+});

--- a/src/components/productView/productViewMissing.js
+++ b/src/components/productView/productViewMissing.js
@@ -1,0 +1,135 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, Card, CardBody, CardFooter, CardTitle, Gallery, Title, PageSection } from '@patternfly/react-core';
+import { ArrowRightIcon } from '@patternfly/react-icons';
+import { useHistory } from 'react-router-dom';
+import { PageLayout, PageHeader } from '../pageLayout/pageLayout';
+import { routerConfig, routerHelpers } from '../router/router';
+import { helpers } from '../../common';
+import { translate } from '../i18n/i18n';
+
+/**
+ * Render a missing product view.
+ *
+ * @fires onClick
+ * @param {object} props
+ * @param {string} props.basePath
+ * @param {Array} props.products
+ * @param {Function} props.t
+ * @returns {Node}
+ */
+const ProductViewMissing = ({ basePath, products, t }) => {
+  const history = useHistory();
+
+  /**
+   * Return a list of available products.
+   *
+   * @returns {Array}
+   */
+  const filterAvailableProducts = () => {
+    const basePathDirs = basePath.split('/');
+    const updatedProducts = {};
+
+    basePathDirs.forEach(dir => {
+      if (dir) {
+        products.forEach(({ id, productParameter, isSearchable, ...navItem }) => {
+          if (isSearchable && new RegExp(dir, 'i').test(productParameter)) {
+            updatedProducts[id] = {
+              id,
+              productParameter,
+              isSearchable,
+              ...navItem
+            };
+          }
+        });
+      }
+    });
+
+    const filteredProducts = Object.values(updatedProducts);
+    return (
+      (filteredProducts.length && filteredProducts) ||
+      routerConfig.navigation.filter(
+        ({ isSearchable, productParameter }) => (isSearchable && productParameter) || false
+      )
+    );
+  };
+
+  /**
+   * On click, update history.
+   *
+   * @event onUpdateHistory
+   * @param {string} path
+   * @returns {void}
+   */
+  const onClick = path => history.push(path);
+
+  return (
+    <PageLayout className="curiosity-missing-view">
+      <PageHeader productLabel="missing" includeTour>
+        {t(`curiosity-view.title`, { appName: helpers.UI_DISPLAY_NAME })}
+      </PageHeader>
+      <PageSection isFilled>
+        <Gallery hasGutter>
+          {filterAvailableProducts().map(product => (
+            <Card key={product.id} isHoverable onClick={() => onClick(product.path)}>
+              <CardTitle>
+                <Title headingLevel="h2" size="lg">
+                  {t('curiosity-view.title', { appName: helpers.UI_DISPLAY_NAME, context: product.pathParameter })}
+                </Title>
+              </CardTitle>
+              <CardBody className="curiosity-missing-view__card-description">
+                {t('curiosity-view.description', {
+                  appName: helpers.UI_DISPLAY_NAME,
+                  context: product.productParameter
+                })}
+              </CardBody>
+              <CardFooter>
+                <Button
+                  variant="link"
+                  isInline
+                  onClick={() => onClick(product.path)}
+                  icon={<ArrowRightIcon />}
+                  iconPosition="right"
+                >
+                  Open
+                </Button>
+              </CardFooter>
+            </Card>
+          ))}
+        </Gallery>
+      </PageSection>
+    </PageLayout>
+  );
+};
+
+/**
+ * Prop types.
+ *
+ * @type {{t: Function}}
+ */
+ProductViewMissing.propTypes = {
+  basePath: PropTypes.string,
+  products: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      isSearchable: PropTypes.bool.isRequired,
+      path: PropTypes.string.isRequired,
+      pathParameter: PropTypes.string,
+      productParameter: PropTypes.string.isRequired
+    })
+  ),
+  t: PropTypes.func
+};
+
+/**
+ * Default props.
+ *
+ * @type {{t: translate}}
+ */
+ProductViewMissing.defaultProps = {
+  basePath: routerHelpers.basePath,
+  products: routerConfig.navigation,
+  t: translate
+};
+
+export { ProductViewMissing as default, ProductViewMissing };

--- a/src/components/router/__tests__/__snapshots__/router.test.js.snap
+++ b/src/components/router/__tests__/__snapshots__/router.test.js.snap
@@ -143,6 +143,19 @@ exports[`Router Component should render a basic component: basic 1`] = `
         "render": true,
         "to": "/optin",
       },
+      Object {
+        "component": Object {
+          "$$typeof": Symbol(react.lazy),
+          "_ctor": [Function],
+          "_result": null,
+          "_status": -1,
+        },
+        "disabled": false,
+        "exact": true,
+        "redirect": "/",
+        "render": true,
+        "to": "/",
+      },
     ]
   }
 >
@@ -176,6 +189,15 @@ exports[`Router Component should render a basic component: basic 1`] = `
       key="/optin"
       path="/optin"
       render={[Function]}
+    />
+    <Route
+      exact={true}
+      key="/"
+      path="/"
+      render={[Function]}
+    />
+    <Redirect
+      to="/"
     />
   </Switch>
 </Router>

--- a/src/components/router/__tests__/__snapshots__/routerConfig.test.js.snap
+++ b/src/components/router/__tests__/__snapshots__/routerConfig.test.js.snap
@@ -5,8 +5,8 @@ exports[`RouterConfig should return specific properties: appName 1`] = `"subscri
 exports[`RouterConfig should return specific properties: navigation 1`] = `
 Array [
   Object {
-    "default": true,
     "id": "rhel",
+    "isSearchable": true,
     "path": "/rhel",
     "pathParameter": "RHEL",
     "productParameter": "RHEL",
@@ -14,6 +14,7 @@ Array [
   },
   Object {
     "id": "rhel-arm",
+    "isSearchable": false,
     "path": "/rhel-arm",
     "pathParameter": "RHEL for ARM",
     "productParameter": "RHEL",
@@ -21,6 +22,7 @@ Array [
   },
   Object {
     "id": "rhel-ibmpower",
+    "isSearchable": false,
     "path": "/rhel-ibmpower",
     "pathParameter": "RHEL for IBM Power",
     "productParameter": "RHEL",
@@ -28,6 +30,7 @@ Array [
   },
   Object {
     "id": "rhel-ibmz",
+    "isSearchable": false,
     "path": "/rhel-ibmz",
     "pathParameter": "RHEL for IBM z",
     "productParameter": "RHEL",
@@ -35,6 +38,7 @@ Array [
   },
   Object {
     "id": "rhel-x86",
+    "isSearchable": false,
     "path": "/rhel-x86",
     "pathParameter": "RHEL for x86",
     "productParameter": "RHEL",
@@ -42,6 +46,7 @@ Array [
   },
   Object {
     "id": "openshift-container",
+    "isSearchable": true,
     "path": "/openshift-container",
     "pathParameter": "OpenShift Container Platform",
     "productParameter": "OpenShift Container Platform",
@@ -49,6 +54,7 @@ Array [
   },
   Object {
     "id": "openshift-dedicated",
+    "isSearchable": true,
     "path": "/openshift-dedicated",
     "pathParameter": "OpenShift-dedicated-metrics",
     "productParameter": "OpenShift-dedicated-metrics",
@@ -56,6 +62,7 @@ Array [
   },
   Object {
     "id": "satellite",
+    "isSearchable": false,
     "path": "/satellite",
     "pathParameter": "Satellite",
     "productParameter": "Satellite",
@@ -63,6 +70,7 @@ Array [
   },
   Object {
     "id": "satellite-capsule",
+    "isSearchable": false,
     "path": "/satellite-capsule",
     "pathParameter": "Satellite Capsule",
     "productParameter": "Satellite",
@@ -70,6 +78,7 @@ Array [
   },
   Object {
     "id": "satellite-server",
+    "isSearchable": false,
     "path": "/satellite-server",
     "pathParameter": "Satellite Server",
     "productParameter": "Satellite",
@@ -77,7 +86,17 @@ Array [
   },
   Object {
     "id": "optin",
+    "isSearchable": false,
     "path": "/optin",
+    "pathParameter": null,
+    "productParameter": null,
+    "viewParameter": null,
+  },
+  Object {
+    "default": true,
+    "id": "missing",
+    "isSearchable": false,
+    "path": "/",
     "pathParameter": null,
     "productParameter": null,
     "viewParameter": null,
@@ -177,6 +196,19 @@ Array [
     "exact": true,
     "render": true,
     "to": "/optin",
+  },
+  Object {
+    "component": Object {
+      "$$typeof": Symbol(react.lazy),
+      "_ctor": [Function],
+      "_result": null,
+      "_status": -1,
+    },
+    "disabled": false,
+    "exact": true,
+    "redirect": "/",
+    "render": true,
+    "to": "/",
   },
 ]
 `;

--- a/src/components/router/__tests__/__snapshots__/routerHelpers.test.js.snap
+++ b/src/components/router/__tests__/__snapshots__/routerHelpers.test.js.snap
@@ -59,8 +59,8 @@ Object {
 exports[`RouterHelpers should return navigation and route details that align to location: detail: match specific path navigation 1`] = `
 Object {
   "nav": Object {
-    "default": true,
     "id": "rhel",
+    "isSearchable": true,
     "path": "/rhel",
     "pathParameter": "RHEL",
     "productParameter": "RHEL",
@@ -74,10 +74,10 @@ Object {
       "_result": null,
       "_status": -1,
     },
-    "default": true,
     "disabled": false,
     "exact": true,
     "id": "rhel",
+    "isSearchable": true,
     "path": "/rhel",
     "pathParameter": "RHEL",
     "productParameter": "RHEL",
@@ -104,8 +104,8 @@ Object {
 exports[`RouterHelpers should return navigation and route details that align to location: detail: missing ID, specific path 1`] = `
 Object {
   "nav": Object {
-    "default": true,
     "id": "rhel",
+    "isSearchable": true,
     "path": "/rhel",
     "pathParameter": "RHEL",
     "productParameter": "RHEL",
@@ -119,10 +119,10 @@ Object {
       "_result": null,
       "_status": -1,
     },
-    "default": true,
     "disabled": false,
     "exact": true,
     "id": "rhel",
+    "isSearchable": true,
     "path": "/rhel",
     "pathParameter": "RHEL",
     "productParameter": "RHEL",
@@ -158,12 +158,13 @@ exports[`RouterHelpers should return navigation and route details that align to 
 Object {
   "nav": Object {
     "default": true,
-    "id": "rhel",
-    "path": "/rhel",
-    "pathParameter": "RHEL",
-    "productParameter": "RHEL",
-    "routeHref": "/rhel",
-    "viewParameter": "viewRHEL",
+    "id": "missing",
+    "isSearchable": false,
+    "path": "/",
+    "pathParameter": null,
+    "productParameter": null,
+    "routeHref": "/",
+    "viewParameter": null,
   },
   "navRoute": Object {
     "component": Object {
@@ -175,14 +176,16 @@ Object {
     "default": true,
     "disabled": false,
     "exact": true,
-    "id": "rhel",
-    "path": "/rhel",
-    "pathParameter": "RHEL",
-    "productParameter": "RHEL",
+    "id": "missing",
+    "isSearchable": false,
+    "path": "/",
+    "pathParameter": null,
+    "productParameter": null,
+    "redirect": "/",
     "render": true,
-    "routeHref": "/rhel",
-    "to": "/:variant(rhel|rhel-arm|rhel-ibmpower|rhel-ibmz|rhel-x86)",
-    "viewParameter": "viewRHEL",
+    "routeHref": "/",
+    "to": "/",
+    "viewParameter": null,
   },
   "route": Object {},
 }
@@ -200,6 +203,7 @@ exports[`RouterHelpers should return navigation and route details that align to 
 Object {
   "nav": Object {
     "id": "rhel-arm",
+    "isSearchable": false,
     "path": "/rhel-arm",
     "pathParameter": "RHEL for ARM",
     "productParameter": "RHEL",
@@ -216,6 +220,7 @@ Object {
     "disabled": false,
     "exact": true,
     "id": "rhel-arm",
+    "isSearchable": false,
     "path": "/rhel-arm",
     "pathParameter": "RHEL for ARM",
     "productParameter": "RHEL",
@@ -232,6 +237,7 @@ exports[`RouterHelpers should return navigation and route details that align to 
 Object {
   "nav": Object {
     "id": "optin",
+    "isSearchable": false,
     "path": "/optin",
     "pathParameter": null,
     "productParameter": null,
@@ -249,6 +255,7 @@ Object {
     "disabled": false,
     "exact": true,
     "id": "optin",
+    "isSearchable": false,
     "path": "/optin",
     "pathParameter": null,
     "productParameter": null,

--- a/src/components/router/__tests__/routerConfig.test.js
+++ b/src/components/router/__tests__/routerConfig.test.js
@@ -30,6 +30,6 @@ describe('RouterConfig', () => {
       }
     });
 
-    expect(lazyLoadComponents.length).toBe(5);
+    expect(lazyLoadComponents.length).toBe(6);
   });
 });

--- a/src/components/router/__tests__/routerHelpers.test.js
+++ b/src/components/router/__tests__/routerHelpers.test.js
@@ -1,5 +1,6 @@
 import {
   baseName,
+  basePath,
   dynamicBaseName,
   getErrorRoute,
   getNavigationDetail,
@@ -19,6 +20,7 @@ describe('RouterHelpers', () => {
 
   it('should return specific properties', () => {
     expect(baseName).toBeDefined();
+    expect(basePath).toBeDefined();
     expect(dynamicBaseName).toBeDefined();
     expect(getErrorRoute).toBeDefined();
     expect(getNavigationDetail).toBeDefined();

--- a/src/components/router/routerConfig.js
+++ b/src/components/router/routerConfig.js
@@ -92,6 +92,14 @@ const routes = [
     render: true,
     activateOnError: true,
     disabled: helpers.UI_DISABLED
+  },
+  {
+    to: '/',
+    redirect: '/',
+    component: React.lazy(() => import('../productView/productViewMissing')),
+    exact: true,
+    render: true,
+    disabled: helpers.UI_DISABLED
   }
 ];
 
@@ -107,77 +115,96 @@ const navigation = [
     pathParameter: RHSM_API_PATH_ID_TYPES.RHEL,
     productParameter: RHSM_API_PATH_ID_TYPES.RHEL,
     viewParameter: `view${RHSM_API_PATH_ID_TYPES.RHEL}`,
-    default: true
+    isSearchable: true
   },
   {
     id: 'rhel-arm',
     path: '/rhel-arm',
     pathParameter: RHSM_API_PATH_ID_TYPES.RHEL_ARM,
     productParameter: RHSM_API_PATH_ID_TYPES.RHEL,
-    viewParameter: `view${RHSM_API_PATH_ID_TYPES.RHEL}`
+    viewParameter: `view${RHSM_API_PATH_ID_TYPES.RHEL}`,
+    isSearchable: false
   },
   {
     id: 'rhel-ibmpower',
     path: '/rhel-ibmpower',
     pathParameter: RHSM_API_PATH_ID_TYPES.RHEL_IBM_POWER,
     productParameter: RHSM_API_PATH_ID_TYPES.RHEL,
-    viewParameter: `view${RHSM_API_PATH_ID_TYPES.RHEL}`
+    viewParameter: `view${RHSM_API_PATH_ID_TYPES.RHEL}`,
+    isSearchable: false
   },
   {
     id: 'rhel-ibmz',
     path: '/rhel-ibmz',
     pathParameter: RHSM_API_PATH_ID_TYPES.RHEL_IBM_Z,
     productParameter: RHSM_API_PATH_ID_TYPES.RHEL,
-    viewParameter: `view${RHSM_API_PATH_ID_TYPES.RHEL}`
+    viewParameter: `view${RHSM_API_PATH_ID_TYPES.RHEL}`,
+    isSearchable: false
   },
   {
     id: 'rhel-x86',
     path: '/rhel-x86',
     pathParameter: RHSM_API_PATH_ID_TYPES.RHEL_X86,
     productParameter: RHSM_API_PATH_ID_TYPES.RHEL,
-    viewParameter: `view${RHSM_API_PATH_ID_TYPES.RHEL}`
+    viewParameter: `view${RHSM_API_PATH_ID_TYPES.RHEL}`,
+    isSearchable: false
   },
   {
     id: 'openshift-container',
     path: '/openshift-container',
     pathParameter: RHSM_API_PATH_ID_TYPES.OPENSHIFT,
     productParameter: RHSM_API_PATH_ID_TYPES.OPENSHIFT,
-    viewParameter: `view${RHSM_API_PATH_ID_TYPES.OPENSHIFT}`
+    viewParameter: `view${RHSM_API_PATH_ID_TYPES.OPENSHIFT}`,
+    isSearchable: true
   },
   {
     id: 'openshift-dedicated',
     path: '/openshift-dedicated',
     pathParameter: RHSM_API_PATH_ID_TYPES.OPENSHIFT_DEDICATED_METRICS,
     productParameter: RHSM_API_PATH_ID_TYPES.OPENSHIFT_DEDICATED_METRICS,
-    viewParameter: `view${RHSM_API_PATH_ID_TYPES.OPENSHIFT_DEDICATED_METRICS}`
+    viewParameter: `view${RHSM_API_PATH_ID_TYPES.OPENSHIFT_DEDICATED_METRICS}`,
+    isSearchable: true
   },
   {
     id: 'satellite',
     path: '/satellite',
     pathParameter: RHSM_API_PATH_ID_TYPES.SATELLITE,
     productParameter: RHSM_API_PATH_ID_TYPES.SATELLITE,
-    viewParameter: `view${RHSM_API_PATH_ID_TYPES.SATELLITE}`
+    viewParameter: `view${RHSM_API_PATH_ID_TYPES.SATELLITE}`,
+    isSearchable: false
   },
   {
     id: 'satellite-capsule',
     path: '/satellite-capsule',
     pathParameter: RHSM_API_PATH_ID_TYPES.SATELLITE_CAPSULE,
     productParameter: RHSM_API_PATH_ID_TYPES.SATELLITE,
-    viewParameter: `view${RHSM_API_PATH_ID_TYPES.SATELLITE}`
+    viewParameter: `view${RHSM_API_PATH_ID_TYPES.SATELLITE}`,
+    isSearchable: false
   },
   {
     id: 'satellite-server',
     path: '/satellite-server',
     pathParameter: RHSM_API_PATH_ID_TYPES.SATELLITE_SERVER,
     productParameter: RHSM_API_PATH_ID_TYPES.SATELLITE,
-    viewParameter: `view${RHSM_API_PATH_ID_TYPES.SATELLITE}`
+    viewParameter: `view${RHSM_API_PATH_ID_TYPES.SATELLITE}`,
+    isSearchable: false
   },
   {
     id: 'optin',
     path: '/optin',
     pathParameter: null,
     productParameter: null,
-    viewParameter: null
+    viewParameter: null,
+    isSearchable: false
+  },
+  {
+    id: 'missing',
+    path: '/',
+    pathParameter: null,
+    productParameter: null,
+    viewParameter: null,
+    isSearchable: false,
+    default: true
   }
 ];
 

--- a/src/components/router/routerHelpers.js
+++ b/src/components/router/routerHelpers.js
@@ -22,6 +22,14 @@ const dynamicBaseName = ({ pathName = window.location.pathname, appName = helper
 const baseName = (helpers.TEST_MODE && '/') || (helpers.DEV_MODE && '/') || dynamicBaseName();
 
 /**
+ * App basePath.
+ *
+ * @type {string}
+ */
+const basePath =
+  (helpers.TEST_MODE && '/') || (helpers.DEV_MODE && '/') || window.location.pathname.split(helpers.UI_NAME)[0];
+
+/**
  * The first error route.
  *
  * @type {object}
@@ -114,6 +122,7 @@ const getNavRouteDetail = ({ id = null, pathname = null, returnDefault = false }
 
 const routerHelpers = {
   baseName,
+  basePath,
   dynamicBaseName,
   getErrorRoute,
   getNavigationDetail,
@@ -125,6 +134,7 @@ export {
   routerHelpers as default,
   routerHelpers,
   baseName,
+  basePath,
   dynamicBaseName,
   getErrorRoute,
   getNavigationDetail,

--- a/src/styles/_inventory-list.scss
+++ b/src/styles/_inventory-list.scss
@@ -1,13 +1,9 @@
 .curiosity {
-  &.pf-c-page__main-section {
-    box-shadow: var(--pf-global--BoxShadow--sm);
-
-    .pf-c-card {
+  .curiosity-inventory-card {
+    &.pf-c-card {
       box-shadow: none;
     }
-  }
 
-  .curiosity-inventory-card {
     .pf-c-card__header {
       padding-bottom: 0;
     }

--- a/src/styles/_page-layout.scss
+++ b/src/styles/_page-layout.scss
@@ -1,3 +1,9 @@
+.curiosity {
+  &.pf-c-page__main-section {
+    box-shadow: var(--pf-global--BoxShadow--sm);
+  }
+}
+
 .curiosity-page-messages,
 .curiosity-page-toolbar,
 .curiosity-page-section,

--- a/src/styles/_product-view.scss
+++ b/src/styles/_product-view.scss
@@ -1,0 +1,15 @@
+.curiosity {
+  &.curiosity-missing-view {
+    padding: 1em;
+
+    .pf-c-card {
+      &.pf-m-hoverable {
+        cursor: pointer;
+
+        .curiosity-missing-view__card-description {
+          color: var(--pf-global--Color--200);
+        }
+      }
+    }
+  }
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -11,6 +11,7 @@
 // App
 @import 'page-layout';
 @import 'fade';
+@import 'product-view';
 @import 'optin';
 @import 'usage-graph';
 @import 'skeleton';

--- a/tests/__snapshots__/dist.test.js.snap
+++ b/tests/__snapshots__/dist.test.js.snap
@@ -17,6 +17,8 @@ Array [
   "./build/static/js/1*chunk.js",
   "./build/static/js/10*chunk*map",
   "./build/static/js/10*chunk.js",
+  "./build/static/js/11*chunk*map",
+  "./build/static/js/11*chunk.js",
   "./build/static/js/2*chunk*map",
   "./build/static/js/2*chunk.js",
   "./build/static/js/5*chunk*LICENSE.txt",


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- feat(productViewMissing): apply a missing product view
   * i18n, missing product view strings, product titles
   * pageLayout, allow additional classNames
   * routerConfig, fallback root route, add nav filter prop, isSearchable
   * routerHelpers, basePath, consistency with baseName
   * styling, add product view styling for missing view, clean up

### Notes
- Utilizes the Curiosity navigation and routing config to display relevant product cards based on the individual directory/path facets within `window.pathname`
   - Curiosity's attempt to match a path in the form of `/beta/insights/subscriptions` or `/rhel/subscriptions` or `/random-path/openshift/subscriptions` will attempt a match on each path/dir segment, ie. for...
      - `/beta/insights/subscriptions` that would be "beta" and "insights", 
      - `/rhel/subscriptions` that would be "rhel"
      - `/random-path/openshift/subscriptions` that would be "random-path" and "openshift"
   - If a match isn't made Curiosity will return ALL cards on searchable/listable products
      -  _* Note, "insights" is a reference towards the Cloud Dot platform, a non-graphable-all-encompassing-product, "insights" will NOT bring up RHEL products. When "insights" is converted towards "RHEL" it will bring up Curiosity's RHEL product card(s)_
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. navigate towards `/beta/insights/subscriptions` or `/beta/openshift/subscriptions`

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
  
![Screen Shot 2021-04-22 at 1 18 27 AM](https://user-images.githubusercontent.com/3761375/115662625-3d1ac900-a30d-11eb-8e7e-be1e987286db.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Relates towards RHCLOUD-13632
Relates ent-3753