### PR TITLE
fix(select,toolbarFields): ent-3879 apply test attributes

### DIFF
--- a/src/components/form/__tests__/__snapshots__/select.test.js.snap
+++ b/src/components/form/__tests__/__snapshots__/select.test.js.snap
@@ -504,6 +504,28 @@ exports[`Select Component should allow being disabled with missing options: opti
 />
 `;
 
+exports[`Select Component should allow data- props: data- attributes 1`] = `
+Object {
+  "ariaLabel": "Select option",
+  "className": "",
+  "data-dolor-sit": "dolor sit",
+  "data-lorem": "ipsum",
+  "direction": "down",
+  "id": "generatedid-",
+  "isDisabled": false,
+  "isToggleText": true,
+  "maxHeight": null,
+  "name": null,
+  "onSelect": [Function],
+  "options": Array [],
+  "placeholder": "Select option",
+  "position": "left",
+  "selectedOptions": null,
+  "toggleIcon": null,
+  "variant": "single",
+}
+`;
+
 exports[`Select Component should allow plain objects as values, and be able to select options based on values within the object: select when option values are objects 1`] = `
 <div
   class="pf-c-select curiosity-select  "
@@ -798,7 +820,7 @@ exports[`Select Component should render a checkbox select: checkbox select 1`] =
 </div>
 `;
 
-exports[`Select Component should render a expanded select: expanded 1`] = `
+exports[`Select Component should render an expanded select: expanded 1`] = `
 <Select
   ariaLabel="Select option"
   className=""

--- a/src/components/form/__tests__/select.test.js
+++ b/src/components/form/__tests__/select.test.js
@@ -102,7 +102,7 @@ describe('Select Component', () => {
     component.instance().onSelect({}, 'world');
   });
 
-  it('should render a expanded select', () => {
+  it('should render an expanded select', () => {
     const props = {
       id: 'test',
       options: ['lorem', 'ipsum', 'hello', 'world']
@@ -162,5 +162,15 @@ describe('Select Component', () => {
     });
 
     expect(component).toMatchSnapshot('options, but disabled');
+  });
+
+  it('should allow data- props', () => {
+    const props = {
+      'data-lorem': 'ipsum',
+      'data-dolor-sit': 'dolor sit'
+    };
+
+    const component = mount(<Select {...props} />);
+    expect(component.props()).toMatchSnapshot('data- attributes');
   });
 });

--- a/src/components/form/select.js
+++ b/src/components/form/select.js
@@ -37,6 +37,8 @@ const SelectPosition = DropdownPosition;
 class Select extends React.Component {
   state = { isExpanded: false, options: null, selected: null };
 
+  selectField = React.createRef();
+
   componentDidMount() {
     const { options } = this.state;
 
@@ -135,13 +137,16 @@ class Select extends React.Component {
     });
   };
 
+  // FixMe: attributes filtered on PF select component. allow data- attributes
   /**
    * Format options into a consumable array of objects format.
    */
   formatOptions() {
+    const { current: domElement = {} } = this.selectField;
     const { options, selectedOptions, variant } = this.props;
+    const dataAttributes = Object.entries(this.props).filter(([key]) => /^data-/i.test(key));
     const updatedOptions = _isPlainObject(options)
-      ? Object.keys(options).map(key => ({ ...options[key], title: key, value: options[key] }))
+      ? Object.entries(options).map(([key, value]) => ({ ...value, title: key, value }))
       : _cloneDeep(options);
 
     const activateOptions =
@@ -195,6 +200,10 @@ class Select extends React.Component {
       updateSelected = (updatedOptions.find(opt => opt.selected === true) || {}).title;
     } else {
       updateSelected = updatedOptions.filter(opt => opt.selected === true).map(opt => opt.title);
+    }
+
+    if (domElement?.parentRef?.current) {
+      dataAttributes.forEach(([key, value]) => domElement?.parentRef?.current.setAttribute(key, value));
     }
 
     this.setState({
@@ -257,6 +266,7 @@ class Select extends React.Component {
         isOpen={isExpanded}
         toggleIcon={toggleIcon}
         placeholderText={placeholder}
+        ref={this.selectField}
         {...pfSelectOptions}
       >
         {(options &&

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldDisplayName.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldDisplayName.test.js.snap
@@ -59,6 +59,7 @@ exports[`ToolbarFieldDisplayName Component should render a non-connected compone
   <TextInput
     aria-label="t(curiosity-toolbar.placeholder, {\\"context\\":\\"displayName\\"})"
     className="curiosity-input__display-name"
+    data-test="toolbarFieldDisplayName"
     iconVariant="search"
     id={null}
     isDisabled={false}

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldGranularity.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldGranularity.test.js.snap
@@ -58,6 +58,7 @@ exports[`ToolbarFieldGranularity Component should render a non-connected compone
   aria-label="t(curiosity-toolbar.placeholder, {\\"context\\":\\"granularity\\"})"
   ariaLabel="Select option"
   className=""
+  data-test="toolbarFieldGranularity"
   direction="down"
   id="generatedid-"
   isDisabled={false}

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldRangedMonthly.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldRangedMonthly.test.js.snap
@@ -118,6 +118,7 @@ exports[`ToolbarFieldGranularity Component should handle selecting an option dir
   aria-label="t(curiosity-toolbar.placeholder, {\\"context\\":\\"granularity\\"})"
   ariaLabel="Select option"
   className=""
+  data-test="toolbarFieldRangeGranularity"
   direction="down"
   id="generatedid-"
   isDisabled={false}
@@ -278,6 +279,7 @@ exports[`ToolbarFieldGranularity Component should render a non-connected compone
   aria-label="t(curiosity-toolbar.placeholder, {\\"context\\":\\"granularity\\"})"
   ariaLabel="Select option"
   className=""
+  data-test="toolbarFieldRangeGranularity"
   direction="down"
   id="generatedid-"
   isDisabled={false}

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldUom.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldUom.test.js.snap
@@ -38,6 +38,7 @@ exports[`ToolbarFieldUom Component should render a non-connected component: non-
   aria-label="t(curiosity-toolbar.placeholder, {\\"context\\":\\"uom\\"})"
   ariaLabel="Select option"
   className=""
+  data-test="toolbarFieldUom"
   direction="down"
   id="generatedid-"
   isDisabled={false}

--- a/src/components/toolbar/toolbarFieldDisplayName.js
+++ b/src/components/toolbar/toolbarFieldDisplayName.js
@@ -107,6 +107,7 @@ const ToolbarFieldDisplayName = ({ t, value, viewId }) => {
         onKeyUp={onKeyUp}
         value={currentValue}
         placeholder={t('curiosity-toolbar.placeholder', { context: 'displayName' })}
+        data-test={ToolbarFieldDisplayName.defaultProps.viewId}
       />
     </InputGroup>
   );

--- a/src/components/toolbar/toolbarFieldGranularity.js
+++ b/src/components/toolbar/toolbarFieldGranularity.js
@@ -75,6 +75,7 @@ const ToolbarFieldGranularity = ({ options, t, value, viewId }) => {
       options={updatedOptions}
       selectedOptions={updatedValue}
       placeholder={t('curiosity-toolbar.placeholder', { context: 'granularity' })}
+      data-test={ToolbarFieldGranularity.defaultProps.viewId}
     />
   );
 };

--- a/src/components/toolbar/toolbarFieldRangedMonthly.js
+++ b/src/components/toolbar/toolbarFieldRangedMonthly.js
@@ -75,6 +75,7 @@ const ToolbarFieldRangedMonthly = ({ options, t, value, viewId }) => {
       placeholder={t('curiosity-toolbar.placeholder', { context: 'granularity' })}
       position={SelectPosition.right}
       maxHeight={250}
+      data-test={ToolbarFieldRangedMonthly.defaultProps.viewId}
     />
   );
 };

--- a/src/components/toolbar/toolbarFieldUom.js
+++ b/src/components/toolbar/toolbarFieldUom.js
@@ -59,6 +59,7 @@ const ToolbarFieldUom = ({ options, t, value, viewId }) => {
       options={updatedOptions}
       selectedOptions={updatedValue}
       placeholder={t('curiosity-toolbar.placeholder', { context: 'uom' })}
+      data-test={ToolbarFieldUom.defaultProps.viewId}
     />
   );
 };


### PR DESCRIPTION


## What's included
<!-- Summary of changes/additions -->
- fix(select,toolbarFields): ent-3879 apply test attributes
   * select, allow data- attributes
   * toolbarFields, apply test attributes

### Notes
- @mirekdlugosz the `data-test` attributes we apply are added after-the-fact, we may need to take page load into consideration
   - the test attributes are as follows
      - display name search = `data-test="toolbarFieldDisplayName"`
      - granularity = `data-test="toolbarFieldGranularity"`
      - ranged monthly (OpenShift On-demand) = `data-test="toolbarFieldRangeGranularity"`
      - uom = `data-test="toolbarFieldUom"`
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. login and inspect the various elements for the `data-test` attribute

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-3879