### PR TITLE
Draft release 1.5.0, Sync Test to Stage - cumulative total display

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+      day: monday
+    open-pull-requests-limit: 2
+    target-branch: "ci"
+    versioning-strategy: increase
+    allow:
+      - dependency-type: direct
+    labels:
+      - "build"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+      day: monday
+    open-pull-requests-limit: 2
+    target-branch: "ci"
+    labels:
+      - "build"


### PR DESCRIPTION
## Description
Update to the draft 1.5.0 GUI release

## Changed/added/updated commits
### Features
1. **graphCard** ent-3715 display core hours monthly total (#632) (6cc546d)

### Bug Fixes
1. **graphCardSelectors** ent-3809 schema check for core hours (#628) (fbd237a)
1. **locale** ent-3810 flexible to on-demand, fixed to annual (#629) (c595aa5)

## Full commit list
see #627 