### PR TITLE
fix(locale): ent-4045 threshold graph legend strings

### DIFF
--- a/src/components/graphCard/__tests__/__snapshots__/graphCardChartLegend.test.js.snap
+++ b/src/components/graphCard/__tests__/__snapshots__/graphCardChartLegend.test.js.snap
@@ -282,7 +282,7 @@ exports[`GraphCardChartLegend Component should render basic data: data 1`] = `
   <Tooltip
     content={
       <p>
-        t(curiosity-graph.legendTooltip_threshold, {"product":"test","context":"dolorSit_test id"})
+        t(curiosity-graph.legendTooltip_threshold, {"product":"test","context":"dolorSit_test"})
       </p>
     }
     distance={5}
@@ -313,13 +313,13 @@ exports[`GraphCardChartLegend Component should render basic data: data 1`] = `
       tabIndex={0}
       variant="link"
     >
-      t(curiosity-graph.label_threshold, {"product":"test","context":"dolorSit_test id"})
+      t(curiosity-graph.label_threshold, {"product":"test","context":"dolorSit_test"})
     </Button>
   </Tooltip>
   <Tooltip
     content={
       <p>
-        t(curiosity-graph.legendTooltip_threshold, {"product":"test","context":"nonCursus_test id"})
+        t(curiosity-graph.legendTooltip_threshold, {"product":"test","context":"nonCursus_test"})
       </p>
     }
     distance={5}
@@ -350,7 +350,7 @@ exports[`GraphCardChartLegend Component should render basic data: data 1`] = `
       tabIndex={0}
       variant="link"
     >
-      t(curiosity-graph.label_threshold, {"product":"test","context":"nonCursus_test id"})
+      t(curiosity-graph.label_threshold, {"product":"test","context":"nonCursus_test"})
     </Button>
   </Tooltip>
 </Fragment>

--- a/src/components/graphCard/graphCard.js
+++ b/src/components/graphCard/graphCard.js
@@ -59,7 +59,7 @@ class GraphCard extends React.Component {
    * @returns {Node}
    */
   renderChart() {
-    const { filterGraphData, graphData, productId, productLabel, query, viewId } = this.props;
+    const { filterGraphData, graphData, productLabel, query, viewId } = this.props;
     const graphGranularity = this.getQueryGranularity();
 
     const chartAreaProps = {
@@ -106,13 +106,7 @@ class GraphCard extends React.Component {
         {...chartAreaProps}
         dataSets={filteredGraphData(graphData)}
         chartLegend={({ chart, datum }) => (
-          <GraphCardChartLegend
-            chart={chart}
-            datum={datum}
-            productId={productId}
-            productLabel={productLabel}
-            viewId={viewId}
-          />
+          <GraphCardChartLegend chart={chart} datum={datum} productLabel={productLabel} viewId={viewId} />
         )}
         chartTooltip={({ datum }) => (
           <GraphCardChartTooltip datum={datum} granularity={graphGranularity} productLabel={productLabel} />

--- a/src/components/graphCard/graphCardChartLegend.js
+++ b/src/components/graphCard/graphCardChartLegend.js
@@ -105,7 +105,7 @@ class GraphCardChartLegend extends React.Component {
    * @returns {Node}
    */
   render() {
-    const { datum, productId, productLabel, t } = this.props;
+    const { datum, productLabel, t } = this.props;
 
     return (
       <React.Fragment>
@@ -117,7 +117,7 @@ class GraphCardChartLegend extends React.Component {
             (isThreshold &&
               t('curiosity-graph.label_threshold', {
                 product: productLabel,
-                context: [id, productId]
+                context: [id, productLabel]
               })) ||
             t([`curiosity-graph.${id}Label`, `curiosity-graph.noLabel`], {
               product: productLabel,
@@ -128,7 +128,7 @@ class GraphCardChartLegend extends React.Component {
             (isThreshold &&
               t('curiosity-graph.legendTooltip_threshold', {
                 product: productLabel,
-                context: [id, productId]
+                context: [id, productLabel]
               })) ||
             t(`curiosity-graph.${id}LegendTooltip`, { product: productLabel, context: productLabel });
 
@@ -149,7 +149,7 @@ class GraphCardChartLegend extends React.Component {
 /**
  * Prop types.
  *
- * @type {{datum: object, productLabel: string, viewId: string, productId: string, t: Function, legend: object,
+ * @type {{datum: object, productLabel: string, viewId: string, t: Function, legend: object,
  *     chart: object}}
  */
 GraphCardChartLegend.propTypes = {
@@ -168,7 +168,6 @@ GraphCardChartLegend.propTypes = {
     )
   }),
   legend: PropTypes.objectOf(PropTypes.bool),
-  productId: PropTypes.string,
   productLabel: PropTypes.string,
   t: PropTypes.func,
   viewId: PropTypes.string
@@ -177,7 +176,7 @@ GraphCardChartLegend.propTypes = {
 /**
  * Default props.
  *
- * @type {{datum: object, productLabel: string, viewId: string, productId: string, t: translate, legend: object,
+ * @type {{datum: object, productLabel: string, viewId: string, t: translate, legend: object,
  *     chart: object}}
  */
 GraphCardChartLegend.defaultProps = {
@@ -190,7 +189,6 @@ GraphCardChartLegend.defaultProps = {
     dataSets: []
   },
   legend: {},
-  productId: '',
   productLabel: '',
   t: translate,
   viewId: 'graphCardLegend'

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -58,7 +58,7 @@ Array [
     "keys": Array [
       Object {
         "key": "curiosity-graph.label_threshold",
-        "match": "t('curiosity-graph.label_threshold', { product: productLabel, context: [id, productId] })",
+        "match": "t('curiosity-graph.label_threshold', { product: productLabel, context: [id, productLabel] })",
       },
       Object {
         "key": "",
@@ -66,7 +66,7 @@ Array [
       },
       Object {
         "key": "curiosity-graph.legendTooltip_threshold",
-        "match": "t('curiosity-graph.legendTooltip_threshold', { product: productLabel, context: [id, productId] })",
+        "match": "t('curiosity-graph.legendTooltip_threshold', { product: productLabel, context: [id, productLabel] })",
       },
       Object {
         "key": "",

--- a/src/components/productView/__tests__/__snapshots__/productViewOpenShiftContainer.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productViewOpenShiftContainer.test.js.snap
@@ -85,7 +85,7 @@ exports[`ProductViewOpenShiftContainer Component should render a non-connected c
         }
         key="graph_OpenShift Container Platform"
         productId="OpenShift Container Platform"
