### PR TITLE
fix(chart,chartHelpers): ent-4064 correct dual axes normalize

### DIFF
--- a/src/components/chart/chart.js
+++ b/src/components/chart/chart.js
@@ -76,9 +76,8 @@ const Chart = ({
       const isMultiYAxis = yAxisProps.length > 1;
       const chartElementsProps = chartHelpers.generateElementsProps({
         dataSets: toggledDataSets,
-        isMultiYAxis,
         maxX,
-        maxY,
+        maxY: (isMultiYAxis && individualMaxY) || maxY,
         xValueFormat,
         yValueFormat
       });

--- a/src/components/chart/chartHelpers.js
+++ b/src/components/chart/chartHelpers.js
@@ -76,14 +76,13 @@ const generateDomains = ({ maxY } = {}) => {
  *
  * @param {object} params
  * @param {Array} params.dataSets
- * @param {boolean} params.isMultiYAxis
  * @param {number} params.maxX
  * @param {number} params.maxY
  * @param {Function} params.xValueFormat
  * @param {Function} params.yValueFormat
  * @returns {{elementsById: object, stackedElements: Array, stackedElementsById: object, elements: Array}}
  */
-const generateElementsProps = ({ dataSets = [], isMultiYAxis, maxX, maxY, xValueFormat, yValueFormat }) => {
+const generateElementsProps = ({ dataSets = [], maxX, maxY, xValueFormat, yValueFormat }) => {
   const elements = [];
   const stackedElements = [];
   const elementsById = {};
@@ -148,10 +147,10 @@ const generateElementsProps = ({ dataSets = [], isMultiYAxis, maxX, maxY, xValue
             (datum =>
               yValueFormat({
                 datum,
-                isMultiAxis: isMultiYAxis,
-                maxY: (typeof maxY === 'number' && maxY) || maxY?.[dataSet.id]
+                isMultiAxis: typeof maxY !== 'number',
+                maxY: typeof maxY === 'number' ? maxY : maxY?.[dataSet.id]
               }))) ||
-          (datum => (isMultiYAxis && datum.y / maxY) || datum.y)
+          (datum => (typeof maxY === 'number' ? datum.y : datum.y / maxY?.[dataSet.id]))
       };
 
       const props = { ...chartElementProps };


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(chart,chartHelpers): ent-4064 correct dual axes normalize

### Notes
- fixes the normalization that was supposed to happen, apparently we missed passing the multiple axes entirely
- corrects a future'ish problem where "truthy" values could fire an unintended condition
- the account used highlights a curious behavior in how normalized data can display... directly overlapped if the normalize percentages line up, @bclarhk @rblackbu @mirekdlugosz 
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm the axes now align to their respective Y axis 

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screen Shot 2021-07-08 at 3 21 50 PM (2)](https://user-images.githubusercontent.com/3761375/124979079-9dfa9900-e000-11eb-9b98-e1e9a23e4dec.png)


https://user-images.githubusercontent.com/3761375/124979089-a226b680-e000-11eb-8bb8-f1ab62738e1d.mp4



## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-4064