### PR TITLE
fix(productViewMissing): ent-3913 apply platform appNavClick

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -39,6 +39,7 @@
     "plugin:jsdoc/recommended"
   ],
   "globals": {
+    "mockHook": "readonly",
     "mountHookComponent": "readonly",
     "mockWindowLocation": "readonly"
   },

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
       "!src/index.js",
       "!src/setupTests.js",
       "!src/components/app.js",
+      "!src/components/**/index.js",
       "!src/common/index.js",
       "!src/redux/index.js",
       "!src/redux/store.js",

--- a/public/locales/en-US.json
+++ b/public/locales/en-US.json
@@ -169,7 +169,6 @@
     "tourDescription": "We'll walk you through each step, and include insight into how Red Hat collects and uses subscription data."
   },
   "curiosity-view": {
-    "redirectError": "Redirect failed",
     "title": "{{appName}}",
     "subtitle": "Monitor your usage based on your subscription terms. <0>Learn more about {{appName}} reporting</0>",
     "description": "Monitor your usage based on your subscription terms.",

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -4,7 +4,7 @@ import { NotificationsPortal } from '@redhat-cloud-services/frontend-components-
 import { connectRouter, reduxActions } from '../redux';
 import { helpers } from '../common/helpers';
 import { I18n } from './i18n/i18n';
-import { Router } from './router/router';
+import { Router } from './router';
 import Authentication from './authentication/authentication';
 
 /**

--- a/src/components/authentication/__tests__/__snapshots__/authentication.test.js.snap
+++ b/src/components/authentication/__tests__/__snapshots__/authentication.test.js.snap
@@ -287,9 +287,123 @@ exports[`Authentication Component should return a message on 401 error: 401 erro
 `;
 
 exports[`Authentication Component should return a redirect on 418 error: 418 error 1`] = `
-<withRouter(Redirect)
-  isRedirect={true}
+<Redirect
+  baseName="/"
+  isForced={false}
   route="/optin"
+  routes={
+    Array [
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewRhel",
+        "disabled": false,
+        "exact": true,
+        "id": "rhel",
+        "path": "/rhel",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewRhel",
+        "disabled": false,
+        "exact": true,
+        "id": "rhel-arm",
+        "path": "/rhel-arm",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewRhel",
+        "disabled": false,
+        "exact": true,
+        "id": "rhel-ibmpower",
+        "path": "/rhel-ibmpower",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewRhel",
+        "disabled": false,
+        "exact": true,
+        "id": "rhel-ibmz",
+        "path": "/rhel-ibmz",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewRhel",
+        "disabled": false,
+        "exact": true,
+        "id": "rhel-x86",
+        "path": "/rhel-x86",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewOpenShiftContainer",
+        "disabled": false,
+        "exact": true,
+        "id": "openshift-container",
+        "path": "/openshift-container",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewOpenShiftDedicated",
+        "disabled": false,
+        "exact": true,
+        "id": "openshift-dedicated",
+        "path": "/openshift-dedicated",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewSatellite",
+        "disabled": false,
+        "exact": true,
+        "id": "satellite",
+        "path": "/satellite",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewSatellite",
+        "disabled": false,
+        "exact": true,
+        "id": "satellite-capsule",
+        "path": "/satellite-capsule",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewSatellite",
+        "disabled": false,
+        "exact": true,
+        "id": "satellite-server",
+        "path": "/satellite-server",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": true,
+        "component": "optinView/optinView",
+        "disabled": false,
+        "exact": true,
+        "id": "optin",
+        "path": "/optin",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewMissing",
+        "disabled": false,
+        "exact": true,
+        "id": "missing",
+        "path": "/",
+        "redirect": "/",
+      },
+    ]
+  }
+  url={null}
 />
 `;
 
@@ -313,8 +427,122 @@ exports[`Authentication Component should return a redirect on a specific 403 err
 `;
 
 exports[`Authentication Component should return a redirect on a specific 403 error and error code: 403 redirect error 1`] = `
-<withRouter(Redirect)
-  isRedirect={true}
+<Redirect
+  baseName="/"
+  isForced={false}
   route="/optin"
+  routes={
+    Array [
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewRhel",
+        "disabled": false,
+        "exact": true,
+        "id": "rhel",
+        "path": "/rhel",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewRhel",
+        "disabled": false,
+        "exact": true,
+        "id": "rhel-arm",
+        "path": "/rhel-arm",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewRhel",
+        "disabled": false,
+        "exact": true,
+        "id": "rhel-ibmpower",
+        "path": "/rhel-ibmpower",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewRhel",
+        "disabled": false,
+        "exact": true,
+        "id": "rhel-ibmz",
+        "path": "/rhel-ibmz",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewRhel",
+        "disabled": false,
+        "exact": true,
+        "id": "rhel-x86",
+        "path": "/rhel-x86",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewOpenShiftContainer",
+        "disabled": false,
+        "exact": true,
+        "id": "openshift-container",
+        "path": "/openshift-container",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewOpenShiftDedicated",
+        "disabled": false,
+        "exact": true,
+        "id": "openshift-dedicated",
+        "path": "/openshift-dedicated",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewSatellite",
+        "disabled": false,
+        "exact": true,
+        "id": "satellite",
+        "path": "/satellite",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewSatellite",
+        "disabled": false,
+        "exact": true,
+        "id": "satellite-capsule",
+        "path": "/satellite-capsule",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewSatellite",
+        "disabled": false,
+        "exact": true,
+        "id": "satellite-server",
+        "path": "/satellite-server",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": true,
+        "component": "optinView/optinView",
+        "disabled": false,
+        "exact": true,
+        "id": "optin",
+        "path": "/optin",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewMissing",
+        "disabled": false,
+        "exact": true,
+        "id": "missing",
+        "path": "/",
+        "redirect": "/",
+      },
+    ]
+  }
+  url={null}
 />
 `;

--- a/src/components/authentication/authentication.js
+++ b/src/components/authentication/authentication.js
@@ -6,7 +6,7 @@ import { NotAuthorized } from '@redhat-cloud-services/frontend-components/NotAut
 import { connectRouter, reduxActions, reduxSelectors } from '../../redux';
 import { rhsmApiTypes } from '../../types';
 import { helpers } from '../../common';
-import { Redirect, routerHelpers } from '../router/router';
+import { routerHelpers, Redirect } from '../router';
 import MessageView from '../messageView/messageView';
 import { translate } from '../i18n/i18n';
 
@@ -85,7 +85,7 @@ class Authentication extends Component {
       (session.errorCodes && session.errorCodes.includes(rhsmApiTypes.RHSM_API_RESPONSE_ERROR_DATA_CODE_TYPES.OPTIN)) ||
       session.status === 418
     ) {
-      return <Redirect isRedirect route={routerHelpers.getErrorRoute.path} />;
+      return <Redirect route={routerHelpers.getErrorRoute.path} />;
     }
 
     return (

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -383,15 +383,6 @@ Array [
     ],
   },
   Object {
-    "file": "./src/components/router/redirect.js",
-    "keys": Array [
-      Object {
-        "key": "curiosity-view.redirectError",
-        "match": "t('curiosity-view.redirectError')",
-      },
-    ],
-  },
-  Object {
     "file": "./src/components/table/table.js",
     "keys": Array [
       Object {

--- a/src/components/productView/__tests__/__snapshots__/productViewMissing.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productViewMissing.test.js.snap
@@ -1,6 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ProductViewMissing Component should redirect when there are limited product cards: redirect 1`] = `"Redirected towards /rhel"`;
+exports[`ProductViewMissing Component should redirect when there are limited product cards: redirect action 1`] = `
+Array [
+  Array [
+    Object {
+      "meta": Object {
+        "appName": undefined,
+        "id": "rhel",
+        "secondaryNav": undefined,
+      },
+      "payload": Promise {},
+      "type": "PLATFORM_SET_NAV",
+    },
+  ],
+]
+`;
 
 exports[`ProductViewMissing Component should render a non-connected component: non-connected 1`] = `
 <PageLayout

--- a/src/components/productView/__tests__/__snapshots__/productViewMissing.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productViewMissing.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ProductViewMissing Component should redirect when there are limited product cards: redirect 1`] = `"Redirected towards /rhel"`;
+
 exports[`ProductViewMissing Component should render a non-connected component: non-connected 1`] = `
 <PageLayout
   className="curiosity-missing-view"
@@ -147,42 +149,6 @@ exports[`ProductViewMissing Component should render a predictable set of product
     <Gallery
       hasGutter={true}
     >
-      <Card
-        isHoverable={true}
-        key="missingViewCard-rhel"
-        onClick={[Function]}
-      >
-        <CardTitle>
-          <Title
-            headingLevel="h2"
-            size="lg"
-          >
-            t(curiosity-view.title, {"appName":"Subscriptions","context":"RHEL"})
-          </Title>
-        </CardTitle>
-        <CardBody
-          className="curiosity-missing-view__card-description"
-        >
-          t(curiosity-view.description, {"appName":"Subscriptions","context":"RHEL"})
-        </CardBody>
-        <CardFooter>
-          <Button
-            icon={
-              <ArrowRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
-              />
-            }
-            iconPosition="right"
-            isInline={true}
-            onClick={[Function]}
-            variant="link"
-          >
-            Open
-          </Button>
-        </CardFooter>
-      </Card>
       <Card
         isHoverable={true}
         key="missingViewCard-openshift-container"

--- a/src/components/productView/__tests__/productViewMissing.test.js
+++ b/src/components/productView/__tests__/productViewMissing.test.js
@@ -1,10 +1,18 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import * as reactRedux from 'react-redux';
 import { ProductViewMissing } from '../productViewMissing';
-import { Redirect } from '../../router';
 
 describe('ProductViewMissing Component', () => {
+  const useDispatchMock = jest.spyOn(reactRedux, 'useDispatch');
+
+  afterEach(() => {
+    useDispatchMock.mockClear();
+  });
+
   it('should render a non-connected component', () => {
+    useDispatchMock.mockReturnValue(jest.fn());
+
     const props = {
       availableProductsRedirect: 1
     };
@@ -28,12 +36,13 @@ describe('ProductViewMissing Component', () => {
     );
   });
 
-  it('should redirect when there are limited product cards', () => {
+  it('should redirect when there are limited product cards', async () => {
+    const mockDispatch = jest.fn();
+    useDispatchMock.mockReturnValue(action => action(mockDispatch));
+
     const props = {};
 
-    mockWindowLocation(() => {
-      const component = shallow(<ProductViewMissing {...props} />);
-      expect(component.find(Redirect).html()).toMatchSnapshot('redirect');
-    });
+    await mountHookComponent(<ProductViewMissing {...props} />);
+    expect(mockDispatch.mock.calls).toMatchSnapshot('redirect action');
   });
 });

--- a/src/components/productView/__tests__/productViewMissing.test.js
+++ b/src/components/productView/__tests__/productViewMissing.test.js
@@ -1,16 +1,21 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { ProductViewMissing } from '../productViewMissing';
+import { Redirect } from '../../router';
 
 describe('ProductViewMissing Component', () => {
   it('should render a non-connected component', () => {
-    const props = {};
+    const props = {
+      availableProductsRedirect: 1
+    };
     const component = shallow(<ProductViewMissing {...props} />);
     expect(component).toMatchSnapshot('non-connected');
   });
 
   it('should render a predictable set of product cards', () => {
-    const props = {};
+    const props = {
+      availableProductsRedirect: 1
+    };
 
     mockWindowLocation(
       () => {
@@ -18,8 +23,17 @@ describe('ProductViewMissing Component', () => {
         expect(component).toMatchSnapshot('non-connected');
       },
       {
-        url: 'https://ci.foo.redhat.com/loremIpsum/dolorSit/'
+        url: 'https://ci.foo.redhat.com/openshift/subscriptions/'
       }
     );
+  });
+
+  it('should redirect when there are limited product cards', () => {
+    const props = {};
+
+    mockWindowLocation(() => {
+      const component = shallow(<ProductViewMissing {...props} />);
+      expect(component.find(Redirect).html()).toMatchSnapshot('redirect');
+    });
   });
 });

--- a/src/components/productView/productViewMissing.js
+++ b/src/components/productView/productViewMissing.js
@@ -2,11 +2,22 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Card, CardBody, CardFooter, CardTitle, Gallery, Title, PageSection } from '@patternfly/react-core';
 import { ArrowRightIcon } from '@patternfly/react-icons';
-import { useHistory } from 'react-router-dom';
+import { useMount } from 'react-use';
 import { PageLayout, PageHeader } from '../pageLayout/pageLayout';
-import { Redirect, routerHelpers } from '../router';
+import { routerHelpers } from '../router';
 import { helpers } from '../../common';
 import { translate } from '../i18n/i18n';
+import { useHistory } from '../../hooks/useRouter';
+
+/**
+ * Return a list of available products.
+ *
+ * @returns {Array}
+ */
+const filterAvailableProducts = () => {
+  const { configs, allConfigs } = routerHelpers.getRouteConfigByPath();
+  return (configs.length && configs) || allConfigs.filter(({ isSearchable }) => isSearchable === true);
+};
 
 /**
  * Render a missing product view.
@@ -19,16 +30,13 @@ import { translate } from '../i18n/i18n';
  */
 const ProductViewMissing = ({ availableProductsRedirect, t }) => {
   const history = useHistory();
+  const availableProducts = filterAvailableProducts();
 
-  /**
-   * Return a list of available products.
-   *
-   * @returns {Array}
-   */
-  const filterAvailableProducts = () => {
-    const { configs, allConfigs } = routerHelpers.getRouteConfigByPath();
-    return (configs.length && configs) || allConfigs.filter(({ isSearchable }) => isSearchable === true);
-  };
+  useMount(() => {
+    if (availableProducts.length <= availableProductsRedirect) {
+      history.push(availableProducts[0].path);
+    }
+  });
 
   /**
    * On click, update history.
@@ -37,16 +45,7 @@ const ProductViewMissing = ({ availableProductsRedirect, t }) => {
    * @param {string} id
    * @returns {void}
    */
-  const onNavigate = id => {
-    const { routeHref } = routerHelpers.getRouteConfig({ id });
-    history.push(routeHref);
-  };
-
-  const availableProducts = filterAvailableProducts();
-
-  if (availableProducts.length <= availableProductsRedirect) {
-    return <Redirect isForced route={availableProducts[0].path} />;
-  }
+  const onNavigate = id => history.push(id);
 
   return (
     <PageLayout className="curiosity-missing-view">

--- a/src/components/productView/productViewMissing.js
+++ b/src/components/productView/productViewMissing.js
@@ -4,19 +4,20 @@ import { Button, Card, CardBody, CardFooter, CardTitle, Gallery, Title, PageSect
 import { ArrowRightIcon } from '@patternfly/react-icons';
 import { useHistory } from 'react-router-dom';
 import { PageLayout, PageHeader } from '../pageLayout/pageLayout';
-import { routerHelpers } from '../router/router';
+import { Redirect, routerHelpers } from '../router';
 import { helpers } from '../../common';
 import { translate } from '../i18n/i18n';
 
 /**
  * Render a missing product view.
  *
- * @fires onClick
+ * @fires onNavigate
  * @param {object} props
+ * @param {number} props.availableProductsRedirect
  * @param {Function} props.t
  * @returns {Node}
  */
-const ProductViewMissing = ({ t }) => {
+const ProductViewMissing = ({ availableProductsRedirect, t }) => {
   const history = useHistory();
 
   /**
@@ -32,14 +33,20 @@ const ProductViewMissing = ({ t }) => {
   /**
    * On click, update history.
    *
-   * @event onUpdateHistory
+   * @event onNavigate
    * @param {string} id
    * @returns {void}
    */
-  const onClick = id => {
+  const onNavigate = id => {
     const { routeHref } = routerHelpers.getRouteConfig({ id });
     history.push(routeHref);
   };
+
+  const availableProducts = filterAvailableProducts();
+
+  if (availableProducts.length <= availableProductsRedirect) {
+    return <Redirect isForced route={availableProducts[0].path} />;
+  }
 
   return (
     <PageLayout className="curiosity-missing-view">
@@ -48,8 +55,8 @@ const ProductViewMissing = ({ t }) => {
       </PageHeader>
       <PageSection isFilled>
         <Gallery hasGutter>
-          {filterAvailableProducts().map(product => (
-            <Card key={`missingViewCard-${product.id}`} isHoverable onClick={() => onClick(product.id)}>
+          {availableProducts.map(product => (
+            <Card key={`missingViewCard-${product.id}`} isHoverable onClick={() => onNavigate(product.id)}>
               <CardTitle>
                 <Title headingLevel="h2" size="lg">
                   {t('curiosity-view.title', {
@@ -71,7 +78,7 @@ const ProductViewMissing = ({ t }) => {
                 <Button
                   variant="link"
                   isInline
-                  onClick={() => onClick(product.id)}
+                  onClick={() => onNavigate(product.id)}
                   icon={<ArrowRightIcon />}
                   iconPosition="right"
                 >
@@ -89,18 +96,20 @@ const ProductViewMissing = ({ t }) => {
 /**
  * Prop types.
  *
- * @type {{t: Function}}
+ * @type {{availableProductsRedirect: number, t: Function}}
  */
 ProductViewMissing.propTypes = {
+  availableProductsRedirect: PropTypes.number,
   t: PropTypes.func
 };
 
 /**
  * Default props.
  *
- * @type {{t: translate}}
+ * @type {{availableProductsRedirect: number, t: translate}}
  */
 ProductViewMissing.defaultProps = {
+  availableProductsRedirect: 3,
   t: translate
 };
 

--- a/src/components/router/__tests__/__snapshots__/redirect.test.js.snap
+++ b/src/components/router/__tests__/__snapshots__/redirect.test.js.snap
@@ -1,5 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Redirect Component should handle a forced redirect: forced route 1`] = `
+<Fragment>
+  Redirected towards 
+  /dolor
+</Fragment>
+`;
+
+exports[`Redirect Component should handle a forced redirect: forced route, replace 1`] = `
+Array [
+  Array [
+    "/dolor?dolor=sit",
+  ],
+]
+`;
+
 exports[`Redirect Component should handle a redirect with a url: redirect url 1`] = `
 <Fragment>
   Redirected towards 
@@ -7,126 +22,159 @@ exports[`Redirect Component should handle a redirect with a url: redirect url 1`
 </Fragment>
 `;
 
-exports[`Redirect Component should handle existing routes with and without withRouter: existing route: outside of withRouter 1`] = `
-<Suspense
-  baseName="/"
-  fallback={
-    <Loader
-      skeletonProps={
-        Object {
-          "size": "sm",
-        }
-      }
-      tableProps={Object {}}
-      variant="title"
-    />
-  }
-  history={Object {}}
-  isRedirect={true}
-  isReplace={false}
-  route="/openshift-container"
-  t={[Function]}
-  url={null}
->
-  <Route
-    path="*"
-  >
-    <lazy />
-  </Route>
-</Suspense>
+exports[`Redirect Component should handle existing routes: existing route 1`] = `
+Object {
+  "activateOnError": false,
+  "aliases": Array [],
+  "component": "productView/productViewOpenShiftContainer",
+  "default": false,
+  "disabled": false,
+  "id": "openshift-container",
+  "isSearchable": true,
+  "path": "*",
+  "pathParameter": "OpenShift Container Platform",
+  "productParameter": "OpenShift Container Platform",
+  "redirect": null,
+  "routeHref": "/openshift-container",
+  "viewParameter": "viewOpenShift Container Platform",
+}
 `;
 
-exports[`Redirect Component should handle existing routes with and without withRouter: existing route: routed redirect route 1`] = `
+exports[`Redirect Component should handle missing routes: missing route, component 1`] = `
+<Fragment>
+  Redirected towards 
+  /lorem-ipsum
+</Fragment>
+`;
+
+exports[`Redirect Component should render a basic component: basic 1`] = `
 <Router
-  history={
-    Object {
-      "action": "POP",
-      "block": [Function],
-      "createHref": [Function],
-      "go": [Function],
-      "goBack": [Function],
-      "goForward": [Function],
-      "length": 1,
-      "listen": [Function],
-      "location": Object {
-        "hash": "",
-        "pathname": "/",
-        "search": "",
-        "state": undefined,
+  routes={
+    Array [
+      Object {
+        "activateOnError": false,
+        "aliases": Array [],
+        "component": "productView/productViewOpenShiftDedicated",
+        "default": false,
+        "disabled": false,
+        "id": "openshift-dedicated",
+        "isSearchable": true,
+        "path": "*",
+        "pathParameter": "OpenShift-dedicated-metrics",
+        "productParameter": "OpenShift-dedicated-metrics",
+        "redirect": null,
+        "routeHref": "/openshift-dedicated",
+        "viewParameter": "viewOpenShift-dedicated-metrics",
       },
-      "push": [Function],
-      "replace": [Function],
-    }
-  }
->
-  <withRouter(Redirect)
-    history={Object {}}
-    isRedirect={true}
-    route="/openshift-container"
-  />
-</Router>
-`;
-
-exports[`Redirect Component should handle missing routes with and without withRouter: missing route: outside of withRouter 1`] = `
-<Suspense
-  baseName="/"
-  fallback={
-    <Loader
-      skeletonProps={
-        Object {
-          "size": "sm",
-        }
-      }
-      tableProps={Object {}}
-      variant="title"
-    />
-  }
-  history={Object {}}
-  isRedirect={true}
-  isReplace={false}
-  route="/lorem-ipsum"
-  t={[Function]}
-  url={null}
->
-  <Route
-    path="*"
-  >
-    <Component />
-  </Route>
-</Suspense>
-`;
-
-exports[`Redirect Component should handle missing routes with and without withRouter: missing route: routed redirect route 1`] = `
-<Router
-  history={
-    Object {
-      "action": "POP",
-      "block": [Function],
-      "createHref": [Function],
-      "go": [Function],
-      "goBack": [Function],
-      "goForward": [Function],
-      "length": 1,
-      "listen": [Function],
-      "location": Object {
-        "hash": "",
-        "pathname": "/",
-        "search": "",
-        "state": undefined,
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewRhel",
+        "disabled": false,
+        "exact": true,
+        "id": "rhel",
+        "path": "/rhel",
+        "redirect": null,
       },
-      "push": [Function],
-      "replace": [Function],
-    }
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewRhel",
+        "disabled": false,
+        "exact": true,
+        "id": "rhel-arm",
+        "path": "/rhel-arm",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewRhel",
+        "disabled": false,
+        "exact": true,
+        "id": "rhel-ibmpower",
+        "path": "/rhel-ibmpower",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewRhel",
+        "disabled": false,
+        "exact": true,
+        "id": "rhel-ibmz",
+        "path": "/rhel-ibmz",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewRhel",
+        "disabled": false,
+        "exact": true,
+        "id": "rhel-x86",
+        "path": "/rhel-x86",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewOpenShiftContainer",
+        "disabled": false,
+        "exact": true,
+        "id": "openshift-container",
+        "path": "/openshift-container",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewOpenShiftDedicated",
+        "disabled": false,
+        "exact": true,
+        "id": "openshift-dedicated",
+        "path": "/openshift-dedicated",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewSatellite",
+        "disabled": false,
+        "exact": true,
+        "id": "satellite",
+        "path": "/satellite",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewSatellite",
+        "disabled": false,
+        "exact": true,
+        "id": "satellite-capsule",
+        "path": "/satellite-capsule",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewSatellite",
+        "disabled": false,
+        "exact": true,
+        "id": "satellite-server",
+        "path": "/satellite-server",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": true,
+        "component": "optinView/optinView",
+        "disabled": false,
+        "exact": true,
+        "id": "optin",
+        "path": "/optin",
+        "redirect": null,
+      },
+      Object {
+        "activateOnError": false,
+        "component": "productView/productViewMissing",
+        "disabled": false,
+        "exact": true,
+        "id": "missing",
+        "path": "/",
+        "redirect": "/",
+      },
+    ]
   }
->
-  <withRouter(Redirect)
-    history={Object {}}
-    isRedirect={true}
-    route="/lorem-ipsum"
-  />
-</Router>
+/>
 `;
-
-exports[`Redirect Component should render a basic component: basic 1`] = `null`;
-
-exports[`Redirect Component should render a routed component: routed 1`] = `null`;

--- a/src/components/router/__tests__/redirect.test.js
+++ b/src/components/router/__tests__/redirect.test.js
@@ -1,73 +1,64 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { BrowserRouter } from 'react-router-dom';
-import { Redirect, RoutedRedirect } from '../redirect';
+import { Redirect } from '../redirect';
+import { Router } from '../router';
 
 describe('Redirect Component', () => {
   it('should render a basic component', () => {
     const props = {
-      isRedirect: false
+      route: '/openshift-dedicated'
     };
     const component = shallow(<Redirect {...props} />);
-    expect(component.render()).toMatchSnapshot('basic');
+    expect(component).toMatchSnapshot('basic');
   });
 
-  it('should render a routed component', () => {
+  it('should handle a forced redirect', () => {
     const props = {
-      isRedirect: false
+      isForced: true,
+      route: '/dolor'
     };
-    const component = shallow(
-      <BrowserRouter>
-        <RoutedRedirect {...props} />
-      </BrowserRouter>
+
+    mockWindowLocation(
+      () => {
+        const mockReplace = jest.spyOn(window.location, 'replace').mockImplementation((type, data) => ({ type, data }));
+        const component = shallow(<Redirect {...props} />);
+
+        expect(mockReplace.mock.calls).toMatchSnapshot('forced route, replace');
+        expect(component).toMatchSnapshot('forced route');
+
+        mockReplace.mockClear();
+      },
+      {
+        url: 'http://lorem/ipsum?dolor=sit'
+      }
     );
-    expect(component.render()).toMatchSnapshot('routed');
   });
 
   it('should handle a redirect with a url', () => {
     const props = {
-      isRedirect: true,
       url: '//lorem/ipsum?dolor=sit'
     };
     const component = shallow(<Redirect {...props} />);
     expect(component).toMatchSnapshot('redirect url');
   });
 
-  it('should handle missing routes with and without withRouter', () => {
+  it('should handle missing routes', () => {
     const props = {
-      isRedirect: true,
-      route: '/lorem-ipsum',
-      history: {}
+      route: '/lorem-ipsum'
     };
     const component = shallow(<Redirect {...props} />);
 
-    expect(component).toMatchSnapshot('missing route: outside of withRouter');
-
-    const componentWithRouter = shallow(
-      <BrowserRouter>
-        <RoutedRedirect {...props} />
-      </BrowserRouter>
-    );
-
-    expect(componentWithRouter).toMatchSnapshot('missing route: routed redirect route');
+    expect(component).toMatchSnapshot('missing route, component');
   });
 
-  it('should handle existing routes with and without withRouter', () => {
+  it('should handle existing routes', () => {
     const props = {
-      isRedirect: true,
-      route: '/openshift-container',
-      history: {}
+      route: '/openshift-container'
     };
+
     const component = shallow(<Redirect {...props} />);
+    const { routes } = component.find(Router).props();
 
-    expect(component).toMatchSnapshot('existing route: outside of withRouter');
-
-    const componentWithRouter = shallow(
-      <BrowserRouter>
-        <RoutedRedirect {...props} />
-      </BrowserRouter>
-    );
-
-    expect(componentWithRouter).toMatchSnapshot('existing route: routed redirect route');
+    expect(routes[0]).toMatchSnapshot('existing route');
   });
 });

--- a/src/components/router/__tests__/router.test.js
+++ b/src/components/router/__tests__/router.test.js
@@ -3,13 +3,11 @@ import { shallow } from 'enzyme';
 import { Provider } from 'react-redux';
 import { MemoryRouter, Route } from 'react-router-dom';
 import { store } from '../../../redux';
-import { Router, Redirect, routerHelpers } from '../router';
+import { Router } from '../router';
 
 describe('Router Component', () => {
   it('should export specific properties', () => {
     expect(Router).toBeDefined();
-    expect(Redirect).toBeDefined();
-    expect(routerHelpers).toBeDefined();
   });
 
   it('should render a basic component', () => {

--- a/src/components/router/index.js
+++ b/src/components/router/index.js
@@ -1,0 +1,5 @@
+import { Redirect } from './redirect';
+import { Router } from './router';
+import { routerHelpers } from './routerHelpers';
+
+export { Redirect, Router, routerHelpers };

--- a/src/components/router/redirect.js
+++ b/src/components/router/redirect.js
@@ -1,95 +1,68 @@
 import path from 'path';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withRouter, Route } from 'react-router-dom';
+import { Router } from './router';
 import { routerHelpers } from './routerHelpers';
 import { helpers } from '../../common';
-import { Loader } from '../loader/loader';
-import MessageView from '../messageView/messageView';
-import { translate } from '../i18n/i18n';
-
 /**
  * A routing redirect.
  *
  * @param {object} props
  * @param {string} props.baseName
- * @param {object} props.history
- * @param {boolean} props.isRedirect
- * @param {boolean} props.isReplace
+ * @param {boolean} props.isForced
  * @param {string} props.route
- * @param {string} props.t
+ * @param {string} props.routes
  * @param {string} props.url
  * @returns {Node}
  */
-const Redirect = ({ baseName, history, isRedirect, isReplace, route, t, url }) => {
-  const forceNavigation = urlRoute => {
-    if (!helpers.DEV_MODE && !helpers.TEST_MODE) {
-      if (isReplace) {
-        window.location.replace(urlRoute);
-      } else {
-        window.location.href = urlRoute;
-      }
-    }
+const Redirect = ({ baseName, isForced, route, routes, url }) => {
+  /**
+   * Bypass router, force the location.
+   */
+  const forceNavigation = () => {
+    const { hash = '', search = '' } = window.location;
+    const forcePath = url || (route && `${path.join(baseName, route)}${search}${hash}`);
+
+    window.location.replace(forcePath);
   };
 
-  if (isRedirect === true) {
-    if (route && history) {
-      const routeDetail = routerHelpers.getRouteConfigByPath({ pathName: route }).firstMatch;
-      const View =
-        (routeDetail && routerHelpers.importView(routeDetail.component)) ||
-        (() => <MessageView message={`${t('curiosity-view.redirectError')}, ${route}`} />);
+  const { path: matchedRoutePath, ...matchedRoute } = routerHelpers.getRouteConfig({ pathName: route, id: route });
 
-      return (
-        <React.Suspense fallback={<Loader variant="title" />}>
-          <Route path="*">
-            <View />
-          </Route>
-        </React.Suspense>
-      );
-    }
-
-    const forcePath = url || (route && path.join(baseName, route));
-    forceNavigation(forcePath);
-
-    return (
-      ((helpers.DEV_MODE || helpers.TEST_MODE) && <React.Fragment>Redirected towards {forcePath}</React.Fragment>) ||
-      null
-    );
+  if (!isForced && matchedRoutePath) {
+    return <Router routes={[{ ...matchedRoute, path: '*' }, ...routes]} />;
   }
 
-  return null;
+  forceNavigation();
+
+  return (helpers.TEST_MODE && <React.Fragment>Redirected towards {url || route}</React.Fragment>) || null;
 };
 
 /**
  * Prop types.
  *
- * @type {{isRedirect: boolean, route: string, t: Function, isReplace: boolean, history: object,
- *     baseName: string, url: string}}
+ * @type {{isRedirect: boolean, route: string, routes: Array, isReplace: boolean, baseName: string, url: string,
+ *    isForced: boolean}}
  */
 Redirect.propTypes = {
   baseName: PropTypes.string,
-  history: PropTypes.object,
-  isRedirect: PropTypes.bool.isRequired,
-  isReplace: PropTypes.bool,
+  isForced: PropTypes.bool,
   route: PropTypes.string,
-  t: PropTypes.func,
+  routes: PropTypes.array,
   url: PropTypes.string
 };
 
 /**
  * Default props.
  *
- * @type {{route: null, t: translate, isReplace: boolean, history: null, baseName: string, url: null}}
+ * @type {{isRedirect: boolean, route: string, routes: Array, isReplace: boolean, baseName: string, url: string,
+ *    isForced: boolean}}
  */
 Redirect.defaultProps = {
   baseName: routerHelpers.baseName,
-  history: null,
-  isReplace: false,
+  isForced: false,
   route: null,
-  t: translate,
+  routes: routerHelpers.routes,
   url: null
 };
 
-const RoutedRedirect = withRouter(Redirect);
-
-export { RoutedRedirect as default, RoutedRedirect, Redirect };
+export { Redirect as default, Redirect };

--- a/src/components/router/router.js
+++ b/src/components/router/router.js
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Redirect as ReactRouterDomRedirect, Route, Switch } from 'react-router-dom';
 import { useMount } from 'react-use';
-import Redirect from './redirect';
 import { routerHelpers } from './routerHelpers';
 import { Loader } from '../loader/loader';
 
@@ -14,8 +13,8 @@ import { Loader } from '../loader/loader';
  * @returns {Node}
  */
 const Router = ({ routes } = {}) => {
-  const [views, setViews] = useState([]);
-  const [redirectRoot, setRedirectRoot] = useState(null);
+  const [updatedRoutes, setUpdatedRoutes] = useState([]);
+  const [redirectDefault, setRedirectDefault] = useState(null);
 
   /**
    * Initialize routes.
@@ -77,15 +76,15 @@ const Router = ({ routes } = {}) => {
       })
     );
 
-    setViews(results);
-    setRedirectRoot(routes.find(({ disabled, redirect }) => !disabled && redirect) ?? null);
+    setUpdatedRoutes(results);
+    setRedirectDefault(routes.find(({ disabled, redirect }) => !disabled && redirect) ?? null);
   });
 
   return (
     <React.Suspense fallback={<Loader variant="title" />}>
       <Switch>
-        {views}
-        {redirectRoot && <ReactRouterDomRedirect to={redirectRoot.redirect} />}
+        {updatedRoutes}
+        {redirectDefault && <ReactRouterDomRedirect to={redirectDefault.redirect} />}
       </Switch>
     </React.Suspense>
   );
@@ -121,4 +120,4 @@ Router.defaultProps = {
   routes: routerHelpers.routes
 };
 
-export { Router as default, Router, Redirect, routerHelpers };
+export { Router as default, Router };

--- a/src/components/router/routerHelpers.js
+++ b/src/components/router/routerHelpers.js
@@ -137,7 +137,7 @@ const getErrorRoute = routes.find(route => route.activateOnError === true) || {}
  * @returns {{configs: Array, configFirstMatch: object, configsById: object}}
  */
 const getRouteConfigByPath = ({ pathName = dynamicBasePath(), config = routesConfig } = {}) => {
-  const basePathDirs = pathName.split('/').filter(str => str.length > 0);
+  const basePathDirs = pathName?.split('/').filter(str => str.length > 0);
   const configs = [];
   const allConfigs = [];
   const configsById = {};
@@ -174,7 +174,7 @@ const getRouteConfigByPath = ({ pathName = dynamicBasePath(), config = routesCon
     });
   };
 
-  if (basePathDirs.length) {
+  if (basePathDirs?.length) {
     basePathDirs.forEach(dir => {
       if (dir) {
         const decodedDir = window.decodeURI(dir);

--- a/src/hooks/__tests__/__snapshots__/useRouter.test.js.snap
+++ b/src/hooks/__tests__/__snapshots__/useRouter.test.js.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useRouter should apply a hook for useHistory: push, config route 1`] = `
+Array [
+  Array [
+    Object {
+      "meta": Object {
+        "appName": undefined,
+        "id": "rhel",
+        "secondaryNav": undefined,
+      },
+      "payload": Promise {},
+      "type": "PLATFORM_SET_NAV",
+    },
+  ],
+]
+`;
+
+exports[`useRouter should apply a hook for useHistory: push, unique route 1`] = `
+Array [
+  Array [
+    "/lorem/ipsum",
+    undefined,
+  ],
+]
+`;
+
+exports[`useRouter should return specific properties: specific properties 1`] = `
+Object {
+  "useHistory": [Function],
+  "useLocation": [Function],
+  "useParams": [Function],
+  "useRouteMatch": [Function],
+}
+`;

--- a/src/hooks/__tests__/useRouter.test.js
+++ b/src/hooks/__tests__/useRouter.test.js
@@ -1,0 +1,24 @@
+import { routerHooks } from '../useRouter';
+
+describe('useRouter', () => {
+  it('should return specific properties', () => {
+    expect(routerHooks).toMatchSnapshot('specific properties');
+  });
+
+  it('should apply a hook for useHistory', () => {
+    const mockDispatch = jest.fn();
+    const mockHistoryPush = jest.fn();
+    const mockUseHistory = mockHook(() =>
+      routerHooks.useHistory({
+        useDispatch: () => action => action(mockDispatch),
+        useHistory: () => ({ push: mockHistoryPush })
+      })
+    );
+
+    mockUseHistory.push('rhel');
+    expect(mockDispatch.mock.calls).toMatchSnapshot('push, config route');
+
+    mockUseHistory.push('/lorem/ipsum');
+    expect(mockHistoryPush.mock.calls).toMatchSnapshot('push, unique route');
+  });
+});

--- a/src/hooks/useRouter.js
+++ b/src/hooks/useRouter.js
@@ -1,0 +1,49 @@
+import { useHistory as useHistoryRRD, useLocation, useParams, useRouteMatch } from 'react-router-dom';
+import { routerHelpers } from '../components/router/routerHelpers';
+import { reduxActions, useDispatch } from '../redux';
+import { helpers } from '../common/helpers';
+
+/**
+ * ToDo: reevaluate this alternative pattern of passing library hooks as options
+ * We did this as a test to see if its more convenient for unit testing instead of
+ * having to spy or mock entire resources.
+ */
+/**
+ * Pass useHistory methods. Proxy useHistory push with Platform specific navigation update.
+ *
+ * @param {object} hooks
+ * @param {Function} hooks.useHistory
+ * @param {Function} hooks.useDispatch
+ * @returns {object<history>}
+ */
+const useHistory = ({
+  useHistory: useAliasHistory = useHistoryRRD,
+  useDispatch: useAliasDispatch = useDispatch
+} = {}) => {
+  const history = useAliasHistory();
+  const dispatch = useAliasDispatch();
+
+  return {
+    ...history,
+    push: (pathLocation, historyState) => {
+      const pathName = (typeof pathLocation === 'string' && pathLocation) || pathLocation?.pathname;
+      const { productParameter, id, routeHref } = routerHelpers.getRouteConfig({ pathName, id: pathName });
+      const { hash, search } = window.location;
+
+      if (!helpers.DEV_MODE && productParameter) {
+        return dispatch(reduxActions.platform.setAppNav(id));
+      }
+
+      return history.push(routeHref || (pathName && `${pathName}${search}${hash}`) || pathLocation, historyState);
+    }
+  };
+};
+
+const routerHooks = {
+  useHistory,
+  useLocation,
+  useParams,
+  useRouteMatch
+};
+
+export { routerHooks as default, routerHooks, useHistory, useLocation, useParams, useRouteMatch };

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
-import { baseName } from './components/router/routerHelpers';
+import { routerHelpers } from './components/router';
 import { store } from './redux';
 import App from './components/app';
 import './styles/index.scss';
@@ -10,7 +10,7 @@ import '@patternfly/react-styles/css/components/Select/select.css';
 
 render(
   <Provider store={store}>
-    <BrowserRouter basename={baseName}>
+    <BrowserRouter basename={routerHelpers.baseName}>
       <App />
     </BrowserRouter>
   </Provider>,

--- a/src/redux/actions/__tests__/__snapshots__/platformActions.test.js.snap
+++ b/src/redux/actions/__tests__/__snapshots__/platformActions.test.js.snap
@@ -30,17 +30,16 @@ exports[`PlatformActions Should return a function for the onNavigation method: e
 
 exports[`PlatformActions Should return a function for the onNavigation method: function 1`] = `[Function]`;
 
-exports[`PlatformActions Should return a function for the setNavigation method: expected process 1`] = `
-Array [
-  Object {
-    "active": false,
+exports[`PlatformActions Should return a function for the setAppNav method: expected process 1`] = `
+Object {
+  "meta": Object {
+    "appName": undefined,
     "id": "lorem",
+    "secondaryNav": undefined,
   },
-  Object {
-    "active": false,
-    "id": "ipsum",
-  },
-]
+  "payload": Promise {},
+  "type": "PLATFORM_SET_NAV",
+}
 `;
 
-exports[`PlatformActions Should return a function for the setNavigation method: function 1`] = `[Function]`;
+exports[`PlatformActions Should return a function for the setAppNav method: function 1`] = `[Function]`;

--- a/src/redux/actions/__tests__/platformActions.test.js
+++ b/src/redux/actions/__tests__/platformActions.test.js
@@ -21,13 +21,11 @@ describe('PlatformActions', () => {
     expect(platformActions.setAppName()).toMatchSnapshot('dispatch object');
   });
 
-  it('Should return a function for the setNavigation method', () => {
-    expect(platformActions.setNavigation()).toMatchSnapshot('function');
+  it('Should return a function for the setAppNav method', () => {
+    expect(platformActions.setAppNav()).toMatchSnapshot('function');
 
     window.insights.chrome.navigation = jest.fn().mockImplementation(value => value);
     const dispatch = obj => obj;
-    expect(platformActions.setNavigation([{ id: 'lorem' }, { id: 'ipsum' }])(dispatch)).toMatchSnapshot(
-      'expected process'
-    );
+    expect(platformActions.setAppNav('lorem')(dispatch)).toMatchSnapshot('expected process');
   });
 });

--- a/src/redux/actions/platformActions.js
+++ b/src/redux/actions/platformActions.js
@@ -78,17 +78,24 @@ const setAppName = name => ({
 });
 
 /**
- * Apply platform method for handling the left-nav navigation active item.
+ * Apply platform method for changing routes via the left-nav navigation.
  *
- * @param {object} data
+ * @param {string} id
+ * @param {object} options
+ * @param {string} options.appName
+ * @param {boolean} options.secondaryNav
  * @returns {Function}
  */
-const setNavigation = data => dispatch => {
+const setAppNav = (id, { appName, secondaryNav } = {}) => dispatch =>
   dispatch({
-    type: platformTypes.PLATFORM_SET_NAV
+    type: platformTypes.PLATFORM_SET_NAV,
+    payload: platformServices.setAppNav(id, { appName, secondaryNav }),
+    meta: {
+      id,
+      appName,
+      secondaryNav
+    }
   });
-  return platformServices.setNavigation(data);
-};
 
 const platformActions = {
   addNotification,
@@ -98,7 +105,7 @@ const platformActions = {
   initializeChrome,
   onNavigation,
   setAppName,
-  setNavigation
+  setAppNav
 };
 
 export {
@@ -111,5 +118,5 @@ export {
   initializeChrome,
   onNavigation,
   setAppName,
-  setNavigation
+  setAppNav
 };

--- a/src/redux/reducers/viewReducer.js
+++ b/src/redux/reducers/viewReducer.js
@@ -1,4 +1,4 @@
-import { routerHelpers } from '../../components/router/routerHelpers';
+import { routerHelpers } from '../../components/router';
 import { reduxTypes } from '../types';
 import { reduxHelpers } from '../common/reduxHelpers';
 import { RHSM_API_QUERY_TYPES } from '../../types/rhsmApiTypes';

--- a/src/services/__tests__/__snapshots__/platformServices.test.js.snap
+++ b/src/services/__tests__/__snapshots__/platformServices.test.js.snap
@@ -8,6 +8,8 @@ exports[`PlatformServices should return a failed initializeChrome: failed initia
 
 exports[`PlatformServices should return a failed setAppName: failed setAppName 1`] = `"{ identifyApp } = insights.chrome, insights.chrome.identifyApp is not a function"`;
 
+exports[`PlatformServices should return a failed setAppNav: failed setAppNav 1`] = `[Error: { appNavClick } = insights.chrome, insights.chrome.appNavClick is not a function]`;
+
 exports[`PlatformServices should return a successful getUser with a specific response: specific success for authorized user 1`] = `"lorem ipsum"`;
 
 exports[`PlatformServices should return a successful getUser: success authorized user 1`] = `

--- a/src/services/__tests__/platformServices.test.js
+++ b/src/services/__tests__/platformServices.test.js
@@ -25,7 +25,7 @@ describe('PlatformServices', () => {
     expect(platformServices.initializeChrome).toBeDefined();
     expect(platformServices.onNavigation).toBeDefined();
     expect(platformServices.setAppName).toBeDefined();
-    expect(platformServices.setNavigation).toBeDefined();
+    expect(platformServices.setAppNav).toBeDefined();
   });
 
   /**
@@ -95,10 +95,10 @@ describe('PlatformServices', () => {
     expect(response).toMatchSnapshot('failed setAppName');
   });
 
-  it('should return a failed setNavigation', () => {
-    window.insights.chrome.navigation = undefined;
-    expect(platformServices.setNavigation).toThrowError(
-      '{ navigation } = insights.chrome, insights.chrome.navigation is not a function'
-    );
+  it('should return a failed setAppNav', async () => {
+    window.insights.chrome.appNavClick = undefined;
+    const response = await returnPromiseAsync(platformServices.setAppNav);
+
+    expect(response).toMatchSnapshot('failed setAppNav');
   });
 });

--- a/src/services/platformServices.js
+++ b/src/services/platformServices.js
@@ -122,24 +122,24 @@ const setAppName = async (name = null) => {
   }
 };
 
-// ToDo: Clean up, consider removing setNavigation, currently no longer used.
 /**
- * Set platform left hand navigation active item.
+ * Set app routes via the platform left-nav navigation.
  *
- * @param {Array} data
- * @returns {*}
+ * @param {string} id The navigation ID associated with internal route config, and external platform nav config
+ * @param {object} options
+ * @param {string} options.appName
+ * @param {boolean} options.secondaryNav
+ * @returns {Promise<object>}
  */
-const setNavigation = (data = []) => {
-  const { insights, location } = window;
+const setAppNav = async (id, { appName = helpers.UI_NAME, secondaryNav = true } = {}) => {
+  const { insights } = window;
   try {
-    return insights.chrome.navigation(
-      data.map(item => ({
-        ...item,
-        active: item.id === location.pathname.split('/').slice(-1)[0]
-      }))
+    return (
+      (helpers.DEV_MODE && { [platformApiTypes.PLATFORM_API_RESPONSE_NAV_TYPES.ACTIVE_APP]: id }) ||
+      (await insights.chrome.appNavClick({ id, secondaryNav, parentId: appName }))
     );
   } catch (e) {
-    throw new Error(`{ navigation } = insights.chrome, ${e.message}`);
+    throw new Error(`{ appNavClick } = insights.chrome, ${e.message}`);
   }
 };
 
@@ -150,7 +150,7 @@ const platformServices = {
   initializeChrome,
   onNavigation,
   setAppName,
-  setNavigation
+  setAppNav
 };
 
 export {
@@ -162,5 +162,5 @@ export {
   initializeChrome,
   onNavigation,
   setAppName,
-  setNavigation
+  setAppNav
 };

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,4 +1,5 @@
-import { configure, mount } from 'enzyme';
+import React from 'react';
+import { configure, mount, shallow } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { act } from 'react-dom/test-utils';
 import * as pfReactCoreComponents from '@patternfly/react-core';
@@ -23,11 +24,6 @@ jest.mock('i18next', () => {
  */
 jest.mock('lodash/debounce', () => jest.fn);
 
-/**
- * FixMe: Use of arrow functions removes the usefulness of the "displayName" when shallow rendering
- * PF appears to have updated components with a "displayName". Because we potentially have internal
- * components, and other resources that are missing "displayName". We're leaving this test helper active.
- */
 /**
  * Add the displayName property to function based components. Makes sure that snapshot tests have named components
  * instead of displaying a generic "<Component.../>".
@@ -54,6 +50,7 @@ addDisplayName(pfReactChartComponents);
  */
 global.window.insights = {
   chrome: {
+    appNavClick: Function.prototype,
     auth: {
       getUser: () =>
         new Promise(resolve =>
@@ -70,7 +67,6 @@ global.window.insights = {
     identifyApp: Function.prototype,
     init: Function.prototype,
     isBeta: Function.prototype,
-    navigation: Function.prototype,
     on: Function.prototype
   }
 };
@@ -90,6 +86,22 @@ global.mountHookComponent = async (component, options = {}) => {
   });
   mountedComponent?.update();
   return mountedComponent;
+};
+
+/**
+ * Fire a hook, return the result.
+ *
+ * @param {Function} useHook
+ * @returns {*}
+ */
+global.mockHook = (useHook = Function.prototype) => {
+  let result;
+  const Hook = () => {
+    result = useHook();
+    return null;
+  };
+  shallow(<Hook />);
+  return result;
 };
 
 /**

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -98,9 +98,13 @@ global.mountHookComponent = async (component, options = {}) => {
  * @param {Function} callback
  * @param {object} options
  * @param {string} options.url
+ * @param {object} options.location
  * @returns {Promise<void>}
  */
-global.mockWindowLocation = async (callback, { url = 'https://ci.foo.redhat.com/subscriptions/rhel' } = {}) => {
+global.mockWindowLocation = async (
+  callback = Function.prototype,
+  { url = 'https://ci.foo.redhat.com/subscriptions/rhel', location: locationProps = {} } = {}
+) => {
   const updatedUrl = new URL(url);
   const { location } = window;
   delete window.location;
@@ -109,9 +113,11 @@ global.mockWindowLocation = async (callback, { url = 'https://ci.foo.redhat.com/
     href: updatedUrl.href,
     search: updatedUrl.search,
     hash: updatedUrl.hash,
-    pathname: updatedUrl.pathname
+    pathname: updatedUrl.pathname,
+    replace: Function.prototype,
+    ...locationProps
   };
-  await callback();
+  await callback(window.location);
   // restore
   window.location = location;
 };
@@ -128,6 +134,8 @@ beforeAll(() => {
       throw new Error(message);
     }
 
-    error.apply(console, [message, ...args]);
+    if (!/(Not implemented: navigation)/gi.test(message)) {
+      error.apply(console, [message, ...args]);
+    }
   };
 });

--- a/src/types/__tests__/__snapshots__/index.test.js.snap
+++ b/src/types/__tests__/__snapshots__/index.test.js.snap
@@ -4,6 +4,9 @@ exports[`ApiTypes should have specific API properties: all exported api types 1`
 Object {
   "apiTypes": Object {
     "platformApi": Object {
+      "PLATFORM_API_RESPONSE_NAV_TYPES": Object {
+        "ACTIVE_APP": "activeApp",
+      },
       "PLATFORM_API_RESPONSE_USER_ENTITLEMENTS": "entitlements",
       "PLATFORM_API_RESPONSE_USER_ENTITLEMENTS_APP_TYPES": Object {
         "ENTITLED": "is_entitled",
@@ -241,6 +244,9 @@ Object {
   },
   "default": Object {
     "platformApi": Object {
+      "PLATFORM_API_RESPONSE_NAV_TYPES": Object {
+        "ACTIVE_APP": "activeApp",
+      },
       "PLATFORM_API_RESPONSE_USER_ENTITLEMENTS": "entitlements",
       "PLATFORM_API_RESPONSE_USER_ENTITLEMENTS_APP_TYPES": Object {
         "ENTITLED": "is_entitled",
@@ -477,6 +483,9 @@ Object {
     },
   },
   "platformApiTypes": Object {
+    "PLATFORM_API_RESPONSE_NAV_TYPES": Object {
+      "ACTIVE_APP": "activeApp",
+    },
     "PLATFORM_API_RESPONSE_USER_ENTITLEMENTS": "entitlements",
     "PLATFORM_API_RESPONSE_USER_ENTITLEMENTS_APP_TYPES": Object {
       "ENTITLED": "is_entitled",
@@ -717,6 +726,9 @@ Object {
 exports[`ApiTypes should have specific API properties: specific types 1`] = `
 Object {
   "platformApi": Object {
+    "PLATFORM_API_RESPONSE_NAV_TYPES": Object {
+      "ACTIVE_APP": "activeApp",
+    },
     "PLATFORM_API_RESPONSE_USER_ENTITLEMENTS": "entitlements",
     "PLATFORM_API_RESPONSE_USER_ENTITLEMENTS_APP_TYPES": Object {
       "ENTITLED": "is_entitled",

--- a/src/types/platformApiTypes.js
+++ b/src/types/platformApiTypes.js
@@ -1,4 +1,13 @@
 /**
+ * Platform response for appNavClick.
+ *
+ * @type {{ACTIVE_APP: string}}
+ */
+const PLATFORM_API_RESPONSE_NAV_TYPES = {
+  ACTIVE_APP: 'activeApp'
+};
+
+/**
  * Platform response entitlements type.
  *
  * @type {string}
@@ -76,6 +85,7 @@ const PLATFORM_API_RESPONSE_USER_PERMISSION_OPERATION_TYPES = {
  *     PLATFORM_API_RESPONSE_USER_IDENTITY_USER_TYPES: {ORG_ADMIN: string}}}
  */
 const platformApiTypes = {
+  PLATFORM_API_RESPONSE_NAV_TYPES,
   PLATFORM_API_RESPONSE_USER_ENTITLEMENTS,
   PLATFORM_API_RESPONSE_USER_ENTITLEMENTS_APP_TYPES,
   PLATFORM_API_RESPONSE_USER_IDENTITY,
@@ -90,6 +100,7 @@ const platformApiTypes = {
 export {
   platformApiTypes as default,
   platformApiTypes,
+  PLATFORM_API_RESPONSE_NAV_TYPES,
   PLATFORM_API_RESPONSE_USER_ENTITLEMENTS,
   PLATFORM_API_RESPONSE_USER_ENTITLEMENTS_APP_TYPES,
   PLATFORM_API_RESPONSE_USER_IDENTITY,

--- a/tests/__snapshots__/code.test.js.snap
+++ b/tests/__snapshots__/code.test.js.snap
@@ -6,6 +6,6 @@ Array [
   "components/inventorySubscriptions/inventorySubscriptions.js:60:        console.warn(\`Sorting can only be performed on select fields, confirm field \${id} is allowed.\`);",
   "redux/common/reduxHelpers.js:250:    console.error(\`Error: Property \${prop} does not exist within the passed state.\`, state);",
   "redux/common/reduxHelpers.js:254:    console.warn(\`Warning: Property \${prop} does not exist within the passed initialState.\`, initialState);",
-  "setupTests.js:132:  console.error = (message, ...args) => {",
+  "setupTests.js:144:  console.error = (message, ...args) => {",
 ]
 `;

--- a/tests/__snapshots__/code.test.js.snap
+++ b/tests/__snapshots__/code.test.js.snap
@@ -6,6 +6,6 @@ Array [
   "components/inventorySubscriptions/inventorySubscriptions.js:60:        console.warn(\`Sorting can only be performed on select fields, confirm field \${id} is allowed.\`);",
   "redux/common/reduxHelpers.js:250:    console.error(\`Error: Property \${prop} does not exist within the passed state.\`, state);",
   "redux/common/reduxHelpers.js:254:    console.warn(\`Warning: Property \${prop} does not exist within the passed initialState.\`, initialState);",
-  "setupTests.js:126:  console.error = (message, ...args) => {",
+  "setupTests.js:132:  console.error = (message, ...args) => {",
 ]
 `;


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(productViewMissing): ent-3913 apply platform appNavClick
   * testing, mock appNavClick, hook
   * productViewMissing, useRouter, setAppNav
   * platformActions, expose setAppNav
   * platformServices, expose appNavClick, replace navigation
   * useRouter, pass useHistory, proxy useHistory push, setAppNav
- fix(redirect): ent-3833 restructure, force a path 
   * testing, window.replace noop
   * authentication, remove isRedirect
   * productViewMissing, on available product cards redirect
   * redirect, restructure, force a path, pass search, hash
   * router, var rename, centralize exports, index.js
   * routerHelpers, optional chain

### Notes
- Each of these commits covers a different form of redirect
   - **fix redirect** covers handling a forced redirect with `window.location.href` 
   - **fix productViewMissing** covers using the platforms `appNavClick` chrome method (allows updating the left hand nav without forcing a refresh)
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
 since the platform still appears to have some redirects in place, and this automagically performs the redirect you can test 2 ways to confirm it's actually doing something.

#### First
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm the redirect happens by purposefully using a botched url, i.e. `/beta/subscriptions/` and confirm that the product id `rhel` is used and the end result is `/beta/subscriptions/rhel`

#### Second
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. navigate to a purposefully broken path `/beta/subscriptions/`
1. modify the `./src/components/productViewMissing.js` file default prop `availableProductsRedirect` to zero, hit refresh and the card view of missing products should appear
1. click on a card and the path should update accordingly

* _NOTE: testing the left menu highlighting may produce a false positive if the platform redirects are still in place_

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-3913
ent-3833