### PR TITLE
fix(productView): low precision display for core hours used

### DIFF
--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -298,7 +298,7 @@ Array [
       },
       Object {
         "key": "curiosity-graph.card-action-total",
-        "match": "translate('curiosity-graph.card-action-total', { context: 'coreHours', total: (total >= 1000 && numbro(total)",
+        "match": "translate('curiosity-graph.card-action-total', { context: 'coreHours', total: numbro(total)",
       },
       Object {
         "key": "curiosity-inventory.label",
@@ -311,7 +311,7 @@ Array [
     "keys": Array [
       Object {
         "key": "curiosity-graph.card-action-total",
-        "match": "translate('curiosity-graph.card-action-total', { context: 'coreHours', total: (total >= 1000 && numbro(total)",
+        "match": "translate('curiosity-graph.card-action-total', { context: 'coreHours', total: numbro(total)",
       },
       Object {
         "key": "curiosity-inventory.label",

--- a/src/components/productView/__tests__/__snapshots__/productViewOpenShiftContainer.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productViewOpenShiftContainer.test.js.snap
@@ -881,7 +881,18 @@ Object {
   "productTwoActionDisplay": <div
     className="curiosity-usage-graph__total"
   >
-    t(curiosity-graph.card-action-total, {"context":"coreHours","total":500})
+    t(curiosity-graph.card-action-total, {"context":"coreHours","total":"500"})
+  </div>,
+}
+`;
+
+exports[`ProductViewOpenShiftContainer Component should set multiple product configurations: product action display should display a total value below 1000000 1`] = `
+Object {
+  "productOneActionDisplay": undefined,
+  "productTwoActionDisplay": <div
+    className="curiosity-usage-graph__total"
+  >
+    t(curiosity-graph.card-action-total, {"context":"coreHours","total":"900K"})
   </div>,
 }
 `;

--- a/src/components/productView/__tests__/__snapshots__/productViewOpenShiftDedicated.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productViewOpenShiftDedicated.test.js.snap
@@ -369,7 +369,17 @@ Object {
   "productActionDisplay": <div
     className="curiosity-usage-graph__total"
   >
-    t(curiosity-graph.card-action-total, {"context":"coreHours","total":500})
+    t(curiosity-graph.card-action-total, {"context":"coreHours","total":"500"})
+  </div>,
+}
+`;
+
+exports[`ProductViewOpenShiftDedicated Component should set product configuration: product action display should display a total value below 1000000 1`] = `
+Object {
+  "productActionDisplay": <div
+    className="curiosity-usage-graph__total"
+  >
+    t(curiosity-graph.card-action-total, {"context":"coreHours","total":"900K"})
   </div>,
 }
 `;

--- a/src/components/productView/__tests__/productViewOpenShiftContainer.test.js
+++ b/src/components/productView/__tests__/productViewOpenShiftContainer.test.js
@@ -118,6 +118,23 @@ describe('ProductViewOpenShiftContainer Component', () => {
             y: 0
           },
           {
+            y: 800000
+          },
+          {
+            y: 100000
+          }
+        ]
+      })
+    }).toMatchSnapshot('product action display should display a total value below 1000000');
+
+    expect({
+      productOneActionDisplay: undefined,
+      productTwoActionDisplay: productTwo.initialGraphSettings.actionDisplay({
+        coreHours: [
+          {
+            y: 0
+          },
+          {
             y: 1000
           },
           {

--- a/src/components/productView/__tests__/productViewOpenShiftDedicated.test.js
+++ b/src/components/productView/__tests__/productViewOpenShiftDedicated.test.js
@@ -91,6 +91,24 @@ describe('ProductViewOpenShiftDedicated Component', () => {
               y: 0
             },
             {
+              y: 800000
+            },
+            {
+              y: 100000
+            }
+          ]
+        }
+      )
+    }).toMatchSnapshot('product action display should display a total value below 1000000');
+
+    expect({
+      productActionDisplay: ProductViewOpenShiftDedicated.defaultProps.productConfig.initialGraphSettings.actionDisplay(
+        {
+          coreHours: [
+            {
+              y: 0
+            },
+            {
               y: 1000
             },
             {

--- a/src/components/productView/productViewOpenShiftContainer.js
+++ b/src/components/productView/productViewOpenShiftContainer.js
@@ -452,10 +452,9 @@ ProductViewOpenShiftContainer.defaultProps = {
 
             displayContent = translate('curiosity-graph.card-action-total', {
               context: 'coreHours',
-              total:
-                (total >= 1000 &&
-                  numbro(total).format({ average: true, mantissa: 2, trimMantissa: true }).toUpperCase()) ||
-                total
+              total: numbro(total)
+                .format({ average: true, mantissa: 2, trimMantissa: true, lowPrecision: false })
+                .toUpperCase()
             });
           }
 

--- a/src/components/productView/productViewOpenShiftDedicated.js
+++ b/src/components/productView/productViewOpenShiftDedicated.js
@@ -96,10 +96,9 @@ ProductViewOpenShiftDedicated.defaultProps = {
 
           displayContent = translate('curiosity-graph.card-action-total', {
             context: 'coreHours',
-            total:
-              (total >= 1000 &&
-                numbro(total).format({ average: true, mantissa: 2, trimMantissa: true }).toUpperCase()) ||
-              total
+            total: numbro(total)
+              .format({ average: true, mantissa: 2, trimMantissa: true, lowPrecision: false })
+              .toUpperCase()
           });
         }
 


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(productView): low precision display for core hours used

### Notes
- use numbro standalone
- @mirekdlugosz 
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm the "core hours used" displays scenarios similar with
   - 0.6K == 600
   - 0.9K == 900
   - 0.6M == 600K
   - 0.9M == 900K

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
relates ent-3816