### PR TITLE
fix(locales): ent-4045 threshold graph legend strings

### DIFF
--- a/public/locales/en-US.json
+++ b/public/locales/en-US.json
@@ -55,11 +55,11 @@
     "physicalSocketsLabel": "Physical {{product}}",
     "physicalSocketsLegendTooltip": "{{product}} CPU socket usage, per socket pair.",
     "physicalSocketsLegendTooltip_RHEL": "Physical {{product}} CPU usage, per socket pair. Each system's socket count is rounded upwards to the next even number.",
-    "thresholdLabel": "Subscription threshold",
-    "thresholdLegendTooltip": "Maximum capacity, based on total {{product}} subscriptions in this account.",
-    "thresholdLegendTooltip_RHEL": "Maximum capacity, as CPU sockets, based on total {{product}} subscriptions in this account.",
-    "thresholdCoresLegendTooltip_OpenShift Container Platform": "Maximum capacity, as CPU cores, based on total {{product}} subscriptions in this account.",
-    "thresholdSocketsLegendTooltip_OpenShift Container Platform": "Maximum capacity, as CPU sockets, based on total {{product}} subscriptions in this account.",
+    "label_threshold": "Subscription threshold",
+    "legendTooltip_threshold": "Maximum capacity, based on total {{product}} subscriptions in this account.",
+    "legendTooltip_threshold_thresholdSockets_RHEL": "Maximum capacity, as CPU sockets, based on total {{product}} subscriptions in this account.",
+    "legendTooltip_threshold_thresholdCores_OpenShift Container Platform": "Maximum capacity, as CPU cores, based on total {{product}} subscriptions in this account.",
+    "legendTooltip_threshold_thresholdSockets_OpenShift Container Platform": "Maximum capacity, as CPU sockets, based on total {{product}} subscriptions in this account.",
     "tooltipSummary": "Your subscription data facets. With one level of column and row headers."
   },
   "curiosity-inventory": {

--- a/src/components/graphCard/__tests__/__snapshots__/graphCardChartLegend.test.js.snap
+++ b/src/components/graphCard/__tests__/__snapshots__/graphCardChartLegend.test.js.snap
@@ -282,7 +282,7 @@ exports[`GraphCardChartLegend Component should render basic data: data 1`] = `
   <Tooltip
     content={
       <p>
-        t(curiosity-graph.dolorSitLegendTooltip,curiosity-graph.thresholdLegendTooltip, {"product":"test","context":"test"})
+        t(curiosity-graph.legendTooltip_threshold, {"product":"test","context":"dolorSit_test id"})
       </p>
     }
     distance={5}
@@ -313,13 +313,13 @@ exports[`GraphCardChartLegend Component should render basic data: data 1`] = `
       tabIndex={0}
       variant="link"
     >
-      t(curiosity-graph.dolorSitLabel,curiosity-graph.thresholdLabel, {"product":"test","context":"test"})
+      t(curiosity-graph.label_threshold, {"product":"test","context":"dolorSit_test id"})
     </Button>
   </Tooltip>
   <Tooltip
     content={
       <p>
-        t(curiosity-graph.nonCursusLegendTooltip,curiosity-graph.thresholdLegendTooltip, {"product":"test","context":"test"})
+        t(curiosity-graph.legendTooltip_threshold, {"product":"test","context":"nonCursus_test id"})
       </p>
     }
     distance={5}
@@ -350,7 +350,7 @@ exports[`GraphCardChartLegend Component should render basic data: data 1`] = `
       tabIndex={0}
       variant="link"
     >
-      t(curiosity-graph.nonCursusLabel,curiosity-graph.thresholdLabel, {"product":"test","context":"test"})
+      t(curiosity-graph.label_threshold, {"product":"test","context":"nonCursus_test id"})
     </Button>
   </Tooltip>
 </Fragment>

--- a/src/components/graphCard/__tests__/graphCardChartLegend.test.js
+++ b/src/components/graphCard/__tests__/graphCardChartLegend.test.js
@@ -51,6 +51,7 @@ describe('GraphCardChartLegend Component', () => {
           }
         ]
       },
+      productId: 'test id',
       productLabel: 'test'
     };
 
@@ -79,6 +80,7 @@ describe('GraphCardChartLegend Component', () => {
       legend: {
         'test-dolorSit': true
       },
+      productId: 'test id',
       productLabel: 'test',
       viewId: 'test'
     };
@@ -119,6 +121,7 @@ describe('GraphCardChartLegend Component', () => {
           }
         ]
       },
+      productId: 'test id',
       productLabel: 'test'
     };
 

--- a/src/components/graphCard/graphCard.js
+++ b/src/components/graphCard/graphCard.js
@@ -59,7 +59,7 @@ class GraphCard extends React.Component {
    * @returns {Node}
    */
   renderChart() {
-    const { filterGraphData, graphData, productLabel, query, viewId } = this.props;
+    const { filterGraphData, graphData, productId, productLabel, query, viewId } = this.props;
     const graphGranularity = this.getQueryGranularity();
 
     const chartAreaProps = {
@@ -106,7 +106,13 @@ class GraphCard extends React.Component {
         {...chartAreaProps}
         dataSets={filteredGraphData(graphData)}
         chartLegend={({ chart, datum }) => (
-          <GraphCardChartLegend chart={chart} datum={datum} productLabel={productLabel} viewId={viewId} />
+          <GraphCardChartLegend
+            chart={chart}
+            datum={datum}
+            productId={productId}
+            productLabel={productLabel}
+            viewId={viewId}
+          />
         )}
         chartTooltip={({ datum }) => (
           <GraphCardChartTooltip datum={datum} granularity={graphGranularity} productLabel={productLabel} />

--- a/src/components/graphCard/graphCardChartLegend.js
+++ b/src/components/graphCard/graphCardChartLegend.js
@@ -105,7 +105,7 @@ class GraphCardChartLegend extends React.Component {
    * @returns {Node}
    */
   render() {
-    const { datum, productLabel, t } = this.props;
+    const { datum, productId, productLabel, t } = this.props;
 
     return (
       <React.Fragment>
@@ -115,9 +115,9 @@ class GraphCardChartLegend extends React.Component {
 
           const labelContent =
             (isThreshold &&
-              t([`curiosity-graph.${id}Label`, `curiosity-graph.thresholdLabel`], {
+              t('curiosity-graph.label_threshold', {
                 product: productLabel,
-                context: productLabel
+                context: [id, productId]
               })) ||
             t([`curiosity-graph.${id}Label`, `curiosity-graph.noLabel`], {
               product: productLabel,
@@ -126,9 +126,9 @@ class GraphCardChartLegend extends React.Component {
 
           const tooltipContent =
             (isThreshold &&
-              t([`curiosity-graph.${id}LegendTooltip`, `curiosity-graph.thresholdLegendTooltip`], {
+              t('curiosity-graph.legendTooltip_threshold', {
                 product: productLabel,
-                context: productLabel
+                context: [id, productId]
               })) ||
             t(`curiosity-graph.${id}LegendTooltip`, { product: productLabel, context: productLabel });
 
@@ -149,7 +149,8 @@ class GraphCardChartLegend extends React.Component {
 /**
  * Prop types.
  *
- * @type {{datum, productLabel: string, t: Function, legend: object, chart: object}}
+ * @type {{datum: object, productLabel: string, viewId: string, productId: string, t: Function, legend: object,
+ *     chart: object}}
  */
 GraphCardChartLegend.propTypes = {
   chart: PropTypes.shape({
@@ -167,6 +168,7 @@ GraphCardChartLegend.propTypes = {
     )
   }),
   legend: PropTypes.objectOf(PropTypes.bool),
+  productId: PropTypes.string,
   productLabel: PropTypes.string,
   t: PropTypes.func,
   viewId: PropTypes.string
@@ -175,8 +177,8 @@ GraphCardChartLegend.propTypes = {
 /**
  * Default props.
  *
- * @type {{datum: {dataSets: Array}, productLabel: string, viewId: string, t: translate, legend: object,
- *     chart: {hide: Function, toggle: Function, isToggled: Function}}}
+ * @type {{datum: object, productLabel: string, viewId: string, productId: string, t: translate, legend: object,
+ *     chart: object}}
  */
 GraphCardChartLegend.defaultProps = {
   chart: {
@@ -188,6 +190,7 @@ GraphCardChartLegend.defaultProps = {
     dataSets: []
   },
   legend: {},
+  productId: '',
   productLabel: '',
   t: translate,
   viewId: 'graphCardLegend'

--- a/src/components/graphCard/graphCardChartTooltip.js
+++ b/src/components/graphCard/graphCardChartTooltip.js
@@ -46,7 +46,7 @@ const GraphCardChartTooltip = ({ datum, granularity, productLabel, t }) => {
           }
         }
 
-        tempDataFacet.label = t(`curiosity-graph.thresholdLabel`);
+        tempDataFacet.label = t('curiosity-graph.label', { context: 'threshold' });
         tempDataFacet.value = thresholdStringValue;
       } else {
         const dataFactsValue =

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -57,16 +57,16 @@ Array [
     "file": "./src/components/graphCard/graphCardChartLegend.js",
     "keys": Array [
       Object {
-        "key": "",
-        "match": "t([\`curiosity-graph.\${id}Label\`, \`curiosity-graph.thresholdLabel\`], { product: productLabel, context: productLabel })",
+        "key": "curiosity-graph.label_threshold",
+        "match": "t('curiosity-graph.label_threshold', { product: productLabel, context: [id, productId] })",
       },
       Object {
         "key": "",
         "match": "t([\`curiosity-graph.\${id}Label\`, \`curiosity-graph.noLabel\`], { product: productLabel, context: productLabel })",
       },
       Object {
-        "key": "",
-        "match": "t([\`curiosity-graph.\${id}LegendTooltip\`, \`curiosity-graph.thresholdLegendTooltip\`], { product: productLabel, context: productLabel })",
+        "key": "curiosity-graph.legendTooltip_threshold",
+        "match": "t('curiosity-graph.legendTooltip_threshold', { product: productLabel, context: [id, productId] })",
       },
       Object {
         "key": "",
@@ -90,8 +90,8 @@ Array [
         "match": "t('curiosity-graph.infiniteThresholdLabel')",
       },
       Object {
-        "key": "curiosity-graph.thresholdLabel",
-        "match": "t(\`curiosity-graph.thresholdLabel\`)",
+        "key": "curiosity-graph.label",
+        "match": "t('curiosity-graph.label', { context: 'threshold' })",
       },
       Object {
         "key": "curiosity-graph.noDataLabel",
@@ -585,6 +585,10 @@ Array [
 
 exports[`I18n Component should have locale keys that exist in the default language JSON: missing locale keys 1`] = `
 Array [
+  Object {
+    "file": "./src/components/graphCard/graphCardChartTooltip.js",
+    "key": "curiosity-graph.label",
+  },
   Object {
     "file": "./src/components/inventoryList/inventoryList.js",
     "key": "curiosity-inventory.tab",


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(locales): ent-4045 threshold graph legend strings
   * locale, threshold strings
   * graphCard, pass productId
   * graphCardChartLegend, productId context, string refs
   * graphCardChartTooltip, string refs

<!-- ### Notes -->
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm each product's graph legend tooltip for thresholds is displaying the corresponding string.
   - Only 2 products should display specific strings for thresholds tooltips, RHEL and OpenShift Container. All other products should display a generic threshold tooltip string

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
#### OpenShift Container
![Screen Shot 2021-07-09 at 5 00 53 PM (2)](https://user-images.githubusercontent.com/3761375/125135787-9528c680-e0d7-11eb-8c50-4d92a64371b1.png)

![Screen Shot 2021-07-09 at 5 01 01 PM (2)](https://user-images.githubusercontent.com/3761375/125135794-9823b700-e0d7-11eb-9219-0f96abc65808.png)


#### RHEL
    
![Screen Shot 2021-07-09 at 4 59 54 PM (2)](https://user-images.githubusercontent.com/3761375/125135761-8b06c800-e0d7-11eb-8ed2-e6343f606250.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-4045