### PR TITLE
fix(productView): ent-3888 use meta to display total core hours

### DIFF
--- a/src/components/graphCard/__tests__/graphCard.test.js
+++ b/src/components/graphCard/__tests__/graphCard.test.js
@@ -179,4 +179,20 @@ describe('GraphCard Component', () => {
 
     expect(component).toMatchSnapshot('disabled component');
   });
+
+  it('should allow a custom display for card actions', () => {
+    const actionDisplay = jest.fn();
+    const props = {
+      query: {
+        [RHSM_API_QUERY_TYPES.GRANULARITY]: GRANULARITY_TYPES.DAILY,
+        [RHSM_API_QUERY_TYPES.END_DATE]: '2021-02-24T23:59:59.999Z',
+        [RHSM_API_QUERY_TYPES.START_DATE]: '2021-01-25T00:00:00.000Z'
+      },
+      productId: 'lorem',
+      settings: { actionDisplay }
+    };
+
+    shallow(<GraphCard {...props} />);
+    expect(actionDisplay).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/components/graphCard/graphCard.js
+++ b/src/components/graphCard/graphCard.js
@@ -142,7 +142,7 @@ class GraphCard extends React.Component {
    * @returns {Node}
    */
   render() {
-    const { cardTitle, children, error, graphData, isDisabled, pending, settings } = this.props;
+    const { cardTitle, children, error, graphData, meta, isDisabled, pending, settings } = this.props;
 
     if (isDisabled) {
       return null;
@@ -152,7 +152,7 @@ class GraphCard extends React.Component {
 
     // Apply actionDisplay callback, return node
     if (typeof settings?.actionDisplay === 'function') {
-      actionDisplay = settings.actionDisplay({ ...graphData });
+      actionDisplay = settings.actionDisplay({ data: { ...graphData }, meta: { ...meta } });
     }
 
     return (
@@ -188,7 +188,8 @@ class GraphCard extends React.Component {
  *
  * @type {{productLabel: string, settings: object, productId: string, query: object, pending: boolean,
  *     error: boolean, cardTitle: Node, filterGraphData: Array, getGraphReportsCapacity: Function,
- *     viewId: string, t: Function, children: Node, graphData: object, isDisabled: boolean}}
+ *     viewId: string, t: Function, children: Node, graphData: object, isDisabled: boolean,
+ *     meta: object}}
  */
 GraphCard.propTypes = {
   cardTitle: PropTypes.node,
@@ -203,6 +204,7 @@ GraphCard.propTypes = {
   ),
   getGraphReportsCapacity: PropTypes.func,
   graphData: PropTypes.object,
+  meta: PropTypes.object,
   query: PropTypes.shape({
     [RHSM_API_QUERY_TYPES.GRANULARITY]: PropTypes.oneOf([...Object.values(GRANULARITY_TYPES)]).isRequired,
     [RHSM_API_QUERY_TYPES.START_DATE]: PropTypes.string.isRequired,
@@ -222,9 +224,9 @@ GraphCard.propTypes = {
 /**
  * Default props.
  *
- * @type {{getGraphReportsCapacity: Function, productLabel: string, settings: object, viewId: string,
- *     t: translate, children: Node, pending: boolean, graphData: object, isDisabled: boolean,
- *     error: boolean, cardTitle: Node, filterGraphData: Array}}
+ * @type {{productLabel: string, settings: object, pending: boolean, error: boolean, cardTitle: Node,
+ *     filterGraphData: Array, getGraphReportsCapacity: Function, viewId: string, t: translate,
+ *     children: Node, graphData: object, isDisabled: boolean, meta: object}}
  */
 GraphCard.defaultProps = {
   cardTitle: null,
@@ -233,6 +235,7 @@ GraphCard.defaultProps = {
   filterGraphData: [],
   getGraphReportsCapacity: helpers.noop,
   graphData: {},
+  meta: {},
   isDisabled: helpers.UI_DISABLED_GRAPH,
   pending: false,
   productLabel: '',

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -315,7 +315,7 @@ Array [
       },
       Object {
         "key": "curiosity-graph.card-action-total",
-        "match": "translate('curiosity-graph.card-action-total', { context: 'coreHours', total: numbro(total)",
+        "match": "translate('curiosity-graph.card-action-total', { context: 'coreHours', total: numbro(totalCoreHours)",
       },
       Object {
         "key": "curiosity-inventory.label",
@@ -328,7 +328,7 @@ Array [
     "keys": Array [
       Object {
         "key": "curiosity-graph.card-action-total",
-        "match": "translate('curiosity-graph.card-action-total', { context: 'coreHours', total: numbro(total)",
+        "match": "translate('curiosity-graph.card-action-total', { context: 'coreHours', total: numbro(totalCoreHours)",
       },
       Object {
         "key": "curiosity-inventory.label",

--- a/src/components/productView/__tests__/productViewOpenShiftContainer.test.js
+++ b/src/components/productView/__tests__/productViewOpenShiftContainer.test.js
@@ -96,68 +96,88 @@ describe('ProductViewOpenShiftContainer Component', () => {
     expect({
       productOneActionDisplay: undefined,
       productTwoActionDisplay: productTwo.initialGraphSettings.actionDisplay({
-        coreHours: [
-          {
-            y: 0
-          },
-          {
-            y: 400
-          },
-          {
-            y: 100
-          }
-        ]
+        data: {
+          coreHours: [
+            {
+              y: 0
+            },
+            {
+              y: 400
+            },
+            {
+              y: 100
+            }
+          ]
+        },
+        meta: {
+          totalCoreHours: 500
+        }
       })
     }).toMatchSnapshot('product action display should display a total value below 1000');
 
     expect({
       productOneActionDisplay: undefined,
       productTwoActionDisplay: productTwo.initialGraphSettings.actionDisplay({
-        coreHours: [
-          {
-            y: 0
-          },
-          {
-            y: 800000
-          },
-          {
-            y: 100000
-          }
-        ]
+        data: {
+          coreHours: [
+            {
+              y: 0
+            },
+            {
+              y: 800000
+            },
+            {
+              y: 100000
+            }
+          ]
+        },
+        meta: {
+          totalCoreHours: 900000
+        }
       })
     }).toMatchSnapshot('product action display should display a total value below 1000000');
 
     expect({
       productOneActionDisplay: undefined,
       productTwoActionDisplay: productTwo.initialGraphSettings.actionDisplay({
-        coreHours: [
-          {
-            y: 0
-          },
-          {
-            y: 1000
-          },
-          {
-            y: 100
-          }
-        ]
+        data: {
+          coreHours: [
+            {
+              y: 0
+            },
+            {
+              y: 1000
+            },
+            {
+              y: 100
+            }
+          ]
+        },
+        meta: {
+          totalCoreHours: 1100
+        }
       })
     }).toMatchSnapshot('product action display should display a total value');
 
     expect({
       productOneActionDisplay: undefined,
       productTwoActionDisplay: productTwo.initialGraphSettings.actionDisplay({
-        loremIpsum: [
-          {
-            y: 0
-          },
-          {
-            y: 1000
-          },
-          {
-            y: 100
-          }
-        ]
+        data: {
+          loremIpsum: [
+            {
+              y: 0
+            },
+            {
+              y: 1000
+            },
+            {
+              y: 100
+            }
+          ]
+        },
+        meta: {
+          totalCoreHours: undefined
+        }
       })
     }).toMatchSnapshot('product action display should NOT display a total value');
   });

--- a/src/components/productView/__tests__/productViewOpenShiftDedicated.test.js
+++ b/src/components/productView/__tests__/productViewOpenShiftDedicated.test.js
@@ -68,17 +68,22 @@ describe('ProductViewOpenShiftDedicated Component', () => {
     expect({
       productActionDisplay: ProductViewOpenShiftDedicated.defaultProps.productConfig.initialGraphSettings.actionDisplay(
         {
-          coreHours: [
-            {
-              y: 0
-            },
-            {
-              y: 400
-            },
-            {
-              y: 100
-            }
-          ]
+          data: {
+            coreHours: [
+              {
+                y: 0
+              },
+              {
+                y: 400
+              },
+              {
+                y: 100
+              }
+            ]
+          },
+          meta: {
+            totalCoreHours: 500
+          }
         }
       )
     }).toMatchSnapshot('product action display should display a total value below 1000');
@@ -86,17 +91,22 @@ describe('ProductViewOpenShiftDedicated Component', () => {
     expect({
       productActionDisplay: ProductViewOpenShiftDedicated.defaultProps.productConfig.initialGraphSettings.actionDisplay(
         {
-          coreHours: [
-            {
-              y: 0
-            },
-            {
-              y: 800000
-            },
-            {
-              y: 100000
-            }
-          ]
+          data: {
+            coreHours: [
+              {
+                y: 0
+              },
+              {
+                y: 800000
+              },
+              {
+                y: 100000
+              }
+            ]
+          },
+          meta: {
+            totalCoreHours: 900000
+          }
         }
       )
     }).toMatchSnapshot('product action display should display a total value below 1000000');
@@ -104,17 +114,22 @@ describe('ProductViewOpenShiftDedicated Component', () => {
     expect({
       productActionDisplay: ProductViewOpenShiftDedicated.defaultProps.productConfig.initialGraphSettings.actionDisplay(
         {
-          coreHours: [
-            {
-              y: 0
-            },
-            {
-              y: 1000
-            },
-            {
-              y: 100
-            }
-          ]
+          data: {
+            coreHours: [
+              {
+                y: 0
+              },
+              {
+                y: 1000
+              },
+              {
+                y: 100
+              }
+            ]
+          },
+          meta: {
+            totalCoreHours: 1100
+          }
         }
       )
     }).toMatchSnapshot('product action display should display a total value');
@@ -123,17 +138,22 @@ describe('ProductViewOpenShiftDedicated Component', () => {
       productOneActionDisplay: undefined,
       productTwoActionDisplay: ProductViewOpenShiftDedicated.defaultProps.productConfig.initialGraphSettings.actionDisplay(
         {
-          loremIpsum: [
-            {
-              y: 0
-            },
-            {
-              y: 1000
-            },
-            {
-              y: 100
-            }
-          ]
+          data: {
+            loremIpsum: [
+              {
+                y: 0
+              },
+              {
+                y: 1000
+              },
+              {
+                y: 100
+              }
+            ]
+          },
+          meta: {
+            totalCoreHours: undefined
+          }
         }
       )
     }).toMatchSnapshot('product action display should NOT display a total value');

--- a/src/components/productView/productViewOpenShiftContainer.js
+++ b/src/components/productView/productViewOpenShiftContainer.js
@@ -441,19 +441,15 @@ ProductViewOpenShiftContainer.defaultProps = {
       ],
       initialGraphSettings: {
         actionDisplay: data => {
-          const { coreHours } = data;
+          const {
+            meta: { totalCoreHours }
+          } = data;
           let displayContent;
 
-          if (coreHours) {
-            let total = 0;
-
-            coreHours.forEach(({ y }) => {
-              total += y ?? 0;
-            });
-
+          if (totalCoreHours) {
             displayContent = translate('curiosity-graph.card-action-total', {
               context: 'coreHours',
-              total: numbro(total)
+              total: numbro(totalCoreHours)
                 .format({ average: true, mantissa: 2, trimMantissa: true, lowPrecision: false })
                 .toUpperCase()
             });

--- a/src/components/productView/productViewOpenShiftDedicated.js
+++ b/src/components/productView/productViewOpenShiftDedicated.js
@@ -85,19 +85,15 @@ ProductViewOpenShiftDedicated.defaultProps = {
     ],
     initialGraphSettings: {
       actionDisplay: data => {
-        const { coreHours } = data;
+        const {
+          meta: { totalCoreHours }
+        } = data;
         let displayContent;
 
-        if (coreHours) {
-          let total = 0;
-
-          coreHours.forEach(({ y }) => {
-            total += y ?? 0;
-          });
-
+        if (totalCoreHours) {
           displayContent = translate('curiosity-graph.card-action-total', {
             context: 'coreHours',
-            total: numbro(total)
+            total: numbro(totalCoreHours)
               .format({ average: true, mantissa: 2, trimMantissa: true, lowPrecision: false })
               .toUpperCase()
           });

--- a/src/redux/selectors/__tests__/__snapshots__/graphCardSelectors.test.js.snap
+++ b/src/redux/selectors/__tests__/__snapshots__/graphCardSelectors.test.js.snap
@@ -5,6 +5,7 @@ Object {
   "error": false,
   "fulfilled": false,
   "graphData": Object {},
+  "meta": Object {},
   "pending": true,
   "query": Object {
     "granularity": "daily",
@@ -459,6 +460,10 @@ Object {
       },
     ],
   },
+  "meta": Object {
+    "count": undefined,
+    "totalCoreHours": undefined,
+  },
   "pending": false,
   "query": Object {
     "granularity": "daily",
@@ -472,6 +477,7 @@ Object {
   "error": false,
   "fulfilled": false,
   "graphData": Object {},
+  "meta": Object {},
   "pending": false,
   "query": Object {
     "granularity": "daily",
@@ -485,6 +491,7 @@ Object {
   "error": false,
   "fulfilled": false,
   "graphData": Object {},
+  "meta": Object {},
   "pending": false,
   "query": Object {},
   "status": undefined,
@@ -496,6 +503,7 @@ Object {
   "error": false,
   "fulfilled": false,
   "graphData": Object {},
+  "meta": Object {},
   "pending": false,
   "query": Object {},
   "status": undefined,
@@ -679,6 +687,10 @@ Object {
         "y": 100,
       },
     ],
+  },
+  "meta": Object {
+    "count": undefined,
+    "totalCoreHours": undefined,
   },
   "pending": false,
   "query": Object {
@@ -866,6 +878,10 @@ Object {
       },
     ],
   },
+  "meta": Object {
+    "count": undefined,
+    "totalCoreHours": undefined,
+  },
   "pending": false,
   "query": Object {
     "granularity": "daily",
@@ -1052,6 +1068,10 @@ Object {
       },
     ],
   },
+  "meta": Object {
+    "count": undefined,
+    "totalCoreHours": undefined,
+  },
   "pending": false,
   "query": Object {
     "granularity": "daily",
@@ -1237,6 +1257,10 @@ Object {
         "y": 100,
       },
     ],
+  },
+  "meta": Object {
+    "count": undefined,
+    "totalCoreHours": undefined,
   },
   "pending": false,
   "query": Object {
@@ -1790,6 +1814,10 @@ Object {
       },
     ],
   },
+  "meta": Object {
+    "count": undefined,
+    "totalCoreHours": undefined,
+  },
   "pending": false,
   "query": Object {
     "granularity": "daily",
@@ -2021,6 +2049,10 @@ Object {
         "y": 0,
       },
     ],
+  },
+  "meta": Object {
+    "count": undefined,
+    "totalCoreHours": undefined,
   },
   "pending": false,
   "query": Object {

--- a/src/redux/selectors/graphCardSelectors.js
+++ b/src/redux/selectors/graphCardSelectors.js
@@ -71,6 +71,7 @@ const selector = createSelector([statePropsFilter, queryFilter], (response, quer
     fulfilled: false,
     pending: responseData.pending || responseData.cancelled || false,
     graphData: {},
+    meta: {},
     query,
     status: responseData.status
   };
@@ -85,6 +86,7 @@ const selector = createSelector([statePropsFilter, queryFilter], (response, quer
   if (responseData.fulfilled && productId === metaId && _isEqual(query, responseMetaQuery)) {
     const [report, capacity] = responseData.data;
     const reportData = report?.[rhsmApiTypes.RHSM_API_RESPONSE_PRODUCTS_DATA] || [];
+    const reportMeta = report?.[rhsmApiTypes.RHSM_API_RESPONSE_META] || {};
     const capacityData = capacity?.[rhsmApiTypes.RHSM_API_RESPONSE_CAPACITY_DATA] || [];
 
     /**
@@ -171,7 +173,16 @@ const selector = createSelector([statePropsFilter, queryFilter], (response, quer
       });
     });
 
+    // Generate normalized properties
+    const [updatedReportMeta] = reduxHelpers.setNormalizedResponse({
+      schema: rhsmApiTypes.RHSM_API_RESPONSE_META_TYPES,
+      data: reportMeta
+    });
+
+    const [meta = {}] = updatedReportMeta || [];
+
     // Update response and cache
+    Object.assign(updatedResponseData.meta, meta);
     updatedResponseData.fulfilled = true;
     selectorCache.set(`${viewId}_${productId}_${JSON.stringify(query)}`, { ...updatedResponseData });
   }

--- a/src/services/rhsmServices.js
+++ b/src/services/rhsmServices.js
@@ -380,7 +380,8 @@ const getApiVersion = (options = {}) => {
  *       "meta": {
  *         "count": 12,
  *         "product": "RHEL",
- *         "granularity": "daily"
+ *         "granularity": "daily",
+ *         "total_core_hours": 30500.04
  *       }
  *     }
  *
@@ -504,7 +505,8 @@ const getApiVersion = (options = {}) => {
  *       "meta": {
  *         "count": 10,
  *         "product": "RHEL",
- *         "granularity": "weekly"
+ *         "granularity": "weekly",
+ *         "total_core_hours": 200.03
  *       }
  *     }
  *
@@ -631,7 +633,8 @@ const getApiVersion = (options = {}) => {
  *       "meta": {
  *         "count": 6,
  *         "product": "RHEL",
- *         "granularity": "monthly"
+ *         "granularity": "monthly",
+ *         "total_core_hours": 2050.04
  *       }
  *     }
  *

--- a/src/types/__tests__/__snapshots__/index.test.js.snap
+++ b/src/types/__tests__/__snapshots__/index.test.js.snap
@@ -218,6 +218,7 @@ Object {
       "RHSM_API_RESPONSE_META": "meta",
       "RHSM_API_RESPONSE_META_TYPES": Object {
         "COUNT": "count",
+        "TOTAL_CORE_HOURS": "total_core_hours",
       },
       "RHSM_API_RESPONSE_PRODUCTS_DATA": "data",
       "RHSM_API_RESPONSE_PRODUCTS_DATA_TYPES": Object {
@@ -454,6 +455,7 @@ Object {
       "RHSM_API_RESPONSE_META": "meta",
       "RHSM_API_RESPONSE_META_TYPES": Object {
         "COUNT": "count",
+        "TOTAL_CORE_HOURS": "total_core_hours",
       },
       "RHSM_API_RESPONSE_PRODUCTS_DATA": "data",
       "RHSM_API_RESPONSE_PRODUCTS_DATA_TYPES": Object {
@@ -689,6 +691,7 @@ Object {
     "RHSM_API_RESPONSE_META": "meta",
     "RHSM_API_RESPONSE_META_TYPES": Object {
       "COUNT": "count",
+      "TOTAL_CORE_HOURS": "total_core_hours",
     },
     "RHSM_API_RESPONSE_PRODUCTS_DATA": "data",
     "RHSM_API_RESPONSE_PRODUCTS_DATA_TYPES": Object {
@@ -928,6 +931,7 @@ Object {
     "RHSM_API_RESPONSE_META": "meta",
     "RHSM_API_RESPONSE_META_TYPES": Object {
       "COUNT": "count",
+      "TOTAL_CORE_HOURS": "total_core_hours",
     },
     "RHSM_API_RESPONSE_PRODUCTS_DATA": "data",
     "RHSM_API_RESPONSE_PRODUCTS_DATA_TYPES": Object {

--- a/src/types/rhsmApiTypes.js
+++ b/src/types/rhsmApiTypes.js
@@ -57,10 +57,11 @@ const RHSM_API_RESPONSE_META = 'meta';
  * RHSM response META types.
  * Schema/map of expected META response properties.
  *
- * @type {string}
+ * @type {{COUNT: string, TOTAL_CORE_HOURS: string}}
  */
 const RHSM_API_RESPONSE_META_TYPES = {
-  COUNT: 'count'
+  COUNT: 'count',
+  TOTAL_CORE_HOURS: 'total_core_hours'
 };
 
 /**
@@ -386,35 +387,35 @@ const RHSM_API_QUERY_TYPES = {
 /**
  * RHSM API types.
  *
- * @type {{RHSM_API_QUERY_SET_INVENTORY_SUBSCRIPTIONS_TYPES: {UOM: string, USAGE: string, DIRECTION: string, SORT: string,
- *     OFFSET: string, SLA: string, LIMIT: string}, RHSM_API_RESPONSE_INVENTORY_SUBSCRIPTIONS_DATA_TYPES: {UOM: string,
- *     PHYSICAL_CAPACITY: string, USAGE: string, UPCOMING_EVENT_TYPE: string, UPCOMING_EVENT_DATE: string,
- *     SUBSCRIPTION_NUMBERS: string, VIRTUAL_CAPACITY: string, TOTAL_CAPACITY: string, SKU: string, SERVICE_LEVEL: string},
+ * @type {{RHSM_API_QUERY_SET_INVENTORY_SUBSCRIPTIONS_TYPES: {UOM: string, USAGE: string, DIRECTION: string,
+ *     SORT: string, OFFSET: string, SLA: string, LIMIT: string},
+ *     RHSM_API_RESPONSE_INVENTORY_SUBSCRIPTIONS_DATA_TYPES: {UOM: string, PHYSICAL_CAPACITY: string, USAGE: string,
+ *     UPCOMING_EVENT_TYPE: string, UPCOMING_EVENT_DATE: string, SUBSCRIPTION_NUMBERS: string,
+ *     VIRTUAL_CAPACITY: string, TOTAL_CAPACITY: string, SKU: string, SERVICE_LEVEL: string},
  *     RHSM_API_RESPONSE_ERROR_DATA_CODE_TYPES: {GENERIC: string, OPTIN: string}, RHSM_API_RESPONSE_INVENTORY_DATA: string,
  *     RHSM_API_RESPONSE_CAPACITY_DATA: string, RHSM_API_RESPONSE_ERROR_DATA_TYPES: {CODE: string, DETAIL: string},
  *     RHSM_API_RESPONSE_CAPACITY_DATA_TYPES: {HYPERVISOR_SOCKETS: string, CORES: string, DATE: string, SOCKETS: string,
  *     PHYSICAL_SOCKETS: string, HYPERVISOR_CORES: string, HAS_INFINITE: string, PHYSICAL_CORES: string},
- *     RHSM_API_QUERY_SUBSCRIPTIONS_SORT_TYPES: {UOM: string, PHYSICAL_CAPACITY: string, USAGE: string,
- *     UPCOMING_EVENT_DATE: string, VIRTUAL_CAPACITY: string, TOTAL_CAPACITY: string, SKU: string, PRODUCT_NAME: string,
- *     SERVICE_LEVEL: string}, RHSM_API_RESPONSE_META_TYPES: string, RHSM_API_QUERY_GRANULARITY_TYPES: {WEEKLY: string,
- *     QUARTERLY: string, DAILY: string, MONTHLY: string}, RHSM_API_QUERY_SORT_DIRECTION_TYPES: {ASCENDING: string,
- *     DESCENDING: string}, RHSM_API_RESPONSE_PRODUCTS_DATA: string, RHSM_API_QUERY_TYPES: {GRANULARITY: string,
- *     TALLY_SYNC: string, DIRECTION: string, END_DATE: string, SLA: string, START_DATE: string, LIMIT: string, UOM: string,
- *     TALLY_REPORT: string, USAGE: string, SORT: string, OFFSET: string, CONDUIT_SYNC: string},
- *     RHSM_API_RESPONSE_LINKS: string, RHSM_API_QUERY_SET_INVENTORY_GUESTS_TYPES: {OFFSET: string, LIMIT: string},
- *     RHSM_API_PATH_ID_TYPES: {RHEL_ARM: string, OPENSHIFT_METRICS: string, SATELLITE: string, RHEL_WORKSTATION: string,
- *     RHEL_COMPUTE_NODE: string, RHEL_X86: string, OPENSHIFT: string, SATELLITE_SERVER: string,
- *     OPENSHIFT_DEDICATED_METRICS: string, RHEL_DESKTOP: string, RHEL: string, SATELLITE_CAPSULE: string, RHEL_SERVER: string,
- *     RHEL_IBM_Z: string, RHEL_IBM_POWER: string}, RHSM_API_QUERY_SET_OPTIN_TYPES: {TALLY_SYNC: string, TALLY_REPORT: string,
- *     CONDUIT_SYNC: string}, RHSM_API_QUERY_USAGE_TYPES: {UNSPECIFIED: string, DISASTER: string, DEVELOPMENT: string,
- *     PRODUCTION: string}, RHSM_API_QUERY_SLA_TYPES: {PREMIUM: string, SELF: string, NONE: string, STANDARD: string},
- *     RHSM_API_QUERY_SET_INVENTORY_TYPES: {UOM: string, USAGE: string, DIRECTION: string, SORT: string, OFFSET: string,
- *     SLA: string, LIMIT: string}, RHSM_API_QUERY_SORT_TYPES: {CORES: string, CORE_HOURS: string, HARDWARE: string,
- *     SOCKETS: string, MEASUREMENT: string, LAST_SEEN: string, NAME: string},
- *     RHSM_API_RESPONSE_PRODUCTS_DATA_TYPES: {HYPERVISOR_SOCKETS: string, CORES: string, SOCKETS: string,
- *     CLOUD_CORES: string, HAS_DATA: string, PHYSICAL_SOCKETS: string, PHYSICAL_CORES: string, CLOUD_INSTANCES: string,
- *     DATE: string, CORE_HOURS: string, CLOUD_SOCKETS: string, HAS_CLOUDIGRADE_DATA: string, HAS_CLOUDIGRADE_MISMATCH: string,
- *     HYPERVISOR_CORES: string}, RHSM_API_QUERY_UOM_TYPES: {CORES: string, SOCKETS: string},
+ *     RHSM_API_QUERY_SUBSCRIPTIONS_SORT_TYPES: {UOM: string, PHYSICAL_CAPACITY: string, USAGE: string, UPCOMING_EVENT_DATE: string,
+ *     VIRTUAL_CAPACITY: string, TOTAL_CAPACITY: string, SKU: string, PRODUCT_NAME: string, SERVICE_LEVEL: string},
+ *     RHSM_API_RESPONSE_META_TYPES: {COUNT: string, TOTAL_CORE_HOURS: string}, RHSM_API_QUERY_GRANULARITY_TYPES: {WEEKLY: string,
+ *     QUARTERLY: string, DAILY: string, MONTHLY: string}, RHSM_API_QUERY_SORT_DIRECTION_TYPES: {ASCENDING: string, DESCENDING: string},
+ *     RHSM_API_RESPONSE_PRODUCTS_DATA: string, RHSM_API_QUERY_TYPES: {GRANULARITY: string, TALLY_SYNC: string, DIRECTION: string,
+ *     END_DATE: string, SLA: string, START_DATE: string, LIMIT: string, UOM: string, TALLY_REPORT: string, USAGE: string,
+ *     SORT: string, OFFSET: string, CONDUIT_SYNC: string}, RHSM_API_RESPONSE_LINKS: string,
+ *     RHSM_API_QUERY_SET_INVENTORY_GUESTS_TYPES: {OFFSET: string, LIMIT: string}, RHSM_API_PATH_ID_TYPES: {RHEL_ARM: string,
+ *     OPENSHIFT_METRICS: string, SATELLITE: string, RHEL_WORKSTATION: string, RHEL_COMPUTE_NODE: string, RHEL_X86: string,
+ *     OPENSHIFT: string, SATELLITE_SERVER: string, OPENSHIFT_DEDICATED_METRICS: string, RHEL_DESKTOP: string, RHEL: string,
+ *     SATELLITE_CAPSULE: string, RHEL_SERVER: string, RHEL_IBM_Z: string, RHEL_IBM_POWER: string},
+ *     RHSM_API_QUERY_SET_OPTIN_TYPES: {TALLY_SYNC: string, TALLY_REPORT: string, CONDUIT_SYNC: string},
+ *     RHSM_API_QUERY_USAGE_TYPES: {UNSPECIFIED: string, DISASTER: string, DEVELOPMENT: string, PRODUCTION: string},
+ *     RHSM_API_QUERY_SLA_TYPES: {PREMIUM: string, SELF: string, NONE: string, STANDARD: string},
+ *     RHSM_API_QUERY_SET_INVENTORY_TYPES: {UOM: string, USAGE: string, DIRECTION: string, SORT: string, OFFSET: string, SLA: string,
+ *     LIMIT: string}, RHSM_API_QUERY_SORT_TYPES: {CORES: string, CORE_HOURS: string, HARDWARE: string, SOCKETS: string,
+ *     MEASUREMENT: string, LAST_SEEN: string, NAME: string}, RHSM_API_RESPONSE_PRODUCTS_DATA_TYPES: {HYPERVISOR_SOCKETS: string,
+ *     CORES: string, SOCKETS: string, CLOUD_CORES: string, HAS_DATA: string, PHYSICAL_SOCKETS: string, PHYSICAL_CORES: string,
+ *     CLOUD_INSTANCES: string, DATE: string, CORE_HOURS: string, CLOUD_SOCKETS: string, HAS_CLOUDIGRADE_DATA: string,
+ *     HAS_CLOUDIGRADE_MISMATCH: string, HYPERVISOR_CORES: string}, RHSM_API_QUERY_UOM_TYPES: {CORES: string, SOCKETS: string},
  *     RHSM_API_RESPONSE_LINKS_TYPES: string, RHSM_API_RESPONSE_INVENTORY_GUESTS_DATA_TYPES: {SUBSCRIPTION_ID: string, ID: string,
  *     NAME: string, LAST_SEEN: string}, RHSM_API_RESPONSE_ERROR_DATA: string, RHSM_API_RESPONSE_META: string,
  *     RHSM_API_RESPONSE_INVENTORY_DATA_TYPES: {CORES: string, CORE_HOURS: string, HARDWARE: string, SOCKETS: string,


### PR DESCRIPTION


## What's included
<!-- Summary of changes/additions -->
- fix(productView): ent-3888 use meta to display total core hours
   * graphCard, pass meta for setting actions callback
   * graphCardSelectors, pass normalized meta
   * productView, OpenShiftContainer, Dedicated, total core hours
   * rhsmServices, API mock

### Notes
- passing the meta object to consuming components resulted in a page load "double jump" when the graph loaded. we ended up "assigning" the values instead of replacing them under the thinking the object was causing an update. We think we've resolved it, but something to keep an eye on @mirekdlugosz 

<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm the total core hours display is coming through on OpenShift Container, Dedicated On Demand

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-3888