### PR TITLE
fix(graphCard): ent-3813 overflow styling for header total display

### DIFF
--- a/src/components/guestsList/__tests__/__snapshots__/guestsList.test.js.snap
+++ b/src/components/guestsList/__tests__/__snapshots__/guestsList.test.js.snap
@@ -59,6 +59,7 @@ exports[`GuestsList Component should handle multiple display states: initial pen
     tableProps={
       Object {
         "borders": false,
+        "className": "curiosity-guests-list",
         "colCount": 1,
         "colWidth": Array [],
         "rowCount": 1,

--- a/src/components/guestsList/guestsList.js
+++ b/src/components/guestsList/guestsList.js
@@ -176,6 +176,7 @@ class GuestsList extends React.Component {
             variant="table"
             tableProps={{
               borders: false,
+              className: 'curiosity-guests-list',
               colCount: filterGuestsData?.length || (listData?.[0] && Object.keys(listData[0]).length) || 1,
               colWidth: (filterGuestsData?.length && filterGuestsData.map(({ cellWidth }) => cellWidth)) || [],
               rowCount: numberOfGuests < perPageDefault ? numberOfGuests : perPageDefault,

--- a/src/styles/_inventory-list.scss
+++ b/src/styles/_inventory-list.scss
@@ -56,8 +56,12 @@
       border-top-width: 0;
     }
 
-    &.pf-c-table.pf-m-compact tr:not(.pf-c-table__expandable-row) > :first-child {
-      padding-left: var(--pf-c-table--m-compact--cell--first-last-child--PaddingLeft);
+    .pf-c-table__toggle {
+      padding-left: 0;
+
+      .pf-c-button {
+        padding-left: var(--pf-c-table--m-compact--cell--first-last-child--xl--PaddingLeft);
+      }
     }
 
     .pf-c-label {
@@ -72,6 +76,10 @@
   }
 
   .curiosity-guests-list {
+    &.pf-c-table.pf-m-compact tr:not(.pf-c-table__expandable-row) > :first-child {
+      padding-left: 20px;
+    }
+
     &.pf-c-table.pf-m-compact tr > *:last-child {
       padding-right: var(--pf-c-table--m-compact--cell--first-last-child--PaddingRight);
     }

--- a/src/styles/_usage-graph.scss
+++ b/src/styles/_usage-graph.scss
@@ -23,10 +23,7 @@
       padding-right: var(--pf-global--spacer--sm);
       text-align: right;
       white-space: normal;
-
-      @media (min-width: $pf-global--breakpoint--sm) {
-        white-space: nowrap;
-      }
+      word-break: break-word;
     }
 
     &__legend-item {


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(productView): ent-4108 guests toggle styling and inventory
- fix(graphCard): ent-3813 overflow styling for header total display

### Notes
- the example attached is a direct string manipulation. it's important to note that this scenario is atypical. typically the number abbreviation tooling we use should attempt to trim that string down to something more readable such `333 T` or `333 B`. 
   - https://numbrojs.com/try-me.html?lang=en-US and the settings we use are `{ average: true, mantissa: 2, trimMantissa: true, lowPrecision: false }`
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm that large numbers/strings displayed in the graph card header for OpenShift Metrics now wraps

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screen Shot 2021-07-15 at 11 03 05 AM](https://user-images.githubusercontent.com/3761375/125814380-aaf2c0de-4846-43f6-a42f-23bc5fcb28a0.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-3813
additional relates ent-4108