### PR TITLE
fix(i18n): allow multi-context

### DIFF
--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -5,6 +5,7 @@ exports[`I18n Component should attempt to perform a component translate: transla
 exports[`I18n Component should attempt to perform a string replace: translate 1`] = `
 Object {
   "localeKey": "t(lorem.ipsum)",
+  "multiContext": "t(lorem.ipsum, {\\"context\\":\\"hello_world\\"})",
   "placeholder": "t(lorem.ipsum, hello world)",
 }
 `;

--- a/src/components/i18n/__tests__/i18n.test.js
+++ b/src/components/i18n/__tests__/i18n.test.js
@@ -107,10 +107,12 @@ describe('I18n Component', () => {
   it('should attempt to perform a string replace', () => {
     const localeKey = translate('lorem.ipsum');
     const placeholder = translate('lorem.ipsum', 'hello world');
+    const multiContext = translate('lorem.ipsum', { context: ['hello', 'world'] });
 
     expect({
       localeKey,
-      placeholder
+      placeholder,
+      multiContext
     }).toMatchSnapshot('translate');
   });
 

--- a/src/components/i18n/i18n.js
+++ b/src/components/i18n/i18n.js
@@ -16,19 +16,25 @@ import { helpers } from '../../common/helpers';
  * @returns {string|Node}
  */
 const translate = (translateKey, values = null, components) => {
+  const updatedValues = values;
+
+  if (Array.isArray(updatedValues?.context)) {
+    updatedValues.context = updatedValues.context.join('_');
+  }
+
   if (helpers.TEST_MODE) {
-    return helpers.noopTranslate(translateKey, values, components);
+    return helpers.noopTranslate(translateKey, updatedValues, components);
   }
 
   if (components) {
     return (
-      (i18next.store && <Trans i18nKey={translateKey} values={values} components={components} />) || (
+      (i18next.store && <Trans i18nKey={translateKey} values={updatedValues} components={components} />) || (
         <React.Fragment>t({translateKey})</React.Fragment>
       )
     );
   }
 
-  return (i18next.store && i18next.t(translateKey, values)) || `t(${translateKey})`;
+  return (i18next.store && i18next.t(translateKey, updatedValues)) || `t(${translateKey})`;
 };
 
 /**


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(i18n): allow multi-context

### Notes
- minor allowance for an array/list of contexts
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests pass

<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing