### PR TITLE
fix(select): env styling cache issue, manually set isPlain

### DIFF
--- a/src/components/form/select.js
+++ b/src/components/form/select.js
@@ -239,6 +239,13 @@ class Select extends React.Component {
      * In this case "null" is a fallback for scenarios where an "undefined" list is passed
      * during initial mount. Converted to an empty list/array "[]" to compensate.
      */
+    /**
+     * FixMe: PFReact isPlain vs Platform styling, removed? Attempt to set isPlain prop
+     * Confusing, possible false positive.?! The styling for select is reverting towards "isPlain"
+     * when Curiosity is viewed WITHOUT browser caching disabled in dev tools. When caching IS
+     * disabled Curiosity displays the correct select styling. This almost appears as if certain
+     * resources are being overridden, unclear why the default comes out as "isPlain".
+     */
     return (
       <PfSelect
         className={`curiosity-select${(!isToggleText && '__no-toggle-text') || ''} ${
@@ -250,6 +257,7 @@ class Select extends React.Component {
         onSelect={this.onSelect}
         selections={selected}
         isOpen={isExpanded}
+        isPlain={false}
         toggleIcon={toggleIcon}
         placeholderText={placeholder}
         {...pfSelectOptions}


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(select): env styling cache issue, manually set isPlain

### Notes
- it appears there's a caching issue in the lower environments around some of the PF styles, this includes the select component. 
- The styling for select is reverting towards "isPlain" when Curiosity is viewed WITHOUT browser caching disabled in dev tools. When caching IS disabled Curiosity displays the correct select styling.
- this lack of "select" styling was noted by QE, @ntkathole @mirekdlugosz . this attempts to manually apply the styling
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
_**This is only reproducible in environment, QA/CI/Stage beta/stable**_
1. login into your preferred environment
1. confirm the select/dropdown lists for Curiosity display with a border
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Ongoing