### PR TITLE
fix(productView): ent-4104 column views inventory reset

### DIFF
--- a/src/components/productView/__tests__/__snapshots__/productViewOpenShiftContainer.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productViewOpenShiftContainer.test.js.snap
@@ -33,7 +33,7 @@ exports[`ProductViewOpenShiftContainer Component should render a non-connected c
             "uom": "cores",
           }
         }
-        viewId="viewOpenShift"
+        viewId="viewOpenShift Container Platform"
       />
     </PageToolbar>
     <PageSection
@@ -94,7 +94,7 @@ exports[`ProductViewOpenShiftContainer Component should render a non-connected c
           }
         }
         settings={Object {}}
-        viewId="viewOpenShift"
+        viewId="viewOpenShift Container Platform"
       >
         <ToolbarFieldUom
           options={
@@ -113,7 +113,7 @@ exports[`ProductViewOpenShiftContainer Component should render a non-connected c
           }
           t={[Function]}
           value="cores"
-          viewId="viewOpenShift"
+          viewId="viewOpenShift Container Platform"
         />
         <ToolbarFieldGranularity
           options={
@@ -142,7 +142,7 @@ exports[`ProductViewOpenShiftContainer Component should render a non-connected c
           }
           t={[Function]}
           value="daily"
-          viewId="viewOpenShift"
+          viewId="viewOpenShift Container Platform"
         />
       </Connect(GraphCard)>
     </PageSection>
@@ -215,7 +215,7 @@ exports[`ProductViewOpenShiftContainer Component should render a non-connected c
               }
             }
             settings={Object {}}
-            viewId="viewOpenShift"
+            viewId="viewOpenShift Container Platform"
           />
         </InventoryTab>
         <InventoryTab
@@ -258,7 +258,7 @@ exports[`ProductViewOpenShiftContainer Component should render a non-connected c
                 "uom": "cores",
               }
             }
-            viewId="viewOpenShift"
+            viewId="viewOpenShift Container Platform"
           />
         </InventoryTab>
       </Connect(InventoryTabs)>
@@ -319,7 +319,7 @@ exports[`ProductViewOpenShiftContainer Component should render a non-connected c
             "actionDisplay": [Function],
           }
         }
-        viewId="viewOpenShiftMetric"
+        viewId="viewOpenShift-metrics"
       >
         <ToolbarFieldRangedMonthly
           options={
@@ -436,7 +436,7 @@ exports[`ProductViewOpenShiftContainer Component should render a non-connected c
           }
           t={[Function]}
           value="t(curiosity-toolbar.granularityRange, {\\"context\\":\\"current\\"})"
-          viewId="viewOpenShiftMetric"
+          viewId="viewOpenShift-metrics"
         />
       </Connect(GraphCard)>
     </PageSection>
@@ -490,7 +490,7 @@ exports[`ProductViewOpenShiftContainer Component should render a non-connected c
               }
             }
             settings={Object {}}
-            viewId="viewOpenShiftMetric"
+            viewId="viewOpenShift-metrics"
           />
         </InventoryTab>
       </Connect(InventoryTabs)>

--- a/src/components/productView/productViewOpenShiftContainer.js
+++ b/src/components/productView/productViewOpenShiftContainer.js
@@ -415,7 +415,7 @@ ProductViewOpenShiftContainer.defaultProps = {
       ],
       productLabel: RHSM_API_PATH_ID_TYPES.OPENSHIFT,
       productId: RHSM_API_PATH_ID_TYPES.OPENSHIFT,
-      viewId: 'viewOpenShift'
+      viewId: `view${RHSM_API_PATH_ID_TYPES.OPENSHIFT}`
     },
     {
       query: {
@@ -503,7 +503,7 @@ ProductViewOpenShiftContainer.defaultProps = {
       initialToolbarFilters: undefined,
       productLabel: RHSM_API_PATH_ID_TYPES.OPENSHIFT_METRICS,
       productId: RHSM_API_PATH_ID_TYPES.OPENSHIFT_METRICS,
-      viewId: 'viewOpenShiftMetric'
+      viewId: `view${RHSM_API_PATH_ID_TYPES.OPENSHIFT_METRICS}`
     }
   ],
   t: translate


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(productView): ent-4104 column views inventory reset

### Notes
- it appears both products' inventory is affected, OpenShift Container and Metrics
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. on the OpenShift Container Platform dual column view a minimum of 11 or 21 or 51 or 101  entries is required to test this bug. Both product columns should be tested!
   - adjust the paging to the desired per page limit
   - move the inventory display to the last page
   - adjust the granularity "like" dropdown, the inventory page and display should reset to the first page

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screen Shot 2021-07-14 at 1 42 02 PM (2)](https://user-images.githubusercontent.com/3761375/125667943-5cf3d0e2-908a-4dd2-a15a-bc19d45a4a19.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-4104