### PR TITLE
fix(productViewMissing): relax proptypes

### DIFF
--- a/src/components/productView/productViewMissing.js
+++ b/src/components/productView/productViewMissing.js
@@ -115,7 +115,7 @@ ProductViewMissing.propTypes = {
       isSearchable: PropTypes.bool.isRequired,
       path: PropTypes.string.isRequired,
       pathParameter: PropTypes.string,
-      productParameter: PropTypes.string.isRequired
+      productParameter: PropTypes.string
     })
   ),
   t: PropTypes.func

--- a/src/styles/_product-view.scss
+++ b/src/styles/_product-view.scss
@@ -1,5 +1,6 @@
 .curiosity {
   &.curiosity-missing-view {
+    box-shadow: none;
     padding: 1em;
 
     .pf-c-card {


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(productViewMissing): relax proptypes

### Notes
- also corrects a minor box shadow issue
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm the box shadow does NOT display below the product cards

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
### before, box shadow
![Screen Shot 2021-04-28 at 5 21 53 PM](https://user-images.githubusercontent.com/3761375/116474255-45f82700-a846-11eb-9489-8972ae293017.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Relates #630 