-        productLabel="OpenShift"
+        productLabel="OpenShift Container Platform"
         query={
           Object {
             "beginning": "2019-06-20T00:00:00.000Z",
@@ -306,7 +306,7 @@ exports[`ProductViewOpenShiftContainer Component should render a non-connected c
         }
         key="graph_OpenShift-metrics"
         productId="OpenShift-metrics"
-        productLabel="OpenShift Metric"
+        productLabel="OpenShift-metrics"
         query={
           Object {
             "beginning": "2019-07-01T00:00:00.000Z",

--- a/src/components/productView/productViewOpenShiftContainer.js
+++ b/src/components/productView/productViewOpenShiftContainer.js
@@ -413,7 +413,7 @@ ProductViewOpenShiftContainer.defaultProps = {
           id: RHSM_API_QUERY_TYPES.SLA
         }
       ],
-      productLabel: 'OpenShift',
+      productLabel: RHSM_API_PATH_ID_TYPES.OPENSHIFT,
       productId: RHSM_API_PATH_ID_TYPES.OPENSHIFT,
       viewId: 'viewOpenShift'
     },
@@ -501,7 +501,7 @@ ProductViewOpenShiftContainer.defaultProps = {
         }
       ],
       initialToolbarFilters: undefined,
-      productLabel: 'OpenShift Metric',
+      productLabel: RHSM_API_PATH_ID_TYPES.OPENSHIFT_METRICS,
       productId: RHSM_API_PATH_ID_TYPES.OPENSHIFT_METRICS,
       viewId: 'viewOpenShiftMetric'
     }


### PR DESCRIPTION

## What's included
<!-- Summary of changes/additions -->
- fix(locale): ent-4045 threshold graph legend strings
   * graphCard, revert pass productId
   * graphCardChartLegend, revert use productId context
   * productViewOpenShiftContainer, productLabel to product like group

### Notes
- Once this fix is confirmed by QE we'll squash it with the prior related commit @mirekdlugosz 
- Corrects the RHEL, and related architecture, tooltips falling back to the default threshold tooltip copy. This fix should still maintain OpenShift Container tooltip fixes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm the RHEL, and related architecture, tooltips reflect the correct copy
1. confirm the OpenShift Container tooltips reflect the correct copy

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screen Shot 2021-07-12 at 6 49 21 PM (2)](https://user-images.githubusercontent.com/3761375/125365399-2dc27f00-e342-11eb-870c-4b6e5c1be925.png)

![Screen Shot 2021-07-12 at 6 49 01 PM (2)](https://user-images.githubusercontent.com/3761375/125365407-30bd6f80-e342-11eb-9977-f55240a51b88.png)

![Screen Shot 2021-07-12 at 6 48 53 PM (2)](https://user-images.githubusercontent.com/3761375/125365413-3450f680-e342-11eb-9092-7bf6cd64e2e8.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-4045