### PR TITLE
fix(userSelectors): ent-3825 add report read permissions

### DIFF
--- a/src/redux/selectors/userSelectors.js
+++ b/src/redux/selectors/userSelectors.js
@@ -88,7 +88,12 @@ const selector = createDeepEqualSelector([statePropsFilter], response => {
     );
 
     // Alias specific app permissions checks
-    updatedSession.authorized[helpers.UI_NAME] = updatedSession.permissions[APP_TYPES.SUBSCRIPTIONS]?.all || false;
+    updatedSession.authorized[helpers.UI_NAME] =
+      updatedSession.permissions[APP_TYPES.SUBSCRIPTIONS]?.all ||
+      Array.isArray(
+        updatedSession.permissions[APP_TYPES.SUBSCRIPTIONS]?.resources?.[RESOURCE_TYPES.REPORTS]?.[OPERATION_TYPES.READ]
+      ) ||
+      false;
 
     updatedSession.authorized.inventory =
       updatedSession.permissions[APP_TYPES.INVENTORY]?.all ||

--- a/src/types/__tests__/__snapshots__/index.test.js.snap
+++ b/src/types/__tests__/__snapshots__/index.test.js.snap
@@ -27,6 +27,7 @@ Object {
       "PLATFORM_API_RESPONSE_USER_PERMISSION_RESOURCE_TYPES": Object {
         "ALL": "*",
         "HOSTS": "hosts",
+        "REPORTS": "reports",
       },
       "PLATFORM_API_RESPONSE_USER_PERMISSION_TYPES": Object {
         "PERMISSION": "permission",
@@ -265,6 +266,7 @@ Object {
       "PLATFORM_API_RESPONSE_USER_PERMISSION_RESOURCE_TYPES": Object {
         "ALL": "*",
         "HOSTS": "hosts",
+        "REPORTS": "reports",
       },
       "PLATFORM_API_RESPONSE_USER_PERMISSION_TYPES": Object {
         "PERMISSION": "permission",
@@ -502,6 +504,7 @@ Object {
     "PLATFORM_API_RESPONSE_USER_PERMISSION_RESOURCE_TYPES": Object {
       "ALL": "*",
       "HOSTS": "hosts",
+      "REPORTS": "reports",
     },
     "PLATFORM_API_RESPONSE_USER_PERMISSION_TYPES": Object {
       "PERMISSION": "permission",
@@ -743,6 +746,7 @@ Object {
     "PLATFORM_API_RESPONSE_USER_PERMISSION_RESOURCE_TYPES": Object {
       "ALL": "*",
       "HOSTS": "hosts",
+      "REPORTS": "reports",
     },
     "PLATFORM_API_RESPONSE_USER_PERMISSION_TYPES": Object {
       "PERMISSION": "permission",

--- a/src/types/platformApiTypes.js
+++ b/src/types/platformApiTypes.js
@@ -46,7 +46,7 @@ const PLATFORM_API_RESPONSE_USER_IDENTITY_USER_TYPES = {
  * Platform response of USER PERMISSION type values.
  * Schema/map of expected response identity user permission types.
  *
- * @type {{PERMISSION: string}}
+ * @type {{PERMISSION: string, RESOURCE_DEFS: string}}
  */
 const PLATFORM_API_RESPONSE_USER_PERMISSION_TYPES = {
   PERMISSION: 'permission',
@@ -60,7 +60,8 @@ const PLATFORM_API_RESPONSE_USER_PERMISSION_APP_TYPES = {
 
 const PLATFORM_API_RESPONSE_USER_PERMISSION_RESOURCE_TYPES = {
   ALL: '*',
-  HOSTS: 'hosts'
+  HOSTS: 'hosts',
+  REPORTS: 'reports'
 };
 
 const PLATFORM_API_RESPONSE_USER_PERMISSION_OPERATION_TYPES = {


### PR DESCRIPTION

## What's included
<!-- Summary of changes/additions -->
- fix(userSelectors): ent-3825 add report read permissions
   * userSelectors, add check for report read
   * platformApiTypes, report const

### Notes
- adds the subscriptions report read permission
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. login with a user having the permissions "subscriptions" "reports" "read" perm, confirm the interface is accessible

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-3825