### PR TITLE
fix(productView): ent-4108 column styling for inventory list overflow

### DIFF
--- a/src/components/graphCard/__tests__/__snapshots__/graphCardChartLegend.test.js.snap
+++ b/src/components/graphCard/__tests__/__snapshots__/graphCardChartLegend.test.js.snap
@@ -114,7 +114,7 @@ exports[`GraphCardChartLegend Component should handle variations in data when re
     </p>
   }
   distance={5}
-  enableFlip={false}
+  enableFlip={true}
   position="top"
 >
   <Button
@@ -175,7 +175,7 @@ exports[`GraphCardChartLegend Component should render a basic component: basic 1
       </p>
     }
     distance={5}
-    enableFlip={false}
+    enableFlip={true}
     key="curiosity-tooltip-loremIpsum"
     position="top"
   >
@@ -217,7 +217,7 @@ exports[`GraphCardChartLegend Component should render basic data: data 1`] = `
       </p>
     }
     distance={5}
-    enableFlip={false}
+    enableFlip={true}
     key="curiosity-tooltip-loremIpsum"
     position="top"
   >
@@ -254,7 +254,7 @@ exports[`GraphCardChartLegend Component should render basic data: data 1`] = `
       </p>
     }
     distance={5}
-    enableFlip={false}
+    enableFlip={true}
     key="curiosity-tooltip-ametConsectetur"
     position="top"
   >
@@ -286,7 +286,7 @@ exports[`GraphCardChartLegend Component should render basic data: data 1`] = `
       </p>
     }
     distance={5}
-    enableFlip={false}
+    enableFlip={true}
     key="curiosity-tooltip-dolorSit"
     position="top"
   >
@@ -323,7 +323,7 @@ exports[`GraphCardChartLegend Component should render basic data: data 1`] = `
       </p>
     }
     distance={5}
-    enableFlip={false}
+    enableFlip={true}
     key="curiosity-tooltip-nonCursus"
     position="top"
   >

--- a/src/components/graphCard/graphCardChartLegend.js
+++ b/src/components/graphCard/graphCardChartLegend.js
@@ -88,7 +88,7 @@ class GraphCardChartLegend extends React.Component {
           key={`curiosity-tooltip-${chartId}`}
           content={<p>{tooltipContent}</p>}
           position={TooltipPosition.top}
-          enableFlip={false}
+          enableFlip
           distance={5}
         >
           {button}

--- a/src/styles/_inventory-list.scss
+++ b/src/styles/_inventory-list.scss
@@ -65,6 +65,10 @@
       padding-bottom: 1px;
       font-size: 0.9em;
     }
+
+    .pf-c-button.pf-m-link.pf-m-inline {
+      word-break: break-word;
+    }
   }
 
   .curiosity-guests-list {


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(productView): ent-4108 column styling for inventory list overflow
- fix(graphCardChartLegend): ent-4109 tooltip for small screens

<!-- ### Notes -->
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. scale the browser width to around 1020px or less to confirm the inventory table no longer breaks out of the column for OpenShift Container

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
#### What should **NOT** happen
![Screen Shot 2021-07-14 at 3 08 36 PM](https://user-images.githubusercontent.com/3761375/125685146-01061d95-2db2-4a5d-bfb9-3cf4c19af60b.png)


https://user-images.githubusercontent.com/3761375/125691433-79fd7215-45f1-4555-bdde-cbcc1f8ec582.mp4



## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-4108
ent-4109