### PR TITLE
fix(graphCard): ent-3813 header styling for total display

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -42,9 +42,11 @@
     "mockObjectProperty": "readonly",
     "mountHook": "readonly",
     "mountHookComponent": "readonly",
+    "mountHookWrapper": "readonly",
     "mockWindowLocation": "readonly",
     "shallowHook": "readonly",
-    "shallowHookComponent": "readonly"
+    "shallowHookComponent": "readonly",
+    "shallowHookWrapper": "readonly"
   },
   "rules": {
     "arrow-parens": [

--- a/src/components/form/__tests__/__snapshots__/select.test.js.snap
+++ b/src/components/form/__tests__/__snapshots__/select.test.js.snap
@@ -2,506 +2,534 @@
 
 exports[`Select Component should allow alternate array and object options: key value object 1`] = `
 <div
-  class="pf-c-select curiosity-select  "
-  data-ouia-component-id="OUIA-Generated-Select-single-2"
-  data-ouia-component-type="PF4/Select"
-  data-ouia-safe="true"
+  class="curiosity-select"
 >
-  <button
-    aria-expanded="false"
-    aria-haspopup="listbox"
-    aria-labelledby=" pf-select-toggle-id-11"
-    class="pf-c-select__toggle"
-    id="pf-select-toggle-id-11"
-    type="button"
+  <div
+    class="pf-c-select curiosity-select-pf  "
+    data-ouia-component-id="OUIA-Generated-Select-single-2"
+    data-ouia-component-type="PF4/Select"
+    data-ouia-safe="true"
   >
-    <div
-      class="pf-c-select__toggle-wrapper"
+    <button
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      aria-labelledby=" pf-select-toggle-id-11"
+      class="pf-c-select__toggle"
+      id="pf-select-toggle-id-11"
+      type="button"
     >
+      <div
+        class="pf-c-select__toggle-wrapper"
+      >
+        <span
+          class="pf-c-select__toggle-text"
+        >
+          lorem
+        </span>
+      </div>
       <span
-        class="pf-c-select__toggle-text"
+        class="pf-c-select__toggle-arrow"
       >
-        lorem
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 320 512"
+          width="1em"
+        >
+          <path
+            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+          />
+        </svg>
       </span>
-    </div>
-    <span
-      class="pf-c-select__toggle-arrow"
-    >
-      <svg
-        aria-hidden="true"
-        fill="currentColor"
-        height="1em"
-        role="img"
-        style="vertical-align: -0.125em;"
-        viewBox="0 0 320 512"
-        width="1em"
-      >
-        <path
-          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-        />
-      </svg>
-    </span>
-  </button>
+    </button>
+  </div>
 </div>
 `;
 
 exports[`Select Component should allow alternate array and object options: string array 1`] = `
 <div
-  class="pf-c-select curiosity-select  "
-  data-ouia-component-id="OUIA-Generated-Select-single-2"
-  data-ouia-component-type="PF4/Select"
-  data-ouia-safe="true"
+  class="curiosity-select"
 >
-  <button
-    aria-expanded="false"
-    aria-haspopup="listbox"
-    aria-labelledby=" pf-select-toggle-id-8"
-    class="pf-c-select__toggle"
-    id="pf-select-toggle-id-8"
-    type="button"
+  <div
+    class="pf-c-select curiosity-select-pf  "
+    data-ouia-component-id="OUIA-Generated-Select-single-2"
+    data-ouia-component-type="PF4/Select"
+    data-ouia-safe="true"
   >
-    <div
-      class="pf-c-select__toggle-wrapper"
+    <button
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      aria-labelledby=" pf-select-toggle-id-8"
+      class="pf-c-select__toggle"
+      id="pf-select-toggle-id-8"
+      type="button"
     >
+      <div
+        class="pf-c-select__toggle-wrapper"
+      >
+        <span
+          class="pf-c-select__toggle-text"
+        >
+          ipsum
+        </span>
+      </div>
       <span
-        class="pf-c-select__toggle-text"
+        class="pf-c-select__toggle-arrow"
       >
-        ipsum
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 320 512"
+          width="1em"
+        >
+          <path
+            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+          />
+        </svg>
       </span>
-    </div>
-    <span
-      class="pf-c-select__toggle-arrow"
-    >
-      <svg
-        aria-hidden="true"
-        fill="currentColor"
-        height="1em"
-        role="img"
-        style="vertical-align: -0.125em;"
-        viewBox="0 0 320 512"
-        width="1em"
-      >
-        <path
-          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-        />
-      </svg>
-    </span>
-  </button>
+    </button>
+  </div>
 </div>
 `;
 
 exports[`Select Component should allow alternate direction and position options: direction up 1`] = `
-<Select
-  aria-describedby=""
-  aria-invalid={false}
-  aria-label="Select option"
-  aria-labelledby=""
-  chipGroupComponent={null}
-  className="curiosity-select  "
-  clearSelectionsAriaLabel="Clear all"
-  createText="Create"
-  customBadgeText={null}
-  customContent={null}
-  direction="up"
-  favorites={Array []}
-  favoritesLabel="Favorites"
-  hasInlineFilter={false}
-  inlineFilterPlaceholderText={null}
-  inputIdPrefix=""
-  isCreatable={false}
-  isDisabled={false}
-  isGrouped={false}
-  isInputValuePersisted={false}
-  isOpen={false}
-  isPlain={false}
-  maxHeight={null}
-  menuAppendTo="inline"
-  noResultsFoundText="No results found"
-  onClear={[Function]}
-  onCreateOption={[Function]}
-  onFilter={null}
-  onSelect={[Function]}
-  onToggle={[Function]}
-  onTypeaheadInputChanged={null}
-  ouiaSafe={true}
-  placeholderText="Select option"
-  removeSelectionAriaLabel="Remove"
-  selections={Array []}
-  toggleAriaLabel="Options menu"
-  toggleIcon={null}
-  toggleId={null}
-  typeAheadAriaLabel=""
-  validated="default"
-  variant="single"
-  width=""
+<div
+  className="curiosity-select"
 >
-  <SelectOption
-    className=""
-    component="button"
-    data-title="lorem"
-    data-value="lorem"
-    id="bG9yZW0tbG9yZW0="
-    index={0}
-    inputId=""
-    isChecked={false}
+  <Select
+    aria-describedby=""
+    aria-invalid={false}
+    aria-label="Select option"
+    aria-labelledby=""
+    chipGroupComponent={null}
+    className="curiosity-select-pf  "
+    clearSelectionsAriaLabel="Clear all"
+    createText="Create"
+    customBadgeText={null}
+    customContent={null}
+    direction="up"
+    favorites={Array []}
+    favoritesLabel="Favorites"
+    hasInlineFilter={false}
+    inlineFilterPlaceholderText={null}
+    inputIdPrefix=""
+    isCreatable={false}
     isDisabled={false}
-    isFavorite={null}
-    isLoad={false}
-    isLoading={false}
-    isNoResultsOption={false}
-    isPlaceholder={false}
-    isSelected={false}
-    key="bG9yZW0tbG9yZW0="
-    keyHandler={[Function]}
-    onClick={[Function]}
-    sendRef={[Function]}
-    value="lorem"
-  />
-  <SelectOption
-    className=""
-    component="button"
-    data-title="ipsum"
-    data-value="ipsum"
-    id="aXBzdW0taXBzdW0="
-    index={0}
-    inputId=""
-    isChecked={false}
-    isDisabled={false}
-    isFavorite={null}
-    isLoad={false}
-    isLoading={false}
-    isNoResultsOption={false}
-    isPlaceholder={false}
-    isSelected={false}
-    key="aXBzdW0taXBzdW0="
-    keyHandler={[Function]}
-    onClick={[Function]}
-    sendRef={[Function]}
-    value="ipsum"
-  />
-</Select>
+    isGrouped={false}
+    isInputValuePersisted={false}
+    isOpen={false}
+    isPlain={false}
+    maxHeight={null}
+    menuAppendTo="parent"
+    noResultsFoundText="No results found"
+    onClear={[Function]}
+    onCreateOption={[Function]}
+    onFilter={null}
+    onSelect={[Function]}
+    onToggle={[Function]}
+    onTypeaheadInputChanged={null}
+    ouiaSafe={true}
+    placeholderText="Select option"
+    removeSelectionAriaLabel="Remove"
+    selections={Array []}
+    toggleAriaLabel="Options menu"
+    toggleIcon={null}
+    toggleId={null}
+    typeAheadAriaLabel=""
+    validated="default"
+    variant="single"
+    width=""
+  >
+    <SelectOption
+      className=""
+      component="button"
+      data-title="lorem"
+      data-value="lorem"
+      id="bG9yZW0tbG9yZW0="
+      index={0}
+      inputId=""
+      isChecked={false}
+      isDisabled={false}
+      isFavorite={null}
+      isLoad={false}
+      isLoading={false}
+      isNoResultsOption={false}
+      isPlaceholder={false}
+      isSelected={false}
+      key="bG9yZW0tbG9yZW0="
+      keyHandler={[Function]}
+      onClick={[Function]}
+      sendRef={[Function]}
+      value="lorem"
+    />
+    <SelectOption
+      className=""
+      component="button"
+      data-title="ipsum"
+      data-value="ipsum"
+      id="aXBzdW0taXBzdW0="
+      index={0}
+      inputId=""
+      isChecked={false}
+      isDisabled={false}
+      isFavorite={null}
+      isLoad={false}
+      isLoading={false}
+      isNoResultsOption={false}
+      isPlaceholder={false}
+      isSelected={false}
+      key="aXBzdW0taXBzdW0="
+      keyHandler={[Function]}
+      onClick={[Function]}
+      sendRef={[Function]}
+      value="ipsum"
+    />
+  </Select>
+</div>
 `;
 
 exports[`Select Component should allow alternate direction and position options: position right 1`] = `
-<Select
-  aria-describedby=""
-  aria-invalid={false}
-  aria-label="Select option"
-  aria-labelledby=""
-  chipGroupComponent={null}
-  className="curiosity-select curiosity-select__position-right "
-  clearSelectionsAriaLabel="Clear all"
-  createText="Create"
-  customBadgeText={null}
-  customContent={null}
-  direction="down"
-  favorites={Array []}
-  favoritesLabel="Favorites"
-  hasInlineFilter={false}
-  inlineFilterPlaceholderText={null}
-  inputIdPrefix=""
-  isCreatable={false}
-  isDisabled={false}
-  isGrouped={false}
-  isInputValuePersisted={false}
-  isOpen={false}
-  isPlain={false}
-  maxHeight={null}
-  menuAppendTo="inline"
-  noResultsFoundText="No results found"
-  onClear={[Function]}
-  onCreateOption={[Function]}
-  onFilter={null}
-  onSelect={[Function]}
-  onToggle={[Function]}
-  onTypeaheadInputChanged={null}
-  ouiaSafe={true}
-  placeholderText="Select option"
-  removeSelectionAriaLabel="Remove"
-  selections={Array []}
-  toggleAriaLabel="Options menu"
-  toggleIcon={null}
-  toggleId={null}
-  typeAheadAriaLabel=""
-  validated="default"
-  variant="single"
-  width=""
+<div
+  className="curiosity-select"
 >
-  <SelectOption
-    className=""
-    component="button"
-    data-title="lorem"
-    data-value="lorem"
-    id="bG9yZW0tbG9yZW0="
-    index={0}
-    inputId=""
-    isChecked={false}
+  <Select
+    aria-describedby=""
+    aria-invalid={false}
+    aria-label="Select option"
+    aria-labelledby=""
+    chipGroupComponent={null}
+    className="curiosity-select-pf curiosity-select-pf__position-right "
+    clearSelectionsAriaLabel="Clear all"
+    createText="Create"
+    customBadgeText={null}
+    customContent={null}
+    direction="down"
+    favorites={Array []}
+    favoritesLabel="Favorites"
+    hasInlineFilter={false}
+    inlineFilterPlaceholderText={null}
+    inputIdPrefix=""
+    isCreatable={false}
     isDisabled={false}
-    isFavorite={null}
-    isLoad={false}
-    isLoading={false}
-    isNoResultsOption={false}
-    isPlaceholder={false}
-    isSelected={false}
-    key="bG9yZW0tbG9yZW0="
-    keyHandler={[Function]}
-    onClick={[Function]}
-    sendRef={[Function]}
-    value="lorem"
-  />
-  <SelectOption
-    className=""
-    component="button"
-    data-title="ipsum"
-    data-value="ipsum"
-    id="aXBzdW0taXBzdW0="
-    index={0}
-    inputId=""
-    isChecked={false}
-    isDisabled={false}
-    isFavorite={null}
-    isLoad={false}
-    isLoading={false}
-    isNoResultsOption={false}
-    isPlaceholder={false}
-    isSelected={false}
-    key="aXBzdW0taXBzdW0="
-    keyHandler={[Function]}
-    onClick={[Function]}
-    sendRef={[Function]}
-    value="ipsum"
-  />
-</Select>
+    isGrouped={false}
+    isInputValuePersisted={false}
+    isOpen={false}
+    isPlain={false}
+    maxHeight={null}
+    menuAppendTo="parent"
+    noResultsFoundText="No results found"
+    onClear={[Function]}
+    onCreateOption={[Function]}
+    onFilter={null}
+    onSelect={[Function]}
+    onToggle={[Function]}
+    onTypeaheadInputChanged={null}
+    ouiaSafe={true}
+    placeholderText="Select option"
+    removeSelectionAriaLabel="Remove"
+    selections={Array []}
+    toggleAriaLabel="Options menu"
+    toggleIcon={null}
+    toggleId={null}
+    typeAheadAriaLabel=""
+    validated="default"
+    variant="single"
+    width=""
+  >
+    <SelectOption
+      className=""
+      component="button"
+      data-title="lorem"
+      data-value="lorem"
+      id="bG9yZW0tbG9yZW0="
+      index={0}
+      inputId=""
+      isChecked={false}
+      isDisabled={false}
+      isFavorite={null}
+      isLoad={false}
+      isLoading={false}
+      isNoResultsOption={false}
+      isPlaceholder={false}
+      isSelected={false}
+      key="bG9yZW0tbG9yZW0="
+      keyHandler={[Function]}
+      onClick={[Function]}
+      sendRef={[Function]}
+      value="lorem"
+    />
+    <SelectOption
+      className=""
+      component="button"
+      data-title="ipsum"
+      data-value="ipsum"
+      id="aXBzdW0taXBzdW0="
+      index={0}
+      inputId=""
+      isChecked={false}
+      isDisabled={false}
+      isFavorite={null}
+      isLoad={false}
+      isLoading={false}
+      isNoResultsOption={false}
+      isPlaceholder={false}
+      isSelected={false}
+      key="aXBzdW0taXBzdW0="
+      keyHandler={[Function]}
+      onClick={[Function]}
+      sendRef={[Function]}
+      value="ipsum"
+    />
+  </Select>
+</div>
 `;
 
 exports[`Select Component should allow being disabled with missing options: no options 1`] = `
-<Select
-  aria-describedby=""
-  aria-invalid={false}
-  aria-label="Select option"
-  aria-labelledby=""
-  chipGroupComponent={null}
-  className="curiosity-select  "
-  clearSelectionsAriaLabel="Clear all"
-  createText="Create"
-  customBadgeText={null}
-  customContent={null}
-  direction="down"
-  favorites={Array []}
-  favoritesLabel="Favorites"
-  hasInlineFilter={false}
-  inlineFilterPlaceholderText={null}
-  inputIdPrefix=""
-  isCreatable={false}
-  isDisabled={true}
-  isGrouped={false}
-  isInputValuePersisted={false}
-  isOpen={false}
-  isPlain={false}
-  maxHeight={null}
-  menuAppendTo="inline"
-  noResultsFoundText="No results found"
-  onClear={[Function]}
-  onCreateOption={[Function]}
-  onFilter={null}
-  onSelect={[Function]}
-  onToggle={[Function]}
-  onTypeaheadInputChanged={null}
-  ouiaSafe={true}
-  placeholderText="Select option"
-  removeSelectionAriaLabel="Remove"
-  selections={Array []}
-  toggleAriaLabel="Options menu"
-  toggleIcon={null}
-  toggleId={null}
-  typeAheadAriaLabel=""
-  validated="default"
-  variant="single"
-  width=""
-/>
+<div
+  className="curiosity-select"
+>
+  <Select
+    aria-describedby=""
+    aria-invalid={false}
+    aria-label="Select option"
+    aria-labelledby=""
+    chipGroupComponent={null}
+    className="curiosity-select-pf  "
+    clearSelectionsAriaLabel="Clear all"
+    createText="Create"
+    customBadgeText={null}
+    customContent={null}
+    direction="down"
+    favorites={Array []}
+    favoritesLabel="Favorites"
+    hasInlineFilter={false}
+    inlineFilterPlaceholderText={null}
+    inputIdPrefix=""
+    isCreatable={false}
+    isDisabled={true}
+    isGrouped={false}
+    isInputValuePersisted={false}
+    isOpen={false}
+    isPlain={false}
+    maxHeight={null}
+    menuAppendTo="parent"
+    noResultsFoundText="No results found"
+    onClear={[Function]}
+    onCreateOption={[Function]}
+    onFilter={null}
+    onSelect={[Function]}
+    onToggle={[Function]}
+    onTypeaheadInputChanged={null}
+    ouiaSafe={true}
+    placeholderText="Select option"
+    removeSelectionAriaLabel="Remove"
+    selections={Array []}
+    toggleAriaLabel="Options menu"
+    toggleIcon={null}
+    toggleId={null}
+    typeAheadAriaLabel=""
+    validated="default"
+    variant="single"
+    width=""
+  />
+</div>
 `;
 
 exports[`Select Component should allow being disabled with missing options: options, but disabled 1`] = `
-<Select
-  aria-describedby=""
-  aria-invalid={false}
-  aria-label="Select option"
-  aria-labelledby=""
-  chipGroupComponent={null}
-  className="curiosity-select  "
-  clearSelectionsAriaLabel="Clear all"
-  createText="Create"
-  customBadgeText={null}
-  customContent={null}
-  direction="down"
-  favorites={Array []}
-  favoritesLabel="Favorites"
-  hasInlineFilter={false}
-  inlineFilterPlaceholderText={null}
-  inputIdPrefix=""
-  isCreatable={false}
-  isDisabled={true}
-  isGrouped={false}
-  isInputValuePersisted={false}
-  isOpen={false}
-  isPlain={false}
-  maxHeight={null}
-  menuAppendTo="inline"
-  noResultsFoundText="No results found"
-  onClear={[Function]}
-  onCreateOption={[Function]}
-  onFilter={null}
-  onSelect={[Function]}
-  onToggle={[Function]}
-  onTypeaheadInputChanged={null}
-  ouiaSafe={true}
-  placeholderText="Select option"
-  removeSelectionAriaLabel="Remove"
-  selections={Array []}
-  toggleAriaLabel="Options menu"
-  toggleIcon={null}
-  toggleId={null}
-  typeAheadAriaLabel=""
-  validated="default"
-  variant="single"
-  width=""
+<div
+  className="curiosity-select"
 >
-  <SelectOption
-    className=""
-    component="button"
-    data-title="lorem"
-    data-value="lorem"
-    id="bG9yZW0tbG9yZW0="
-    index={0}
-    inputId=""
-    isChecked={false}
-    isDisabled={false}
-    isFavorite={null}
-    isLoad={false}
-    isLoading={false}
-    isNoResultsOption={false}
-    isPlaceholder={false}
-    isSelected={false}
-    key="bG9yZW0tbG9yZW0="
-    keyHandler={[Function]}
-    onClick={[Function]}
-    sendRef={[Function]}
-    value="lorem"
-  />
-  <SelectOption
-    className=""
-    component="button"
-    data-title="ipsum"
-    data-value="ipsum"
-    id="aXBzdW0taXBzdW0="
-    index={0}
-    inputId=""
-    isChecked={false}
-    isDisabled={false}
-    isFavorite={null}
-    isLoad={false}
-    isLoading={false}
-    isNoResultsOption={false}
-    isPlaceholder={false}
-    isSelected={false}
-    key="aXBzdW0taXBzdW0="
-    keyHandler={[Function]}
-    onClick={[Function]}
-    sendRef={[Function]}
-    value="ipsum"
-  />
-  <SelectOption
-    className=""
-    component="button"
-    data-title="hello"
-    data-value="hello"
-    id="aGVsbG8taGVsbG8="
-    index={0}
-    inputId=""
-    isChecked={false}
-    isDisabled={false}
-    isFavorite={null}
-    isLoad={false}
-    isLoading={false}
-    isNoResultsOption={false}
-    isPlaceholder={false}
-    isSelected={false}
-    key="aGVsbG8taGVsbG8="
-    keyHandler={[Function]}
-    onClick={[Function]}
-    sendRef={[Function]}
-    value="hello"
-  />
-  <SelectOption
-    className=""
-    component="button"
-    data-title="world"
-    data-value="world"
-    id="d29ybGQtd29ybGQ="
-    index={0}
-    inputId=""
-    isChecked={false}
-    isDisabled={false}
-    isFavorite={null}
-    isLoad={false}
-    isLoading={false}
-    isNoResultsOption={false}
-    isPlaceholder={false}
-    isSelected={false}
-    key="d29ybGQtd29ybGQ="
-    keyHandler={[Function]}
-    onClick={[Function]}
-    sendRef={[Function]}
-    value="world"
-  />
-</Select>
+  <Select
+    aria-describedby=""
+    aria-invalid={false}
+    aria-label="Select option"
+    aria-labelledby=""
+    chipGroupComponent={null}
+    className="curiosity-select-pf  "
+    clearSelectionsAriaLabel="Clear all"
+    createText="Create"
+    customBadgeText={null}
+    customContent={null}
+    direction="down"
+    favorites={Array []}
+    favoritesLabel="Favorites"
+    hasInlineFilter={false}
+    inlineFilterPlaceholderText={null}
+    inputIdPrefix=""
+    isCreatable={false}
+    isDisabled={true}
+    isGrouped={false}
+    isInputValuePersisted={false}
+    isOpen={false}
+    isPlain={false}
+    maxHeight={null}
+    menuAppendTo="parent"
+    noResultsFoundText="No results found"
+    onClear={[Function]}
+    onCreateOption={[Function]}
+    onFilter={null}
+    onSelect={[Function]}
+    onToggle={[Function]}
+    onTypeaheadInputChanged={null}
+    ouiaSafe={true}
+    placeholderText="Select option"
+    removeSelectionAriaLabel="Remove"
+    selections={Array []}
+    toggleAriaLabel="Options menu"
+    toggleIcon={null}
+    toggleId={null}
+    typeAheadAriaLabel=""
+    validated="default"
+    variant="single"
+    width=""
+  >
+    <SelectOption
+      className=""
+      component="button"
+      data-title="lorem"
+      data-value="lorem"
+      id="bG9yZW0tbG9yZW0="
+      index={0}
+      inputId=""
+      isChecked={false}
+      isDisabled={false}
+      isFavorite={null}
+      isLoad={false}
+      isLoading={false}
+      isNoResultsOption={false}
+      isPlaceholder={false}
+      isSelected={false}
+      key="bG9yZW0tbG9yZW0="
+      keyHandler={[Function]}
+      onClick={[Function]}
+      sendRef={[Function]}
+      value="lorem"
+    />
+    <SelectOption
+      className=""
+      component="button"
+      data-title="ipsum"
+      data-value="ipsum"
+      id="aXBzdW0taXBzdW0="
+      index={0}
+      inputId=""
+      isChecked={false}
+      isDisabled={false}
+      isFavorite={null}
+      isLoad={false}
+      isLoading={false}
+      isNoResultsOption={false}
+      isPlaceholder={false}
+      isSelected={false}
+      key="aXBzdW0taXBzdW0="
+      keyHandler={[Function]}
+      onClick={[Function]}
+      sendRef={[Function]}
+      value="ipsum"
+    />
+    <SelectOption
+      className=""
+      component="button"
+      data-title="hello"
+      data-value="hello"
+      id="aGVsbG8taGVsbG8="
+      index={0}
+      inputId=""
+      isChecked={false}
+      isDisabled={false}
+      isFavorite={null}
+      isLoad={false}
+      isLoading={false}
+      isNoResultsOption={false}
+      isPlaceholder={false}
+      isSelected={false}
+      key="aGVsbG8taGVsbG8="
+      keyHandler={[Function]}
+      onClick={[Function]}
+      sendRef={[Function]}
+      value="hello"
+    />
+    <SelectOption
+      className=""
+      component="button"
+      data-title="world"
+      data-value="world"
+      id="d29ybGQtd29ybGQ="
+      index={0}
+      inputId=""
+      isChecked={false}
+      isDisabled={false}
+      isFavorite={null}
+      isLoad={false}
+      isLoading={false}
+      isNoResultsOption={false}
+      isPlaceholder={false}
+      isSelected={false}
+      key="d29ybGQtd29ybGQ="
+      keyHandler={[Function]}
+      onClick={[Function]}
+      sendRef={[Function]}
+      value="world"
+    />
+  </Select>
+</div>
 `;
 
 exports[`Select Component should allow being disabled with missing options: options, but no content 1`] = `
-<Select
-  aria-describedby=""
-  aria-invalid={false}
-  aria-label="Select option"
-  aria-labelledby=""
-  chipGroupComponent={null}
-  className="curiosity-select  "
-  clearSelectionsAriaLabel="Clear all"
-  createText="Create"
-  customBadgeText={null}
-  customContent={null}
-  direction="down"
-  favorites={Array []}
-  favoritesLabel="Favorites"
-  hasInlineFilter={false}
-  inlineFilterPlaceholderText={null}
-  inputIdPrefix=""
-  isCreatable={false}
-  isDisabled={true}
-  isGrouped={false}
-  isInputValuePersisted={false}
-  isOpen={false}
-  isPlain={false}
-  maxHeight={null}
-  menuAppendTo="inline"
-  noResultsFoundText="No results found"
-  onClear={[Function]}
-  onCreateOption={[Function]}
-  onFilter={null}
-  onSelect={[Function]}
-  onToggle={[Function]}
-  onTypeaheadInputChanged={null}
-  ouiaSafe={true}
-  placeholderText="Select option"
-  removeSelectionAriaLabel="Remove"
-  selections={Array []}
-  toggleAriaLabel="Options menu"
-  toggleIcon={null}
-  toggleId={null}
-  typeAheadAriaLabel=""
-  validated="default"
-  variant="single"
-  width=""
-/>
+<div
+  className="curiosity-select"
+>
+  <Select
+    aria-describedby=""
+    aria-invalid={false}
+    aria-label="Select option"
+    aria-labelledby=""
+    chipGroupComponent={null}
+    className="curiosity-select-pf  "
+    clearSelectionsAriaLabel="Clear all"
+    createText="Create"
+    customBadgeText={null}
+    customContent={null}
+    direction="down"
+    favorites={Array []}
+    favoritesLabel="Favorites"
+    hasInlineFilter={false}
+    inlineFilterPlaceholderText={null}
+    inputIdPrefix=""
+    isCreatable={false}
+    isDisabled={true}
+    isGrouped={false}
+    isInputValuePersisted={false}
+    isOpen={false}
+    isPlain={false}
+    maxHeight={null}
+    menuAppendTo="parent"
+    noResultsFoundText="No results found"
+    onClear={[Function]}
+    onCreateOption={[Function]}
+    onFilter={null}
+    onSelect={[Function]}
+    onToggle={[Function]}
+    onTypeaheadInputChanged={null}
+    ouiaSafe={true}
+    placeholderText="Select option"
+    removeSelectionAriaLabel="Remove"
+    selections={Array []}
+    toggleAriaLabel="Options menu"
+    toggleIcon={null}
+    toggleId={null}
+    typeAheadAriaLabel=""
+    validated="default"
+    variant="single"
+    width=""
+  />
+</div>
 `;
 
 exports[`Select Component should allow data- props: data- attributes 1`] = `
@@ -528,295 +556,315 @@ Object {
 
 exports[`Select Component should allow plain objects as values, and be able to select options based on values within the object: select when option values are objects 1`] = `
 <div
-  class="pf-c-select curiosity-select  "
-  data-ouia-component-id="OUIA-Generated-Select-single-3"
-  data-ouia-component-type="PF4/Select"
-  data-ouia-safe="true"
+  class="curiosity-select"
 >
-  <button
-    aria-expanded="false"
-    aria-haspopup="listbox"
-    aria-labelledby=" pf-select-toggle-id-14"
-    class="pf-c-select__toggle"
-    id="pf-select-toggle-id-14"
-    type="button"
+  <div
+    class="pf-c-select curiosity-select-pf  "
+    data-ouia-component-id="OUIA-Generated-Select-single-3"
+    data-ouia-component-type="PF4/Select"
+    data-ouia-safe="true"
   >
-    <div
-      class="pf-c-select__toggle-wrapper"
+    <button
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      aria-labelledby=" pf-select-toggle-id-14"
+      class="pf-c-select__toggle"
+      id="pf-select-toggle-id-14"
+      type="button"
     >
+      <div
+        class="pf-c-select__toggle-wrapper"
+      >
+        <span
+          class="pf-c-select__toggle-text"
+        >
+          hello
+        </span>
+      </div>
       <span
-        class="pf-c-select__toggle-text"
+        class="pf-c-select__toggle-arrow"
       >
-        hello
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 320 512"
+          width="1em"
+        >
+          <path
+            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+          />
+        </svg>
       </span>
-    </div>
-    <span
-      class="pf-c-select__toggle-arrow"
-    >
-      <svg
-        aria-hidden="true"
-        fill="currentColor"
-        height="1em"
-        role="img"
-        style="vertical-align: -0.125em;"
-        viewBox="0 0 320 512"
-        width="1em"
-      >
-        <path
-          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-        />
-      </svg>
-    </span>
-  </button>
+    </button>
+  </div>
 </div>
 `;
 
 exports[`Select Component should allow selected options to match value or title: value or title match 1`] = `
 <div
-  class="pf-c-select curiosity-select  "
-  data-ouia-component-id="OUIA-Generated-Select-checkbox-2"
-  data-ouia-component-type="PF4/Select"
-  data-ouia-safe="true"
+  class="curiosity-select"
 >
-  <button
-    aria-expanded="false"
-    aria-labelledby=" pf-select-toggle-id-17"
-    class="pf-c-select__toggle"
-    id="pf-select-toggle-id-17"
-    type="button"
+  <div
+    class="pf-c-select curiosity-select-pf  "
+    data-ouia-component-id="OUIA-Generated-Select-checkbox-2"
+    data-ouia-component-type="PF4/Select"
+    data-ouia-safe="true"
   >
-    <div
-      class="pf-c-select__toggle-wrapper"
+    <button
+      aria-expanded="false"
+      aria-labelledby=" pf-select-toggle-id-17"
+      class="pf-c-select__toggle"
+      id="pf-select-toggle-id-17"
+      type="button"
     >
-      <span
-        class="pf-c-select__toggle-text"
-      >
-        Select option
-      </span>
       <div
-        class="pf-c-select__toggle-badge"
+        class="pf-c-select__toggle-wrapper"
       >
         <span
-          class="pf-c-badge pf-m-read"
+          class="pf-c-select__toggle-text"
         >
-          2
+          Select option
         </span>
+        <div
+          class="pf-c-select__toggle-badge"
+        >
+          <span
+            class="pf-c-badge pf-m-read"
+          >
+            2
+          </span>
+        </div>
       </div>
-    </div>
-    <span
-      class="pf-c-select__toggle-arrow"
-    >
-      <svg
-        aria-hidden="true"
-        fill="currentColor"
-        height="1em"
-        role="img"
-        style="vertical-align: -0.125em;"
-        viewBox="0 0 320 512"
-        width="1em"
+      <span
+        class="pf-c-select__toggle-arrow"
       >
-        <path
-          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-        />
-      </svg>
-    </span>
-  </button>
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 320 512"
+          width="1em"
+        >
+          <path
+            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+          />
+        </svg>
+      </span>
+    </button>
+  </div>
 </div>
 `;
 
 exports[`Select Component should disable toggle text: disabled text 1`] = `
-<Select
-  aria-describedby=""
-  aria-invalid={false}
-  aria-label="Select option"
-  aria-labelledby=""
-  chipGroupComponent={null}
-  className="curiosity-select__no-toggle-text  "
-  clearSelectionsAriaLabel="Clear all"
-  createText="Create"
-  customBadgeText={null}
-  customContent={null}
-  direction="down"
-  favorites={Array []}
-  favoritesLabel="Favorites"
-  hasInlineFilter={false}
-  inlineFilterPlaceholderText={null}
-  inputIdPrefix=""
-  isCreatable={false}
-  isDisabled={false}
-  isGrouped={false}
-  isInputValuePersisted={false}
-  isOpen={false}
-  isPlain={false}
-  maxHeight={null}
-  menuAppendTo="inline"
-  noResultsFoundText="No results found"
-  onClear={[Function]}
-  onCreateOption={[Function]}
-  onFilter={null}
-  onSelect={[Function]}
-  onToggle={[Function]}
-  onTypeaheadInputChanged={null}
-  ouiaSafe={true}
-  placeholderText="Select option"
-  removeSelectionAriaLabel="Remove"
-  selections={Array []}
-  toggleAriaLabel="Options menu"
-  toggleIcon={
-    <FilterIcon
-      color="currentColor"
-      noVerticalAlign={false}
-      size="sm"
-    />
-  }
-  toggleId={null}
-  typeAheadAriaLabel=""
-  validated="default"
-  variant="single"
-  width=""
+<div
+  className="curiosity-select"
 >
-  <SelectOption
-    className=""
-    component="button"
-    data-title="lorem"
-    data-value="lorem"
-    id="bG9yZW0tbG9yZW0="
-    index={0}
-    inputId=""
-    isChecked={false}
+  <Select
+    aria-describedby=""
+    aria-invalid={false}
+    aria-label="Select option"
+    aria-labelledby=""
+    chipGroupComponent={null}
+    className="curiosity-select-pf__no-toggle-text  "
+    clearSelectionsAriaLabel="Clear all"
+    createText="Create"
+    customBadgeText={null}
+    customContent={null}
+    direction="down"
+    favorites={Array []}
+    favoritesLabel="Favorites"
+    hasInlineFilter={false}
+    inlineFilterPlaceholderText={null}
+    inputIdPrefix=""
+    isCreatable={false}
     isDisabled={false}
-    isFavorite={null}
-    isLoad={false}
-    isLoading={false}
-    isNoResultsOption={false}
-    isPlaceholder={false}
-    isSelected={false}
-    key="bG9yZW0tbG9yZW0="
-    keyHandler={[Function]}
-    onClick={[Function]}
-    sendRef={[Function]}
-    value="lorem"
-  />
-  <SelectOption
-    className=""
-    component="button"
-    data-title="ipsum"
-    data-value="ipsum"
-    id="aXBzdW0taXBzdW0="
-    index={0}
-    inputId=""
-    isChecked={false}
-    isDisabled={false}
-    isFavorite={null}
-    isLoad={false}
-    isLoading={false}
-    isNoResultsOption={false}
-    isPlaceholder={false}
-    isSelected={false}
-    key="aXBzdW0taXBzdW0="
-    keyHandler={[Function]}
-    onClick={[Function]}
-    sendRef={[Function]}
-    value="ipsum"
-  />
-</Select>
+    isGrouped={false}
+    isInputValuePersisted={false}
+    isOpen={false}
+    isPlain={false}
+    maxHeight={null}
+    menuAppendTo="parent"
+    noResultsFoundText="No results found"
+    onClear={[Function]}
+    onCreateOption={[Function]}
+    onFilter={null}
+    onSelect={[Function]}
+    onToggle={[Function]}
+    onTypeaheadInputChanged={null}
+    ouiaSafe={true}
+    placeholderText="Select option"
+    removeSelectionAriaLabel="Remove"
+    selections={Array []}
+    toggleAriaLabel="Options menu"
+    toggleIcon={
+      <FilterIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />
+    }
+    toggleId={null}
+    typeAheadAriaLabel=""
+    validated="default"
+    variant="single"
+    width=""
+  >
+    <SelectOption
+      className=""
+      component="button"
+      data-title="lorem"
+      data-value="lorem"
+      id="bG9yZW0tbG9yZW0="
+      index={0}
+      inputId=""
+      isChecked={false}
+      isDisabled={false}
+      isFavorite={null}
+      isLoad={false}
+      isLoading={false}
+      isNoResultsOption={false}
+      isPlaceholder={false}
+      isSelected={false}
+      key="bG9yZW0tbG9yZW0="
+      keyHandler={[Function]}
+      onClick={[Function]}
+      sendRef={[Function]}
+      value="lorem"
+    />
+    <SelectOption
+      className=""
+      component="button"
+      data-title="ipsum"
+      data-value="ipsum"
+      id="aXBzdW0taXBzdW0="
+      index={0}
+      inputId=""
+      isChecked={false}
+      isDisabled={false}
+      isFavorite={null}
+      isLoad={false}
+      isLoading={false}
+      isNoResultsOption={false}
+      isPlaceholder={false}
+      isSelected={false}
+      key="aXBzdW0taXBzdW0="
+      keyHandler={[Function]}
+      onClick={[Function]}
+      sendRef={[Function]}
+      value="ipsum"
+    />
+  </Select>
+</div>
 `;
 
 exports[`Select Component should render a basic component: basic component 1`] = `
 <div
-  class="pf-c-select curiosity-select  "
-  data-ouia-component-id="OUIA-Generated-Select-single-1"
-  data-ouia-component-type="PF4/Select"
-  data-ouia-safe="true"
+  class="curiosity-select"
 >
-  <button
-    aria-expanded="false"
-    aria-haspopup="listbox"
-    aria-labelledby=" pf-select-toggle-id-2"
-    class="pf-c-select__toggle"
-    id="pf-select-toggle-id-2"
-    type="button"
+  <div
+    class="pf-c-select curiosity-select-pf  "
+    data-ouia-component-id="OUIA-Generated-Select-single-1"
+    data-ouia-component-type="PF4/Select"
+    data-ouia-safe="true"
   >
-    <div
-      class="pf-c-select__toggle-wrapper"
+    <button
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      aria-labelledby=" pf-select-toggle-id-2"
+      class="pf-c-select__toggle"
+      id="pf-select-toggle-id-2"
+      type="button"
     >
+      <div
+        class="pf-c-select__toggle-wrapper"
+      >
+        <span
+          class="pf-c-select__toggle-text"
+        >
+          hello
+        </span>
+      </div>
       <span
-        class="pf-c-select__toggle-text"
+        class="pf-c-select__toggle-arrow"
       >
-        hello
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 320 512"
+          width="1em"
+        >
+          <path
+            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+          />
+        </svg>
       </span>
-    </div>
-    <span
-      class="pf-c-select__toggle-arrow"
-    >
-      <svg
-        aria-hidden="true"
-        fill="currentColor"
-        height="1em"
-        role="img"
-        style="vertical-align: -0.125em;"
-        viewBox="0 0 320 512"
-        width="1em"
-      >
-        <path
-          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-        />
-      </svg>
-    </span>
-  </button>
+    </button>
+  </div>
 </div>
 `;
 
 exports[`Select Component should render a checkbox select: checkbox select 1`] = `
 <div
-  class="pf-c-select curiosity-select  "
-  data-ouia-component-id="OUIA-Generated-Select-checkbox-1"
-  data-ouia-component-type="PF4/Select"
-  data-ouia-safe="true"
+  class="curiosity-select"
 >
-  <button
-    aria-expanded="false"
-    aria-labelledby=" pf-select-toggle-id-5"
-    class="pf-c-select__toggle"
-    id="pf-select-toggle-id-5"
-    type="button"
+  <div
+    class="pf-c-select curiosity-select-pf  "
+    data-ouia-component-id="OUIA-Generated-Select-checkbox-1"
+    data-ouia-component-type="PF4/Select"
+    data-ouia-safe="true"
   >
-    <div
-      class="pf-c-select__toggle-wrapper"
+    <button
+      aria-expanded="false"
+      aria-labelledby=" pf-select-toggle-id-5"
+      class="pf-c-select__toggle"
+      id="pf-select-toggle-id-5"
+      type="button"
     >
-      <span
-        class="pf-c-select__toggle-text"
-      >
-        multiselect test
-      </span>
       <div
-        class="pf-c-select__toggle-badge"
+        class="pf-c-select__toggle-wrapper"
       >
         <span
-          class="pf-c-badge pf-m-read"
+          class="pf-c-select__toggle-text"
         >
-          2
+          multiselect test
         </span>
+        <div
+          class="pf-c-select__toggle-badge"
+        >
+          <span
+            class="pf-c-badge pf-m-read"
+          >
+            2
+          </span>
+        </div>
       </div>
-    </div>
-    <span
-      class="pf-c-select__toggle-arrow"
-    >
-      <svg
-        aria-hidden="true"
-        fill="currentColor"
-        height="1em"
-        role="img"
-        style="vertical-align: -0.125em;"
-        viewBox="0 0 320 512"
-        width="1em"
+      <span
+        class="pf-c-select__toggle-arrow"
       >
-        <path
-          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-        />
-      </svg>
-    </span>
-  </button>
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 320 512"
+          width="1em"
+        >
+          <path
+            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+          />
+        </svg>
+      </span>
+    </button>
+  </div>
 </div>
 `;
 
@@ -845,149 +893,63 @@ exports[`Select Component should render an expanded select: expanded 1`] = `
   toggleIcon={null}
   variant="single"
 >
-  <Select
-    aria-describedby=""
-    aria-invalid={false}
-    aria-label="Select option"
-    aria-labelledby=""
-    chipGroupComponent={null}
-    className="curiosity-select  "
-    clearSelectionsAriaLabel="Clear all"
-    createText="Create"
-    customBadgeText={null}
-    customContent={null}
-    direction="down"
-    favorites={Array []}
-    favoritesLabel="Favorites"
-    hasInlineFilter={false}
-    inlineFilterPlaceholderText={null}
-    inputIdPrefix=""
-    isCreatable={false}
-    isDisabled={false}
-    isGrouped={false}
-    isInputValuePersisted={false}
-    isOpen={true}
-    isPlain={false}
-    maxHeight={null}
-    menuAppendTo="inline"
-    noResultsFoundText="No results found"
-    onClear={[Function]}
-    onCreateOption={[Function]}
-    onFilter={null}
-    onSelect={[Function]}
-    onToggle={[Function]}
-    onTypeaheadInputChanged={null}
-    ouiaSafe={true}
-    placeholderText="Select option"
-    removeSelectionAriaLabel="Remove"
-    selections={Array []}
-    toggleAriaLabel="Options menu"
-    toggleIcon={null}
-    toggleId={null}
-    typeAheadAriaLabel=""
-    validated="default"
-    variant="single"
-    width=""
+  <div
+    className="curiosity-select"
   >
-    <GenerateId
-      prefix="pf-random-id-"
+    <Select
+      aria-describedby=""
+      aria-invalid={false}
+      aria-label="Select option"
+      aria-labelledby=""
+      chipGroupComponent={null}
+      className="curiosity-select-pf  "
+      clearSelectionsAriaLabel="Clear all"
+      createText="Create"
+      customBadgeText={null}
+      customContent={null}
+      direction="down"
+      favorites={Array []}
+      favoritesLabel="Favorites"
+      hasInlineFilter={false}
+      inlineFilterPlaceholderText={null}
+      inputIdPrefix=""
+      isCreatable={false}
+      isDisabled={false}
+      isGrouped={false}
+      isInputValuePersisted={false}
+      isOpen={true}
+      isPlain={false}
+      maxHeight={null}
+      menuAppendTo="parent"
+      noResultsFoundText="No results found"
+      onClear={[Function]}
+      onCreateOption={[Function]}
+      onFilter={null}
+      onSelect={[Function]}
+      onToggle={[Function]}
+      onTypeaheadInputChanged={null}
+      ouiaSafe={true}
+      placeholderText="Select option"
+      removeSelectionAriaLabel="Remove"
+      selections={Array []}
+      toggleAriaLabel="Options menu"
+      toggleIcon={null}
+      toggleId={null}
+      typeAheadAriaLabel=""
+      validated="default"
+      variant="single"
+      width=""
     >
-      <div
-        className="pf-c-select pf-m-expanded curiosity-select  "
-        data-ouia-component-id="OUIA-Generated-Select-single-5"
-        data-ouia-component-type="PF4/Select"
-        data-ouia-safe={true}
+      <GenerateId
+        prefix="pf-random-id-"
       >
-        <SelectToggle
-          aria-label="Options menu"
-          aria-labelledby=" pf-select-toggle-id-32"
-          className=""
-          handleTypeaheadKeys={[Function]}
-          hasClearButton={false}
-          hasFooter={false}
-          id="pf-select-toggle-id-32"
-          isActive={false}
-          isDisabled={false}
-          isOpen={true}
-          isPlain={false}
-          menuRef={
-            Object {
-              "current": <ul
-                aria-label="Select option"
-                class="pf-c-select__menu"
-                role="listbox"
-              >
-                <li
-                  class="pf-c-select__menu-wrapper"
-                  id="bG9yZW0tbG9yZW0="
-                  role="presentation"
-                >
-                  <button
-                    class="pf-c-select__menu-item"
-                    data-title="lorem"
-                    data-value="lorem"
-                    role="option"
-                    type="button"
-                  >
-                    lorem
-                  </button>
-                </li>
-                <li
-                  class="pf-c-select__menu-wrapper"
-                  id="aXBzdW0taXBzdW0="
-                  role="presentation"
-                >
-                  <button
-                    class="pf-c-select__menu-item"
-                    data-title="ipsum"
-                    data-value="ipsum"
-                    role="option"
-                    type="button"
-                  >
-                    ipsum
-                  </button>
-                </li>
-                <li
-                  class="pf-c-select__menu-wrapper"
-                  id="aGVsbG8taGVsbG8="
-                  role="presentation"
-                >
-                  <button
-                    class="pf-c-select__menu-item"
-                    data-title="hello"
-                    data-value="hello"
-                    role="option"
-                    type="button"
-                  >
-                    hello
-                  </button>
-                </li>
-                <li
-                  class="pf-c-select__menu-wrapper"
-                  id="d29ybGQtd29ybGQ="
-                  role="presentation"
-                >
-                  <button
-                    class="pf-c-select__menu-item"
-                    data-title="world"
-                    data-value="world"
-                    role="option"
-                    type="button"
-                  >
-                    world
-                  </button>
-                </li>
-              </ul>,
-            }
-          }
-          onClickTypeaheadToggleButton={[Function]}
-          onClose={[Function]}
-          onEnter={[Function]}
-          onToggle={[Function]}
-          parentRef={
-            Object {
-              "current": <div
-                class="pf-c-select pf-m-expanded curiosity-select  "
+        <Popper
+          appendTo={
+            <div
+              class="curiosity-select"
+            >
+              <div
+                class="pf-c-select pf-m-expanded curiosity-select-pf  "
                 data-ouia-component-id="OUIA-Generated-Select-single-5"
                 data-ouia-component-type="PF4/Select"
                 data-ouia-safe="true"
@@ -1027,6 +989,11 @@ exports[`Select Component should render an expanded select: expanded 1`] = `
                     </svg>
                   </span>
                 </button>
+              </div>
+              <div
+                class="pf-c-select pf-m-expanded curiosity-select-pf  "
+                style="position: absolute; left: 0px; top: 0px; z-index: 9999; width: 0px;"
+              >
                 <ul
                   aria-label="Select option"
                   class="pf-c-select__menu"
@@ -1093,342 +1060,889 @@ exports[`Select Component should render an expanded select: expanded 1`] = `
                     </button>
                   </li>
                 </ul>
-              </div>,
-            }
+              </div>
+            </div>
           }
-          type="button"
-          variant="single"
+          direction="down"
+          isVisible={true}
+          popper={
+            <div
+              className="pf-c-select pf-m-expanded curiosity-select-pf  "
+            >
+              <ForwardRef
+                aria-label="Select option"
+                aria-labelledby=""
+                footerRef={
+                  Object {
+                    "current": null,
+                  }
+                }
+                hasInlineFilter={false}
+                isGrouped={false}
+                keyHandler={[Function]}
+                maxHeight={null}
+                openedOnEnter={false}
+                sendRef={[Function]}
+              >
+                <SelectOption
+                  className=""
+                  component="button"
+                  data-title="lorem"
+                  data-value="lorem"
+                  id="bG9yZW0tbG9yZW0="
+                  index={0}
+                  inputId=""
+                  isChecked={false}
+                  isDisabled={false}
+                  isFavorite={null}
+                  isLoad={false}
+                  isLoading={false}
+                  isNoResultsOption={false}
+                  isPlaceholder={false}
+                  isSelected={false}
+                  keyHandler={[Function]}
+                  onClick={[Function]}
+                  sendRef={[Function]}
+                  value="lorem"
+                />
+                <SelectOption
+                  className=""
+                  component="button"
+                  data-title="ipsum"
+                  data-value="ipsum"
+                  id="aXBzdW0taXBzdW0="
+                  index={0}
+                  inputId=""
+                  isChecked={false}
+                  isDisabled={false}
+                  isFavorite={null}
+                  isLoad={false}
+                  isLoading={false}
+                  isNoResultsOption={false}
+                  isPlaceholder={false}
+                  isSelected={false}
+                  keyHandler={[Function]}
+                  onClick={[Function]}
+                  sendRef={[Function]}
+                  value="ipsum"
+                />
+                <SelectOption
+                  className=""
+                  component="button"
+                  data-title="hello"
+                  data-value="hello"
+                  id="aGVsbG8taGVsbG8="
+                  index={0}
+                  inputId=""
+                  isChecked={false}
+                  isDisabled={false}
+                  isFavorite={null}
+                  isLoad={false}
+                  isLoading={false}
+                  isNoResultsOption={false}
+                  isPlaceholder={false}
+                  isSelected={false}
+                  keyHandler={[Function]}
+                  onClick={[Function]}
+                  sendRef={[Function]}
+                  value="hello"
+                />
+                <SelectOption
+                  className=""
+                  component="button"
+                  data-title="world"
+                  data-value="world"
+                  id="d29ybGQtd29ybGQ="
+                  index={0}
+                  inputId=""
+                  isChecked={false}
+                  isDisabled={false}
+                  isFavorite={null}
+                  isLoad={false}
+                  isLoading={false}
+                  isNoResultsOption={false}
+                  isPlaceholder={false}
+                  isSelected={false}
+                  keyHandler={[Function]}
+                  onClick={[Function]}
+                  sendRef={[Function]}
+                  value="world"
+                />
+              </ForwardRef>
+            </div>
+          }
+          trigger={
+            <div
+              className="pf-c-select pf-m-expanded curiosity-select-pf  "
+              data-ouia-component-id="OUIA-Generated-Select-single-5"
+              data-ouia-component-type="PF4/Select"
+              data-ouia-safe={true}
+            >
+              <SelectToggle
+                aria-label="Options menu"
+                aria-labelledby=" pf-select-toggle-id-32"
+                className=""
+                handleTypeaheadKeys={[Function]}
+                hasClearButton={false}
+                hasFooter={false}
+                id="pf-select-toggle-id-32"
+                isActive={false}
+                isDisabled={false}
+                isOpen={true}
+                isPlain={false}
+                menuRef={
+                  Object {
+                    "current": <ul
+                      aria-label="Select option"
+                      class="pf-c-select__menu"
+                      role="listbox"
+                    >
+                      <li
+                        class="pf-c-select__menu-wrapper"
+                        id="bG9yZW0tbG9yZW0="
+                        role="presentation"
+                      >
+                        <button
+                          class="pf-c-select__menu-item"
+                          data-title="lorem"
+                          data-value="lorem"
+                          role="option"
+                          type="button"
+                        >
+                          lorem
+                        </button>
+                      </li>
+                      <li
+                        class="pf-c-select__menu-wrapper"
+                        id="aXBzdW0taXBzdW0="
+                        role="presentation"
+                      >
+                        <button
+                          class="pf-c-select__menu-item"
+                          data-title="ipsum"
+                          data-value="ipsum"
+                          role="option"
+                          type="button"
+                        >
+                          ipsum
+                        </button>
+                      </li>
+                      <li
+                        class="pf-c-select__menu-wrapper"
+                        id="aGVsbG8taGVsbG8="
+                        role="presentation"
+                      >
+                        <button
+                          class="pf-c-select__menu-item"
+                          data-title="hello"
+                          data-value="hello"
+                          role="option"
+                          type="button"
+                        >
+                          hello
+                        </button>
+                      </li>
+                      <li
+                        class="pf-c-select__menu-wrapper"
+                        id="d29ybGQtd29ybGQ="
+                        role="presentation"
+                      >
+                        <button
+                          class="pf-c-select__menu-item"
+                          data-title="world"
+                          data-value="world"
+                          role="option"
+                          type="button"
+                        >
+                          world
+                        </button>
+                      </li>
+                    </ul>,
+                  }
+                }
+                onClickTypeaheadToggleButton={[Function]}
+                onClose={[Function]}
+                onEnter={[Function]}
+                onToggle={[Function]}
+                parentRef={
+                  Object {
+                    "current": <div
+                      class="pf-c-select pf-m-expanded curiosity-select-pf  "
+                      data-ouia-component-id="OUIA-Generated-Select-single-5"
+                      data-ouia-component-type="PF4/Select"
+                      data-ouia-safe="true"
+                    >
+                      <button
+                        aria-expanded="true"
+                        aria-haspopup="listbox"
+                        aria-labelledby=" pf-select-toggle-id-32"
+                        class="pf-c-select__toggle"
+                        id="pf-select-toggle-id-32"
+                        type="button"
+                      >
+                        <div
+                          class="pf-c-select__toggle-wrapper"
+                        >
+                          <span
+                            class="pf-c-select__toggle-text"
+                          >
+                            Select option
+                          </span>
+                        </div>
+                        <span
+                          class="pf-c-select__toggle-arrow"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                    </div>,
+                  }
+                }
+                type="button"
+                variant="single"
+              >
+                <React.Fragment>
+                  <div
+                    className="pf-c-select__toggle-wrapper"
+                  >
+                    <span
+                      className="pf-c-select__toggle-text"
+                    >
+                      Select option
+                    </span>
+                  </div>
+                </React.Fragment>
+              </SelectToggle>
+            </div>
+          }
         >
-          <button
-            aria-expanded={true}
-            aria-haspopup="listbox"
-            aria-labelledby=" pf-select-toggle-id-32"
-            className="pf-c-select__toggle"
-            disabled={false}
-            id="pf-select-toggle-id-32"
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            type="button"
+          <FindRefWrapper
+            onFoundRef={[Function]}
           >
             <div
-              className="pf-c-select__toggle-wrapper"
+              className="pf-c-select pf-m-expanded curiosity-select-pf  "
+              data-ouia-component-id="OUIA-Generated-Select-single-5"
+              data-ouia-component-type="PF4/Select"
+              data-ouia-safe={true}
             >
-              <span
-                className="pf-c-select__toggle-text"
+              <SelectToggle
+                aria-label="Options menu"
+                aria-labelledby=" pf-select-toggle-id-32"
+                className=""
+                handleTypeaheadKeys={[Function]}
+                hasClearButton={false}
+                hasFooter={false}
+                id="pf-select-toggle-id-32"
+                isActive={false}
+                isDisabled={false}
+                isOpen={true}
+                isPlain={false}
+                menuRef={
+                  Object {
+                    "current": <ul
+                      aria-label="Select option"
+                      class="pf-c-select__menu"
+                      role="listbox"
+                    >
+                      <li
+                        class="pf-c-select__menu-wrapper"
+                        id="bG9yZW0tbG9yZW0="
+                        role="presentation"
+                      >
+                        <button
+                          class="pf-c-select__menu-item"
+                          data-title="lorem"
+                          data-value="lorem"
+                          role="option"
+                          type="button"
+                        >
+                          lorem
+                        </button>
+                      </li>
+                      <li
+                        class="pf-c-select__menu-wrapper"
+                        id="aXBzdW0taXBzdW0="
+                        role="presentation"
+                      >
+                        <button
+                          class="pf-c-select__menu-item"
+                          data-title="ipsum"
+                          data-value="ipsum"
+                          role="option"
+                          type="button"
+                        >
+                          ipsum
+                        </button>
+                      </li>
+                      <li
+                        class="pf-c-select__menu-wrapper"
+                        id="aGVsbG8taGVsbG8="
+                        role="presentation"
+                      >
+                        <button
+                          class="pf-c-select__menu-item"
+                          data-title="hello"
+                          data-value="hello"
+                          role="option"
+                          type="button"
+                        >
+                          hello
+                        </button>
+                      </li>
+                      <li
+                        class="pf-c-select__menu-wrapper"
+                        id="d29ybGQtd29ybGQ="
+                        role="presentation"
+                      >
+                        <button
+                          class="pf-c-select__menu-item"
+                          data-title="world"
+                          data-value="world"
+                          role="option"
+                          type="button"
+                        >
+                          world
+                        </button>
+                      </li>
+                    </ul>,
+                  }
+                }
+                onClickTypeaheadToggleButton={[Function]}
+                onClose={[Function]}
+                onEnter={[Function]}
+                onToggle={[Function]}
+                parentRef={
+                  Object {
+                    "current": <div
+                      class="pf-c-select pf-m-expanded curiosity-select-pf  "
+                      data-ouia-component-id="OUIA-Generated-Select-single-5"
+                      data-ouia-component-type="PF4/Select"
+                      data-ouia-safe="true"
+                    >
+                      <button
+                        aria-expanded="true"
+                        aria-haspopup="listbox"
+                        aria-labelledby=" pf-select-toggle-id-32"
+                        class="pf-c-select__toggle"
+                        id="pf-select-toggle-id-32"
+                        type="button"
+                      >
+                        <div
+                          class="pf-c-select__toggle-wrapper"
+                        >
+                          <span
+                            class="pf-c-select__toggle-text"
+                          >
+                            Select option
+                          </span>
+                        </div>
+                        <span
+                          class="pf-c-select__toggle-arrow"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                    </div>,
+                  }
+                }
+                type="button"
+                variant="single"
               >
-                Select option
-              </span>
+                <button
+                  aria-expanded={true}
+                  aria-haspopup="listbox"
+                  aria-labelledby=" pf-select-toggle-id-32"
+                  className="pf-c-select__toggle"
+                  disabled={false}
+                  id="pf-select-toggle-id-32"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
+                >
+                  <div
+                    className="pf-c-select__toggle-wrapper"
+                  >
+                    <span
+                      className="pf-c-select__toggle-text"
+                    >
+                      Select option
+                    </span>
+                  </div>
+                  <span
+                    className="pf-c-select__toggle-arrow"
+                  >
+                    <CaretDownIcon
+                      color="currentColor"
+                      noVerticalAlign={false}
+                      size="sm"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        aria-labelledby={null}
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        style={
+                          Object {
+                            "verticalAlign": "-0.125em",
+                          }
+                        }
+                        viewBox="0 0 320 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                        />
+                      </svg>
+                    </CaretDownIcon>
+                  </span>
+                </button>
+              </SelectToggle>
             </div>
-            <span
-              className="pf-c-select__toggle-arrow"
-            >
-              <CaretDownIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+          </FindRefWrapper>
+          <Portal
+            containerInfo={
+              <div
+                class="curiosity-select"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
+                <div
+                  class="pf-c-select pf-m-expanded curiosity-select-pf  "
+                  data-ouia-component-id="OUIA-Generated-Select-single-5"
+                  data-ouia-component-type="PF4/Select"
+                  data-ouia-safe="true"
+                >
+                  <button
+                    aria-expanded="true"
+                    aria-haspopup="listbox"
+                    aria-labelledby=" pf-select-toggle-id-32"
+                    class="pf-c-select__toggle"
+                    id="pf-select-toggle-id-32"
+                    type="button"
+                  >
+                    <div
+                      class="pf-c-select__toggle-wrapper"
+                    >
+                      <span
+                        class="pf-c-select__toggle-text"
+                      >
+                        Select option
+                      </span>
+                    </div>
+                    <span
+                      class="pf-c-select__toggle-arrow"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        style="vertical-align: -0.125em;"
+                        viewBox="0 0 320 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                </div>
+                <div
+                  class="pf-c-select pf-m-expanded curiosity-select-pf  "
+                  style="position: absolute; left: 0px; top: 0px; z-index: 9999; width: 0px;"
+                >
+                  <ul
+                    aria-label="Select option"
+                    class="pf-c-select__menu"
+                    role="listbox"
+                  >
+                    <li
+                      class="pf-c-select__menu-wrapper"
+                      id="bG9yZW0tbG9yZW0="
+                      role="presentation"
+                    >
+                      <button
+                        class="pf-c-select__menu-item"
+                        data-title="lorem"
+                        data-value="lorem"
+                        role="option"
+                        type="button"
+                      >
+                        lorem
+                      </button>
+                    </li>
+                    <li
+                      class="pf-c-select__menu-wrapper"
+                      id="aXBzdW0taXBzdW0="
+                      role="presentation"
+                    >
+                      <button
+                        class="pf-c-select__menu-item"
+                        data-title="ipsum"
+                        data-value="ipsum"
+                        role="option"
+                        type="button"
+                      >
+                        ipsum
+                      </button>
+                    </li>
+                    <li
+                      class="pf-c-select__menu-wrapper"
+                      id="aGVsbG8taGVsbG8="
+                      role="presentation"
+                    >
+                      <button
+                        class="pf-c-select__menu-item"
+                        data-title="hello"
+                        data-value="hello"
+                        role="option"
+                        type="button"
+                      >
+                        hello
+                      </button>
+                    </li>
+                    <li
+                      class="pf-c-select__menu-wrapper"
+                      id="d29ybGQtd29ybGQ="
+                      role="presentation"
+                    >
+                      <button
+                        class="pf-c-select__menu-item"
+                        data-title="world"
+                        data-value="world"
+                        role="option"
+                        type="button"
+                      >
+                        world
+                      </button>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            }
+          >
+            <FindRefWrapper
+              onFoundRef={[Function]}
+            >
+              <div
+                className="pf-c-select pf-m-expanded curiosity-select-pf  "
+                style={
+                  Object {
+                    "left": "0",
+                    "position": "absolute",
+                    "top": "0",
+                    "zIndex": 9999,
+                  }
+                }
+              >
+                <ForwardRef
+                  aria-label="Select option"
+                  aria-labelledby=""
+                  footerRef={
                     Object {
-                      "verticalAlign": "-0.125em",
+                      "current": null,
                     }
                   }
-                  viewBox="0 0 320 512"
-                  width="1em"
+                  hasInlineFilter={false}
+                  isGrouped={false}
+                  keyHandler={[Function]}
+                  maxHeight={null}
+                  openedOnEnter={false}
+                  sendRef={[Function]}
                 >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  />
-                </svg>
-              </CaretDownIcon>
-            </span>
-          </button>
-        </SelectToggle>
-        <ForwardRef
-          aria-label="Select option"
-          aria-labelledby=""
-          footerRef={
-            Object {
-              "current": null,
-            }
-          }
-          hasInlineFilter={false}
-          isGrouped={false}
-          keyHandler={[Function]}
-          maxHeight={null}
-          openedOnEnter={false}
-          sendRef={[Function]}
-        >
-          <SelectMenu
-            aria-label="Select option"
-            aria-labelledby=""
-            className=""
-            footerRef={
-              Object {
-                "current": null,
-              }
-            }
-            hasInlineFilter={false}
-            innerRef={
-              Object {
-                "current": <ul
-                  aria-label="Select option"
-                  class="pf-c-select__menu"
-                  role="listbox"
-                >
-                  <li
-                    class="pf-c-select__menu-wrapper"
-                    id="bG9yZW0tbG9yZW0="
-                    role="presentation"
+                  <SelectMenu
+                    aria-label="Select option"
+                    aria-labelledby=""
+                    className=""
+                    footerRef={
+                      Object {
+                        "current": null,
+                      }
+                    }
+                    hasInlineFilter={false}
+                    innerRef={
+                      Object {
+                        "current": <ul
+                          aria-label="Select option"
+                          class="pf-c-select__menu"
+                          role="listbox"
+                        >
+                          <li
+                            class="pf-c-select__menu-wrapper"
+                            id="bG9yZW0tbG9yZW0="
+                            role="presentation"
+                          >
+                            <button
+                              class="pf-c-select__menu-item"
+                              data-title="lorem"
+                              data-value="lorem"
+                              role="option"
+                              type="button"
+                            >
+                              lorem
+                            </button>
+                          </li>
+                          <li
+                            class="pf-c-select__menu-wrapper"
+                            id="aXBzdW0taXBzdW0="
+                            role="presentation"
+                          >
+                            <button
+                              class="pf-c-select__menu-item"
+                              data-title="ipsum"
+                              data-value="ipsum"
+                              role="option"
+                              type="button"
+                            >
+                              ipsum
+                            </button>
+                          </li>
+                          <li
+                            class="pf-c-select__menu-wrapper"
+                            id="aGVsbG8taGVsbG8="
+                            role="presentation"
+                          >
+                            <button
+                              class="pf-c-select__menu-item"
+                              data-title="hello"
+                              data-value="hello"
+                              role="option"
+                              type="button"
+                            >
+                              hello
+                            </button>
+                          </li>
+                          <li
+                            class="pf-c-select__menu-wrapper"
+                            id="d29ybGQtd29ybGQ="
+                            role="presentation"
+                          >
+                            <button
+                              class="pf-c-select__menu-item"
+                              data-title="world"
+                              data-value="world"
+                              role="option"
+                              type="button"
+                            >
+                              world
+                            </button>
+                          </li>
+                        </ul>,
+                      }
+                    }
+                    isCustomContent={false}
+                    isExpanded={false}
+                    isGrouped={false}
+                    keyHandler={[Function]}
+                    maxHeight={null}
+                    openedOnEnter={false}
+                    selected=""
+                    sendRef={[Function]}
                   >
-                    <button
-                      class="pf-c-select__menu-item"
-                      data-title="lorem"
-                      data-value="lorem"
-                      role="option"
-                      type="button"
+                    <ul
+                      aria-label="Select option"
+                      aria-labelledby={null}
+                      className="pf-c-select__menu"
+                      role="listbox"
                     >
-                      lorem
-                    </button>
-                  </li>
-                  <li
-                    class="pf-c-select__menu-wrapper"
-                    id="aXBzdW0taXBzdW0="
-                    role="presentation"
-                  >
-                    <button
-                      class="pf-c-select__menu-item"
-                      data-title="ipsum"
-                      data-value="ipsum"
-                      role="option"
-                      type="button"
-                    >
-                      ipsum
-                    </button>
-                  </li>
-                  <li
-                    class="pf-c-select__menu-wrapper"
-                    id="aGVsbG8taGVsbG8="
-                    role="presentation"
-                  >
-                    <button
-                      class="pf-c-select__menu-item"
-                      data-title="hello"
-                      data-value="hello"
-                      role="option"
-                      type="button"
-                    >
-                      hello
-                    </button>
-                  </li>
-                  <li
-                    class="pf-c-select__menu-wrapper"
-                    id="d29ybGQtd29ybGQ="
-                    role="presentation"
-                  >
-                    <button
-                      class="pf-c-select__menu-item"
-                      data-title="world"
-                      data-value="world"
-                      role="option"
-                      type="button"
-                    >
-                      world
-                    </button>
-                  </li>
-                </ul>,
-              }
-            }
-            isCustomContent={false}
-            isExpanded={false}
-            isGrouped={false}
-            keyHandler={[Function]}
-            maxHeight={null}
-            openedOnEnter={false}
-            selected=""
-            sendRef={[Function]}
-          >
-            <ul
-              aria-label="Select option"
-              aria-labelledby={null}
-              className="pf-c-select__menu"
-              role="listbox"
-            >
-              <SelectOption
-                className=""
-                component="button"
-                data-title="lorem"
-                data-value="lorem"
-                id="bG9yZW0tbG9yZW0="
-                index={0}
-                inputId="pf-random-id-6-0"
-                isChecked={false}
-                isDisabled={false}
-                isFavorite={null}
-                isLoad={false}
-                isLoading={false}
-                isNoResultsOption={false}
-                isPlaceholder={false}
-                isSelected={false}
-                key=".$bG9yZW0tbG9yZW0=0"
-                keyHandler={[Function]}
-                onClick={[Function]}
-                sendRef={[Function]}
-                value="lorem"
-              >
-                <li
-                  className="pf-c-select__menu-wrapper"
-                  id="bG9yZW0tbG9yZW0="
-                  role="presentation"
-                >
-                  <button
-                    aria-selected={null}
-                    className="pf-c-select__menu-item"
-                    data-title="lorem"
-                    data-value="lorem"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    role="option"
-                    type="button"
-                  >
-                    lorem
-                  </button>
-                </li>
-              </SelectOption>
-              <SelectOption
-                className=""
-                component="button"
-                data-title="ipsum"
-                data-value="ipsum"
-                id="aXBzdW0taXBzdW0="
-                index={1}
-                inputId="pf-random-id-6-1"
-                isChecked={false}
-                isDisabled={false}
-                isFavorite={null}
-                isLoad={false}
-                isLoading={false}
-                isNoResultsOption={false}
-                isPlaceholder={false}
-                isSelected={false}
-                key=".$aXBzdW0taXBzdW0=0"
-                keyHandler={[Function]}
-                onClick={[Function]}
-                sendRef={[Function]}
-                value="ipsum"
-              >
-                <li
-                  className="pf-c-select__menu-wrapper"
-                  id="aXBzdW0taXBzdW0="
-                  role="presentation"
-                >
-                  <button
-                    aria-selected={null}
-                    className="pf-c-select__menu-item"
-                    data-title="ipsum"
-                    data-value="ipsum"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    role="option"
-                    type="button"
-                  >
-                    ipsum
-                  </button>
-                </li>
-              </SelectOption>
-              <SelectOption
-                className=""
-                component="button"
-                data-title="hello"
-                data-value="hello"
-                id="aGVsbG8taGVsbG8="
-                index={2}
-                inputId="pf-random-id-6-2"
-                isChecked={false}
-                isDisabled={false}
-                isFavorite={null}
-                isLoad={false}
-                isLoading={false}
-                isNoResultsOption={false}
-                isPlaceholder={false}
-                isSelected={false}
-                key=".$aGVsbG8taGVsbG8=0"
-                keyHandler={[Function]}
-                onClick={[Function]}
-                sendRef={[Function]}
-                value="hello"
-              >
-                <li
-                  className="pf-c-select__menu-wrapper"
-                  id="aGVsbG8taGVsbG8="
-                  role="presentation"
-                >
-                  <button
-                    aria-selected={null}
-                    className="pf-c-select__menu-item"
-                    data-title="hello"
-                    data-value="hello"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    role="option"
-                    type="button"
-                  >
-                    hello
-                  </button>
-                </li>
-              </SelectOption>
-              <SelectOption
-                className=""
-                component="button"
-                data-title="world"
-                data-value="world"
-                id="d29ybGQtd29ybGQ="
-                index={3}
-                inputId="pf-random-id-6-3"
-                isChecked={false}
-                isDisabled={false}
-                isFavorite={null}
-                isLoad={false}
-                isLoading={false}
-                isNoResultsOption={false}
-                isPlaceholder={false}
-                isSelected={false}
-                key=".$d29ybGQtd29ybGQ=0"
-                keyHandler={[Function]}
-                onClick={[Function]}
-                sendRef={[Function]}
-                value="world"
-              >
-                <li
-                  className="pf-c-select__menu-wrapper"
-                  id="d29ybGQtd29ybGQ="
-                  role="presentation"
-                >
-                  <button
-                    aria-selected={null}
-                    className="pf-c-select__menu-item"
-                    data-title="world"
-                    data-value="world"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    role="option"
-                    type="button"
-                  >
-                    world
-                  </button>
-                </li>
-              </SelectOption>
-            </ul>
-          </SelectMenu>
-        </ForwardRef>
-      </div>
-    </GenerateId>
-  </Select>
+                      <SelectOption
+                        className=""
+                        component="button"
+                        data-title="lorem"
+                        data-value="lorem"
+                        id="bG9yZW0tbG9yZW0="
+                        index={0}
+                        inputId="pf-random-id-6-0"
+                        isChecked={false}
+                        isDisabled={false}
+                        isFavorite={null}
+                        isLoad={false}
+                        isLoading={false}
+                        isNoResultsOption={false}
+                        isPlaceholder={false}
+                        isSelected={false}
+                        key=".$bG9yZW0tbG9yZW0=0"
+                        keyHandler={[Function]}
+                        onClick={[Function]}
+                        sendRef={[Function]}
+                        value="lorem"
+                      >
+                        <li
+                          className="pf-c-select__menu-wrapper"
+                          id="bG9yZW0tbG9yZW0="
+                          role="presentation"
+                        >
+                          <button
+                            aria-selected={null}
+                            className="pf-c-select__menu-item"
+                            data-title="lorem"
+                            data-value="lorem"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            role="option"
+                            type="button"
+                          >
+                            lorem
+                          </button>
+                        </li>
+                      </SelectOption>
+                      <SelectOption
+                        className=""
+                        component="button"
+                        data-title="ipsum"
+                        data-value="ipsum"
+                        id="aXBzdW0taXBzdW0="
+                        index={1}
+                        inputId="pf-random-id-6-1"
+                        isChecked={false}
+                        isDisabled={false}
+                        isFavorite={null}
+                        isLoad={false}
+                        isLoading={false}
+                        isNoResultsOption={false}
+                        isPlaceholder={false}
+                        isSelected={false}
+                        key=".$aXBzdW0taXBzdW0=0"
+                        keyHandler={[Function]}
+                        onClick={[Function]}
+                        sendRef={[Function]}
+                        value="ipsum"
+                      >
+                        <li
+                          className="pf-c-select__menu-wrapper"
+                          id="aXBzdW0taXBzdW0="
+                          role="presentation"
+                        >
+                          <button
+                            aria-selected={null}
+                            className="pf-c-select__menu-item"
+                            data-title="ipsum"
+                            data-value="ipsum"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            role="option"
+                            type="button"
+                          >
+                            ipsum
+                          </button>
+                        </li>
+                      </SelectOption>
+                      <SelectOption
+                        className=""
+                        component="button"
+                        data-title="hello"
+                        data-value="hello"
+                        id="aGVsbG8taGVsbG8="
+                        index={2}
+                        inputId="pf-random-id-6-2"
+                        isChecked={false}
+                        isDisabled={false}
+                        isFavorite={null}
+                        isLoad={false}
+                        isLoading={false}
+                        isNoResultsOption={false}
+                        isPlaceholder={false}
+                        isSelected={false}
+                        key=".$aGVsbG8taGVsbG8=0"
+                        keyHandler={[Function]}
+                        onClick={[Function]}
+                        sendRef={[Function]}
+                        value="hello"
+                      >
+                        <li
+                          className="pf-c-select__menu-wrapper"
+                          id="aGVsbG8taGVsbG8="
+                          role="presentation"
+                        >
+                          <button
+                            aria-selected={null}
+                            className="pf-c-select__menu-item"
+                            data-title="hello"
+                            data-value="hello"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            role="option"
+                            type="button"
+                          >
+                            hello
+                          </button>
+                        </li>
+                      </SelectOption>
+                      <SelectOption
+                        className=""
+                        component="button"
+                        data-title="world"
+                        data-value="world"
+                        id="d29ybGQtd29ybGQ="
+                        index={3}
+                        inputId="pf-random-id-6-3"
+                        isChecked={false}
+                        isDisabled={false}
+                        isFavorite={null}
+                        isLoad={false}
+                        isLoading={false}
+                        isNoResultsOption={false}
+                        isPlaceholder={false}
+                        isSelected={false}
+                        key=".$d29ybGQtd29ybGQ=0"
+                        keyHandler={[Function]}
+                        onClick={[Function]}
+                        sendRef={[Function]}
+                        value="world"
+                      >
+                        <li
+                          className="pf-c-select__menu-wrapper"
+                          id="d29ybGQtd29ybGQ="
+                          role="presentation"
+                        >
+                          <button
+                            aria-selected={null}
+                            className="pf-c-select__menu-item"
+                            data-title="world"
+                            data-value="world"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            role="option"
+                            type="button"
+                          >
+                            world
+                          </button>
+                        </li>
+                      </SelectOption>
+                    </ul>
+                  </SelectMenu>
+                </ForwardRef>
+              </div>
+            </FindRefWrapper>
+          </Portal>
+        </Popper>
+      </GenerateId>
+    </Select>
+  </div>
 </Select>
 `;
 

--- a/src/components/form/__tests__/__snapshots__/select.test.js.snap
+++ b/src/components/form/__tests__/__snapshots__/select.test.js.snap
@@ -1,293 +1,85 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Select Component should allow alternate array and object options: key value object 1`] = `
-<div
-  class="curiosity-select"
->
-  <div
-    class="pf-c-select curiosity-select-pf  "
-    data-ouia-component-id="OUIA-Generated-Select-single-2"
-    data-ouia-component-type="PF4/Select"
-    data-ouia-safe="true"
-  >
-    <button
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-labelledby=" pf-select-toggle-id-11"
-      class="pf-c-select__toggle"
-      id="pf-select-toggle-id-11"
-      type="button"
-    >
-      <div
-        class="pf-c-select__toggle-wrapper"
-      >
-        <span
-          class="pf-c-select__toggle-text"
-        >
-          lorem
-        </span>
-      </div>
-      <span
-        class="pf-c-select__toggle-arrow"
-      >
-        <svg
-          aria-hidden="true"
-          fill="currentColor"
-          height="1em"
-          role="img"
-          style="vertical-align: -0.125em;"
-          viewBox="0 0 320 512"
-          width="1em"
-        >
-          <path
-            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-          />
-        </svg>
-      </span>
-    </button>
-  </div>
-</div>
+Array [
+  Object {
+    "0": "i",
+    "1": "p",
+    "2": "s",
+    "3": "u",
+    "4": "m",
+    "label": "lorem",
+    "selected": true,
+    "text": "lorem",
+    "textContent": "lorem",
+    "title": "lorem",
+    "value": "ipsum",
+  },
+  Object {
+    "0": "w",
+    "1": "o",
+    "2": "r",
+    "3": "l",
+    "4": "d",
+    "label": "hello",
+    "selected": true,
+    "text": "hello",
+    "textContent": "hello",
+    "title": "hello",
+    "value": "world",
+  },
+]
 `;
 
 exports[`Select Component should allow alternate array and object options: string array 1`] = `
-<div
-  class="curiosity-select"
->
-  <div
-    class="pf-c-select curiosity-select-pf  "
-    data-ouia-component-id="OUIA-Generated-Select-single-2"
-    data-ouia-component-type="PF4/Select"
-    data-ouia-safe="true"
-  >
-    <button
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-labelledby=" pf-select-toggle-id-8"
-      class="pf-c-select__toggle"
-      id="pf-select-toggle-id-8"
-      type="button"
-    >
-      <div
-        class="pf-c-select__toggle-wrapper"
-      >
-        <span
-          class="pf-c-select__toggle-text"
-        >
-          ipsum
-        </span>
-      </div>
-      <span
-        class="pf-c-select__toggle-arrow"
-      >
-        <svg
-          aria-hidden="true"
-          fill="currentColor"
-          height="1em"
-          role="img"
-          style="vertical-align: -0.125em;"
-          viewBox="0 0 320 512"
-          width="1em"
-        >
-          <path
-            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-          />
-        </svg>
-      </span>
-    </button>
-  </div>
-</div>
+Array [
+  Object {
+    "label": "lorem",
+    "selected": false,
+    "text": "lorem",
+    "textContent": "lorem",
+    "title": "lorem",
+    "value": "lorem",
+  },
+  Object {
+    "label": "ipsum",
+    "selected": true,
+    "text": "ipsum",
+    "textContent": "ipsum",
+    "title": "ipsum",
+    "value": "ipsum",
+  },
+  Object {
+    "label": "hello",
+    "selected": false,
+    "text": "hello",
+    "textContent": "hello",
+    "title": "hello",
+    "value": "hello",
+  },
+  Object {
+    "label": "world",
+    "selected": false,
+    "text": "world",
+    "textContent": "world",
+    "title": "world",
+    "value": "world",
+  },
+]
 `;
 
 exports[`Select Component should allow alternate direction and position options: direction up 1`] = `
-<div
-  className="curiosity-select"
->
-  <Select
-    aria-describedby=""
-    aria-invalid={false}
-    aria-label="Select option"
-    aria-labelledby=""
-    chipGroupComponent={null}
-    className="curiosity-select-pf  "
-    clearSelectionsAriaLabel="Clear all"
-    createText="Create"
-    customBadgeText={null}
-    customContent={null}
-    direction="up"
-    favorites={Array []}
-    favoritesLabel="Favorites"
-    hasInlineFilter={false}
-    inlineFilterPlaceholderText={null}
-    inputIdPrefix=""
-    isCreatable={false}
-    isDisabled={false}
-    isGrouped={false}
-    isInputValuePersisted={false}
-    isOpen={false}
-    isPlain={false}
-    maxHeight={null}
-    menuAppendTo="parent"
-    noResultsFoundText="No results found"
-    onClear={[Function]}
-    onCreateOption={[Function]}
-    onFilter={null}
-    onSelect={[Function]}
-    onToggle={[Function]}
-    onTypeaheadInputChanged={null}
-    ouiaSafe={true}
-    placeholderText="Select option"
-    removeSelectionAriaLabel="Remove"
-    selections={Array []}
-    toggleAriaLabel="Options menu"
-    toggleIcon={null}
-    toggleId={null}
-    typeAheadAriaLabel=""
-    validated="default"
-    variant="single"
-    width=""
-  >
-    <SelectOption
-      className=""
-      component="button"
-      data-title="lorem"
-      data-value="lorem"
-      id="bG9yZW0tbG9yZW0="
-      index={0}
-      inputId=""
-      isChecked={false}
-      isDisabled={false}
-      isFavorite={null}
-      isLoad={false}
-      isLoading={false}
-      isNoResultsOption={false}
-      isPlaceholder={false}
-      isSelected={false}
-      key="bG9yZW0tbG9yZW0="
-      keyHandler={[Function]}
-      onClick={[Function]}
-      sendRef={[Function]}
-      value="lorem"
-    />
-    <SelectOption
-      className=""
-      component="button"
-      data-title="ipsum"
-      data-value="ipsum"
-      id="aXBzdW0taXBzdW0="
-      index={0}
-      inputId=""
-      isChecked={false}
-      isDisabled={false}
-      isFavorite={null}
-      isLoad={false}
-      isLoading={false}
-      isNoResultsOption={false}
-      isPlaceholder={false}
-      isSelected={false}
-      key="aXBzdW0taXBzdW0="
-      keyHandler={[Function]}
-      onClick={[Function]}
-      sendRef={[Function]}
-      value="ipsum"
-    />
-  </Select>
-</div>
+Object {
+  "className": "curiosity-select-pf  ",
+  "direction": "up",
+}
 `;
 
 exports[`Select Component should allow alternate direction and position options: position right 1`] = `
-<div
-  className="curiosity-select"
->
-  <Select
-    aria-describedby=""
-    aria-invalid={false}
-    aria-label="Select option"
-    aria-labelledby=""
-    chipGroupComponent={null}
-    className="curiosity-select-pf curiosity-select-pf__position-right "
-    clearSelectionsAriaLabel="Clear all"
-    createText="Create"
-    customBadgeText={null}
-    customContent={null}
-    direction="down"
-    favorites={Array []}
-    favoritesLabel="Favorites"
-    hasInlineFilter={false}
-    inlineFilterPlaceholderText={null}
-    inputIdPrefix=""
-    isCreatable={false}
-    isDisabled={false}
-    isGrouped={false}
-    isInputValuePersisted={false}
-    isOpen={false}
-    isPlain={false}
-    maxHeight={null}
-    menuAppendTo="parent"
-    noResultsFoundText="No results found"
-    onClear={[Function]}
-    onCreateOption={[Function]}
-    onFilter={null}
-    onSelect={[Function]}
-    onToggle={[Function]}
-    onTypeaheadInputChanged={null}
-    ouiaSafe={true}
-    placeholderText="Select option"
-    removeSelectionAriaLabel="Remove"
-    selections={Array []}
-    toggleAriaLabel="Options menu"
-    toggleIcon={null}
-    toggleId={null}
-    typeAheadAriaLabel=""
-    validated="default"
-    variant="single"
-    width=""
-  >
-    <SelectOption
-      className=""
-      component="button"
-      data-title="lorem"
-      data-value="lorem"
-      id="bG9yZW0tbG9yZW0="
-      index={0}
-      inputId=""
-      isChecked={false}
-      isDisabled={false}
-      isFavorite={null}
-      isLoad={false}
-      isLoading={false}
-      isNoResultsOption={false}
-      isPlaceholder={false}
-      isSelected={false}
-      key="bG9yZW0tbG9yZW0="
-      keyHandler={[Function]}
-      onClick={[Function]}
-      sendRef={[Function]}
-      value="lorem"
-    />
-    <SelectOption
-      className=""
-      component="button"
-      data-title="ipsum"
-      data-value="ipsum"
-      id="aXBzdW0taXBzdW0="
-      index={0}
-      inputId=""
-      isChecked={false}
-      isDisabled={false}
-      isFavorite={null}
-      isLoad={false}
-      isLoading={false}
-      isNoResultsOption={false}
-      isPlaceholder={false}
-      isSelected={false}
-      key="aXBzdW0taXBzdW0="
-      keyHandler={[Function]}
-      onClick={[Function]}
-      sendRef={[Function]}
-      value="ipsum"
-    />
-  </Select>
-</div>
+Object {
+  "className": "curiosity-select-pf curiosity-select-pf__position-right ",
+  "direction": "down",
+}
 `;
 
 exports[`Select Component should allow being disabled with missing options: no options 1`] = `
@@ -555,212 +347,83 @@ Object {
 `;
 
 exports[`Select Component should allow plain objects as values, and be able to select options based on values within the object: select when option values are objects 1`] = `
-<div
-  class="curiosity-select"
->
-  <div
-    class="pf-c-select curiosity-select-pf  "
-    data-ouia-component-id="OUIA-Generated-Select-single-3"
-    data-ouia-component-type="PF4/Select"
-    data-ouia-safe="true"
-  >
-    <button
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-labelledby=" pf-select-toggle-id-14"
-      class="pf-c-select__toggle"
-      id="pf-select-toggle-id-14"
-      type="button"
-    >
-      <div
-        class="pf-c-select__toggle-wrapper"
-      >
-        <span
-          class="pf-c-select__toggle-text"
-        >
-          hello
-        </span>
-      </div>
-      <span
-        class="pf-c-select__toggle-arrow"
-      >
-        <svg
-          aria-hidden="true"
-          fill="currentColor"
-          height="1em"
-          role="img"
-          style="vertical-align: -0.125em;"
-          viewBox="0 0 320 512"
-          width="1em"
-        >
-          <path
-            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-          />
-        </svg>
-      </span>
-    </button>
-  </div>
-</div>
+Array [
+  Object {
+    "label": "lorem",
+    "selected": false,
+    "text": "lorem",
+    "textContent": "lorem",
+    "title": "lorem",
+    "value": Object {
+      "dolor": "sit",
+    },
+  },
+  Object {
+    "label": "dolor",
+    "selected": false,
+    "text": "dolor",
+    "textContent": "dolor",
+    "title": "dolor",
+    "value": Object {
+      "lorem": "ipsum",
+    },
+  },
+  Object {
+    "label": "hello",
+    "selected": true,
+    "text": "hello",
+    "textContent": "hello",
+    "title": "hello",
+    "value": Object {
+      "hello": "world",
+    },
+  },
+]
 `;
 
 exports[`Select Component should allow selected options to match value or title: value or title match 1`] = `
-<div
-  class="curiosity-select"
->
-  <div
-    class="pf-c-select curiosity-select-pf  "
-    data-ouia-component-id="OUIA-Generated-Select-checkbox-2"
-    data-ouia-component-type="PF4/Select"
-    data-ouia-safe="true"
-  >
-    <button
-      aria-expanded="false"
-      aria-labelledby=" pf-select-toggle-id-17"
-      class="pf-c-select__toggle"
-      id="pf-select-toggle-id-17"
-      type="button"
-    >
-      <div
-        class="pf-c-select__toggle-wrapper"
-      >
-        <span
-          class="pf-c-select__toggle-text"
-        >
-          Select option
-        </span>
-        <div
-          class="pf-c-select__toggle-badge"
-        >
-          <span
-            class="pf-c-badge pf-m-read"
-          >
-            2
-          </span>
-        </div>
-      </div>
-      <span
-        class="pf-c-select__toggle-arrow"
-      >
-        <svg
-          aria-hidden="true"
-          fill="currentColor"
-          height="1em"
-          role="img"
-          style="vertical-align: -0.125em;"
-          viewBox="0 0 320 512"
-          width="1em"
-        >
-          <path
-            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-          />
-        </svg>
-      </span>
-    </button>
-  </div>
-</div>
+Array [
+  Object {
+    "0": "i",
+    "1": "p",
+    "2": "s",
+    "3": "u",
+    "4": "m",
+    "label": "lorem",
+    "selected": true,
+    "text": "lorem",
+    "textContent": "lorem",
+    "title": "lorem",
+    "value": "ipsum",
+  },
+  Object {
+    "0": "w",
+    "1": "o",
+    "2": "r",
+    "3": "l",
+    "4": "d",
+    "label": "hello",
+    "selected": true,
+    "text": "hello",
+    "textContent": "hello",
+    "title": "hello",
+    "value": "world",
+  },
+  Object {
+    "0": "s",
+    "1": "e",
+    "2": "t",
+    "label": "dolor",
+    "selected": false,
+    "text": "dolor",
+    "textContent": "dolor",
+    "title": "dolor",
+    "value": "set",
+  },
+]
 `;
 
-exports[`Select Component should disable toggle text: disabled text 1`] = `
-<div
-  className="curiosity-select"
->
-  <Select
-    aria-describedby=""
-    aria-invalid={false}
-    aria-label="Select option"
-    aria-labelledby=""
-    chipGroupComponent={null}
-    className="curiosity-select-pf__no-toggle-text  "
-    clearSelectionsAriaLabel="Clear all"
-    createText="Create"
-    customBadgeText={null}
-    customContent={null}
-    direction="down"
-    favorites={Array []}
-    favoritesLabel="Favorites"
-    hasInlineFilter={false}
-    inlineFilterPlaceholderText={null}
-    inputIdPrefix=""
-    isCreatable={false}
-    isDisabled={false}
-    isGrouped={false}
-    isInputValuePersisted={false}
-    isOpen={false}
-    isPlain={false}
-    maxHeight={null}
-    menuAppendTo="parent"
-    noResultsFoundText="No results found"
-    onClear={[Function]}
-    onCreateOption={[Function]}
-    onFilter={null}
-    onSelect={[Function]}
-    onToggle={[Function]}
-    onTypeaheadInputChanged={null}
-    ouiaSafe={true}
-    placeholderText="Select option"
-    removeSelectionAriaLabel="Remove"
-    selections={Array []}
-    toggleAriaLabel="Options menu"
-    toggleIcon={
-      <FilterIcon
-        color="currentColor"
-        noVerticalAlign={false}
-        size="sm"
-      />
-    }
-    toggleId={null}
-    typeAheadAriaLabel=""
-    validated="default"
-    variant="single"
-    width=""
-  >
-    <SelectOption
-      className=""
-      component="button"
-      data-title="lorem"
-      data-value="lorem"
-      id="bG9yZW0tbG9yZW0="
-      index={0}
-      inputId=""
-      isChecked={false}
-      isDisabled={false}
-      isFavorite={null}
-      isLoad={false}
-      isLoading={false}
-      isNoResultsOption={false}
-      isPlaceholder={false}
-      isSelected={false}
-      key="bG9yZW0tbG9yZW0="
-      keyHandler={[Function]}
-      onClick={[Function]}
-      sendRef={[Function]}
-      value="lorem"
-    />
-    <SelectOption
-      className=""
-      component="button"
-      data-title="ipsum"
-      data-value="ipsum"
-      id="aXBzdW0taXBzdW0="
-      index={0}
-      inputId=""
-      isChecked={false}
-      isDisabled={false}
-      isFavorite={null}
-      isLoad={false}
-      isLoading={false}
-      isNoResultsOption={false}
-      isPlaceholder={false}
-      isSelected={false}
-      key="aXBzdW0taXBzdW0="
-      keyHandler={[Function]}
-      onClick={[Function]}
-      sendRef={[Function]}
-      value="ipsum"
-    />
-  </Select>
-</div>
-`;
+exports[`Select Component should disable toggle text: disabled text 1`] = `"curiosity-select-pf__no-toggle-text  "`;
 
 exports[`Select Component should render a basic component: basic component 1`] = `
 <div
@@ -869,1170 +532,78 @@ exports[`Select Component should render a checkbox select: checkbox select 1`] =
 `;
 
 exports[`Select Component should render an expanded select: expanded 1`] = `
-<Select
-  ariaLabel="Select option"
-  className=""
-  direction="down"
-  id="test"
-  isDisabled={false}
-  isToggleText={true}
-  maxHeight={null}
-  name={null}
-  onSelect={[Function]}
-  options={
-    Array [
-      "lorem",
-      "ipsum",
-      "hello",
-      "world",
-    ]
-  }
-  placeholder="Select option"
-  position="left"
-  selectedOptions={null}
-  toggleIcon={null}
-  variant="single"
->
-  <div
-    className="curiosity-select"
+Array [
+  <button
+    aria-selected={null}
+    className="pf-c-select__menu-item"
+    data-title="lorem"
+    data-value="lorem"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    role="option"
+    type="button"
   >
-    <Select
-      aria-describedby=""
-      aria-invalid={false}
-      aria-label="Select option"
-      aria-labelledby=""
-      chipGroupComponent={null}
-      className="curiosity-select-pf  "
-      clearSelectionsAriaLabel="Clear all"
-      createText="Create"
-      customBadgeText={null}
-      customContent={null}
-      direction="down"
-      favorites={Array []}
-      favoritesLabel="Favorites"
-      hasInlineFilter={false}
-      inlineFilterPlaceholderText={null}
-      inputIdPrefix=""
-      isCreatable={false}
-      isDisabled={false}
-      isGrouped={false}
-      isInputValuePersisted={false}
-      isOpen={true}
-      isPlain={false}
-      maxHeight={null}
-      menuAppendTo="parent"
-      noResultsFoundText="No results found"
-      onClear={[Function]}
-      onCreateOption={[Function]}
-      onFilter={null}
-      onSelect={[Function]}
-      onToggle={[Function]}
-      onTypeaheadInputChanged={null}
-      ouiaSafe={true}
-      placeholderText="Select option"
-      removeSelectionAriaLabel="Remove"
-      selections={Array []}
-      toggleAriaLabel="Options menu"
-      toggleIcon={null}
-      toggleId={null}
-      typeAheadAriaLabel=""
-      validated="default"
-      variant="single"
-      width=""
-    >
-      <GenerateId
-        prefix="pf-random-id-"
-      >
-        <Popper
-          appendTo={
-            <div
-              class="curiosity-select"
-            >
-              <div
-                class="pf-c-select pf-m-expanded curiosity-select-pf  "
-                data-ouia-component-id="OUIA-Generated-Select-single-5"
-                data-ouia-component-type="PF4/Select"
-                data-ouia-safe="true"
-              >
-                <button
-                  aria-expanded="true"
-                  aria-haspopup="listbox"
-                  aria-labelledby=" pf-select-toggle-id-32"
-                  class="pf-c-select__toggle"
-                  id="pf-select-toggle-id-32"
-                  type="button"
-                >
-                  <div
-                    class="pf-c-select__toggle-wrapper"
-                  >
-                    <span
-                      class="pf-c-select__toggle-text"
-                    >
-                      Select option
-                    </span>
-                  </div>
-                  <span
-                    class="pf-c-select__toggle-arrow"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      style="vertical-align: -0.125em;"
-                      viewBox="0 0 320 512"
-                      width="1em"
-                    >
-                      <path
-                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-              </div>
-              <div
-                class="pf-c-select pf-m-expanded curiosity-select-pf  "
-                style="position: absolute; left: 0px; top: 0px; z-index: 9999; width: 0px;"
-              >
-                <ul
-                  aria-label="Select option"
-                  class="pf-c-select__menu"
-                  role="listbox"
-                >
-                  <li
-                    class="pf-c-select__menu-wrapper"
-                    id="bG9yZW0tbG9yZW0="
-                    role="presentation"
-                  >
-                    <button
-                      class="pf-c-select__menu-item"
-                      data-title="lorem"
-                      data-value="lorem"
-                      role="option"
-                      type="button"
-                    >
-                      lorem
-                    </button>
-                  </li>
-                  <li
-                    class="pf-c-select__menu-wrapper"
-                    id="aXBzdW0taXBzdW0="
-                    role="presentation"
-                  >
-                    <button
-                      class="pf-c-select__menu-item"
-                      data-title="ipsum"
-                      data-value="ipsum"
-                      role="option"
-                      type="button"
-                    >
-                      ipsum
-                    </button>
-                  </li>
-                  <li
-                    class="pf-c-select__menu-wrapper"
-                    id="aGVsbG8taGVsbG8="
-                    role="presentation"
-                  >
-                    <button
-                      class="pf-c-select__menu-item"
-                      data-title="hello"
-                      data-value="hello"
-                      role="option"
-                      type="button"
-                    >
-                      hello
-                    </button>
-                  </li>
-                  <li
-                    class="pf-c-select__menu-wrapper"
-                    id="d29ybGQtd29ybGQ="
-                    role="presentation"
-                  >
-                    <button
-                      class="pf-c-select__menu-item"
-                      data-title="world"
-                      data-value="world"
-                      role="option"
-                      type="button"
-                    >
-                      world
-                    </button>
-                  </li>
-                </ul>
-              </div>
-            </div>
-          }
-          direction="down"
-          isVisible={true}
-          popper={
-            <div
-              className="pf-c-select pf-m-expanded curiosity-select-pf  "
-            >
-              <ForwardRef
-                aria-label="Select option"
-                aria-labelledby=""
-                footerRef={
-                  Object {
-                    "current": null,
-                  }
-                }
-                hasInlineFilter={false}
-                isGrouped={false}
-                keyHandler={[Function]}
-                maxHeight={null}
-                openedOnEnter={false}
-                sendRef={[Function]}
-              >
-                <SelectOption
-                  className=""
-                  component="button"
-                  data-title="lorem"
-                  data-value="lorem"
-                  id="bG9yZW0tbG9yZW0="
-                  index={0}
-                  inputId=""
-                  isChecked={false}
-                  isDisabled={false}
-                  isFavorite={null}
-                  isLoad={false}
-                  isLoading={false}
-                  isNoResultsOption={false}
-                  isPlaceholder={false}
-                  isSelected={false}
-                  keyHandler={[Function]}
-                  onClick={[Function]}
-                  sendRef={[Function]}
-                  value="lorem"
-                />
-                <SelectOption
-                  className=""
-                  component="button"
-                  data-title="ipsum"
-                  data-value="ipsum"
-                  id="aXBzdW0taXBzdW0="
-                  index={0}
-                  inputId=""
-                  isChecked={false}
-                  isDisabled={false}
-                  isFavorite={null}
-                  isLoad={false}
-                  isLoading={false}
-                  isNoResultsOption={false}
-                  isPlaceholder={false}
-                  isSelected={false}
-                  keyHandler={[Function]}
-                  onClick={[Function]}
-                  sendRef={[Function]}
-                  value="ipsum"
-                />
-                <SelectOption
-                  className=""
-                  component="button"
-                  data-title="hello"
-                  data-value="hello"
-                  id="aGVsbG8taGVsbG8="
-                  index={0}
-                  inputId=""
-                  isChecked={false}
-                  isDisabled={false}
-                  isFavorite={null}
-                  isLoad={false}
-                  isLoading={false}
-                  isNoResultsOption={false}
-                  isPlaceholder={false}
-                  isSelected={false}
-                  keyHandler={[Function]}
-                  onClick={[Function]}
-                  sendRef={[Function]}
-                  value="hello"
-                />
-                <SelectOption
-                  className=""
-                  component="button"
-                  data-title="world"
-                  data-value="world"
-                  id="d29ybGQtd29ybGQ="
-                  index={0}
-                  inputId=""
-                  isChecked={false}
-                  isDisabled={false}
-                  isFavorite={null}
-                  isLoad={false}
-                  isLoading={false}
-                  isNoResultsOption={false}
-                  isPlaceholder={false}
-                  isSelected={false}
-                  keyHandler={[Function]}
-                  onClick={[Function]}
-                  sendRef={[Function]}
-                  value="world"
-                />
-              </ForwardRef>
-            </div>
-          }
-          trigger={
-            <div
-              className="pf-c-select pf-m-expanded curiosity-select-pf  "
-              data-ouia-component-id="OUIA-Generated-Select-single-5"
-              data-ouia-component-type="PF4/Select"
-              data-ouia-safe={true}
-            >
-              <SelectToggle
-                aria-label="Options menu"
-                aria-labelledby=" pf-select-toggle-id-32"
-                className=""
-                handleTypeaheadKeys={[Function]}
-                hasClearButton={false}
-                hasFooter={false}
-                id="pf-select-toggle-id-32"
-                isActive={false}
-                isDisabled={false}
-                isOpen={true}
-                isPlain={false}
-                menuRef={
-                  Object {
-                    "current": <ul
-                      aria-label="Select option"
-                      class="pf-c-select__menu"
-                      role="listbox"
-                    >
-                      <li
-                        class="pf-c-select__menu-wrapper"
-                        id="bG9yZW0tbG9yZW0="
-                        role="presentation"
-                      >
-                        <button
-                          class="pf-c-select__menu-item"
-                          data-title="lorem"
-                          data-value="lorem"
-                          role="option"
-                          type="button"
-                        >
-                          lorem
-                        </button>
-                      </li>
-                      <li
-                        class="pf-c-select__menu-wrapper"
-                        id="aXBzdW0taXBzdW0="
-                        role="presentation"
-                      >
-                        <button
-                          class="pf-c-select__menu-item"
-                          data-title="ipsum"
-                          data-value="ipsum"
-                          role="option"
-                          type="button"
-                        >
-                          ipsum
-                        </button>
-                      </li>
-                      <li
-                        class="pf-c-select__menu-wrapper"
-                        id="aGVsbG8taGVsbG8="
-                        role="presentation"
-                      >
-                        <button
-                          class="pf-c-select__menu-item"
-                          data-title="hello"
-                          data-value="hello"
-                          role="option"
-                          type="button"
-                        >
-                          hello
-                        </button>
-                      </li>
-                      <li
-                        class="pf-c-select__menu-wrapper"
-                        id="d29ybGQtd29ybGQ="
-                        role="presentation"
-                      >
-                        <button
-                          class="pf-c-select__menu-item"
-                          data-title="world"
-                          data-value="world"
-                          role="option"
-                          type="button"
-                        >
-                          world
-                        </button>
-                      </li>
-                    </ul>,
-                  }
-                }
-                onClickTypeaheadToggleButton={[Function]}
-                onClose={[Function]}
-                onEnter={[Function]}
-                onToggle={[Function]}
-                parentRef={
-                  Object {
-                    "current": <div
-                      class="pf-c-select pf-m-expanded curiosity-select-pf  "
-                      data-ouia-component-id="OUIA-Generated-Select-single-5"
-                      data-ouia-component-type="PF4/Select"
-                      data-ouia-safe="true"
-                    >
-                      <button
-                        aria-expanded="true"
-                        aria-haspopup="listbox"
-                        aria-labelledby=" pf-select-toggle-id-32"
-                        class="pf-c-select__toggle"
-                        id="pf-select-toggle-id-32"
-                        type="button"
-                      >
-                        <div
-                          class="pf-c-select__toggle-wrapper"
-                        >
-                          <span
-                            class="pf-c-select__toggle-text"
-                          >
-                            Select option
-                          </span>
-                        </div>
-                        <span
-                          class="pf-c-select__toggle-arrow"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: -0.125em;"
-                            viewBox="0 0 320 512"
-                            width="1em"
-                          >
-                            <path
-                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                            />
-                          </svg>
-                        </span>
-                      </button>
-                    </div>,
-                  }
-                }
-                type="button"
-                variant="single"
-              >
-                <React.Fragment>
-                  <div
-                    className="pf-c-select__toggle-wrapper"
-                  >
-                    <span
-                      className="pf-c-select__toggle-text"
-                    >
-                      Select option
-                    </span>
-                  </div>
-                </React.Fragment>
-              </SelectToggle>
-            </div>
-          }
-        >
-          <FindRefWrapper
-            onFoundRef={[Function]}
-          >
-            <div
-              className="pf-c-select pf-m-expanded curiosity-select-pf  "
-              data-ouia-component-id="OUIA-Generated-Select-single-5"
-              data-ouia-component-type="PF4/Select"
-              data-ouia-safe={true}
-            >
-              <SelectToggle
-                aria-label="Options menu"
-                aria-labelledby=" pf-select-toggle-id-32"
-                className=""
-                handleTypeaheadKeys={[Function]}
-                hasClearButton={false}
-                hasFooter={false}
-                id="pf-select-toggle-id-32"
-                isActive={false}
-                isDisabled={false}
-                isOpen={true}
-                isPlain={false}
-                menuRef={
-                  Object {
-                    "current": <ul
-                      aria-label="Select option"
-                      class="pf-c-select__menu"
-                      role="listbox"
-                    >
-                      <li
-                        class="pf-c-select__menu-wrapper"
-                        id="bG9yZW0tbG9yZW0="
-                        role="presentation"
-                      >
-                        <button
-                          class="pf-c-select__menu-item"
-                          data-title="lorem"
-                          data-value="lorem"
-                          role="option"
-                          type="button"
-                        >
-                          lorem
-                        </button>
-                      </li>
-                      <li
-                        class="pf-c-select__menu-wrapper"
-                        id="aXBzdW0taXBzdW0="
-                        role="presentation"
-                      >
-                        <button
-                          class="pf-c-select__menu-item"
-                          data-title="ipsum"
-                          data-value="ipsum"
-                          role="option"
-                          type="button"
-                        >
-                          ipsum
-                        </button>
-                      </li>
-                      <li
-                        class="pf-c-select__menu-wrapper"
-                        id="aGVsbG8taGVsbG8="
-                        role="presentation"
-                      >
-                        <button
-                          class="pf-c-select__menu-item"
-                          data-title="hello"
-                          data-value="hello"
-                          role="option"
-                          type="button"
-                        >
-                          hello
-                        </button>
-                      </li>
-                      <li
-                        class="pf-c-select__menu-wrapper"
-                        id="d29ybGQtd29ybGQ="
-                        role="presentation"
-                      >
-                        <button
-                          class="pf-c-select__menu-item"
-                          data-title="world"
-                          data-value="world"
-                          role="option"
-                          type="button"
-                        >
-                          world
-                        </button>
-                      </li>
-                    </ul>,
-                  }
-                }
-                onClickTypeaheadToggleButton={[Function]}
-                onClose={[Function]}
-                onEnter={[Function]}
-                onToggle={[Function]}
-                parentRef={
-                  Object {
-                    "current": <div
-                      class="pf-c-select pf-m-expanded curiosity-select-pf  "
-                      data-ouia-component-id="OUIA-Generated-Select-single-5"
-                      data-ouia-component-type="PF4/Select"
-                      data-ouia-safe="true"
-                    >
-                      <button
-                        aria-expanded="true"
-                        aria-haspopup="listbox"
-                        aria-labelledby=" pf-select-toggle-id-32"
-                        class="pf-c-select__toggle"
-                        id="pf-select-toggle-id-32"
-                        type="button"
-                      >
-                        <div
-                          class="pf-c-select__toggle-wrapper"
-                        >
-                          <span
-                            class="pf-c-select__toggle-text"
-                          >
-                            Select option
-                          </span>
-                        </div>
-                        <span
-                          class="pf-c-select__toggle-arrow"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: -0.125em;"
-                            viewBox="0 0 320 512"
-                            width="1em"
-                          >
-                            <path
-                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                            />
-                          </svg>
-                        </span>
-                      </button>
-                    </div>,
-                  }
-                }
-                type="button"
-                variant="single"
-              >
-                <button
-                  aria-expanded={true}
-                  aria-haspopup="listbox"
-                  aria-labelledby=" pf-select-toggle-id-32"
-                  className="pf-c-select__toggle"
-                  disabled={false}
-                  id="pf-select-toggle-id-32"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  type="button"
-                >
-                  <div
-                    className="pf-c-select__toggle-wrapper"
-                  >
-                    <span
-                      className="pf-c-select__toggle-text"
-                    >
-                      Select option
-                    </span>
-                  </div>
-                  <span
-                    className="pf-c-select__toggle-arrow"
-                  >
-                    <CaretDownIcon
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="sm"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        aria-labelledby={null}
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 320 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                        />
-                      </svg>
-                    </CaretDownIcon>
-                  </span>
-                </button>
-              </SelectToggle>
-            </div>
-          </FindRefWrapper>
-          <Portal
-            containerInfo={
-              <div
-                class="curiosity-select"
-              >
-                <div
-                  class="pf-c-select pf-m-expanded curiosity-select-pf  "
-                  data-ouia-component-id="OUIA-Generated-Select-single-5"
-                  data-ouia-component-type="PF4/Select"
-                  data-ouia-safe="true"
-                >
-                  <button
-                    aria-expanded="true"
-                    aria-haspopup="listbox"
-                    aria-labelledby=" pf-select-toggle-id-32"
-                    class="pf-c-select__toggle"
-                    id="pf-select-toggle-id-32"
-                    type="button"
-                  >
-                    <div
-                      class="pf-c-select__toggle-wrapper"
-                    >
-                      <span
-                        class="pf-c-select__toggle-text"
-                      >
-                        Select option
-                      </span>
-                    </div>
-                    <span
-                      class="pf-c-select__toggle-arrow"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style="vertical-align: -0.125em;"
-                        viewBox="0 0 320 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                        />
-                      </svg>
-                    </span>
-                  </button>
-                </div>
-                <div
-                  class="pf-c-select pf-m-expanded curiosity-select-pf  "
-                  style="position: absolute; left: 0px; top: 0px; z-index: 9999; width: 0px;"
-                >
-                  <ul
-                    aria-label="Select option"
-                    class="pf-c-select__menu"
-                    role="listbox"
-                  >
-                    <li
-                      class="pf-c-select__menu-wrapper"
-                      id="bG9yZW0tbG9yZW0="
-                      role="presentation"
-                    >
-                      <button
-                        class="pf-c-select__menu-item"
-                        data-title="lorem"
-                        data-value="lorem"
-                        role="option"
-                        type="button"
-                      >
-                        lorem
-                      </button>
-                    </li>
-                    <li
-                      class="pf-c-select__menu-wrapper"
-                      id="aXBzdW0taXBzdW0="
-                      role="presentation"
-                    >
-                      <button
-                        class="pf-c-select__menu-item"
-                        data-title="ipsum"
-                        data-value="ipsum"
-                        role="option"
-                        type="button"
-                      >
-                        ipsum
-                      </button>
-                    </li>
-                    <li
-                      class="pf-c-select__menu-wrapper"
-                      id="aGVsbG8taGVsbG8="
-                      role="presentation"
-                    >
-                      <button
-                        class="pf-c-select__menu-item"
-                        data-title="hello"
-                        data-value="hello"
-                        role="option"
-                        type="button"
-                      >
-                        hello
-                      </button>
-                    </li>
-                    <li
-                      class="pf-c-select__menu-wrapper"
-                      id="d29ybGQtd29ybGQ="
-                      role="presentation"
-                    >
-                      <button
-                        class="pf-c-select__menu-item"
-                        data-title="world"
-                        data-value="world"
-                        role="option"
-                        type="button"
-                      >
-                        world
-                      </button>
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            }
-          >
-            <FindRefWrapper
-              onFoundRef={[Function]}
-            >
-              <div
-                className="pf-c-select pf-m-expanded curiosity-select-pf  "
-                style={
-                  Object {
-                    "left": "0",
-                    "position": "absolute",
-                    "top": "0",
-                    "zIndex": 9999,
-                  }
-                }
-              >
-                <ForwardRef
-                  aria-label="Select option"
-                  aria-labelledby=""
-                  footerRef={
-                    Object {
-                      "current": null,
-                    }
-                  }
-                  hasInlineFilter={false}
-                  isGrouped={false}
-                  keyHandler={[Function]}
-                  maxHeight={null}
-                  openedOnEnter={false}
-                  sendRef={[Function]}
-                >
-                  <SelectMenu
-                    aria-label="Select option"
-                    aria-labelledby=""
-                    className=""
-                    footerRef={
-                      Object {
-                        "current": null,
-                      }
-                    }
-                    hasInlineFilter={false}
-                    innerRef={
-                      Object {
-                        "current": <ul
-                          aria-label="Select option"
-                          class="pf-c-select__menu"
-                          role="listbox"
-                        >
-                          <li
-                            class="pf-c-select__menu-wrapper"
-                            id="bG9yZW0tbG9yZW0="
-                            role="presentation"
-                          >
-                            <button
-                              class="pf-c-select__menu-item"
-                              data-title="lorem"
-                              data-value="lorem"
-                              role="option"
-                              type="button"
-                            >
-                              lorem
-                            </button>
-                          </li>
-                          <li
-                            class="pf-c-select__menu-wrapper"
-                            id="aXBzdW0taXBzdW0="
-                            role="presentation"
-                          >
-                            <button
-                              class="pf-c-select__menu-item"
-                              data-title="ipsum"
-                              data-value="ipsum"
-                              role="option"
-                              type="button"
-                            >
-                              ipsum
-                            </button>
-                          </li>
-                          <li
-                            class="pf-c-select__menu-wrapper"
-                            id="aGVsbG8taGVsbG8="
-                            role="presentation"
-                          >
-                            <button
-                              class="pf-c-select__menu-item"
-                              data-title="hello"
-                              data-value="hello"
-                              role="option"
-                              type="button"
-                            >
-                              hello
-                            </button>
-                          </li>
-                          <li
-                            class="pf-c-select__menu-wrapper"
-                            id="d29ybGQtd29ybGQ="
-                            role="presentation"
-                          >
-                            <button
-                              class="pf-c-select__menu-item"
-                              data-title="world"
-                              data-value="world"
-                              role="option"
-                              type="button"
-                            >
-                              world
-                            </button>
-                          </li>
-                        </ul>,
-                      }
-                    }
-                    isCustomContent={false}
-                    isExpanded={false}
-                    isGrouped={false}
-                    keyHandler={[Function]}
-                    maxHeight={null}
-                    openedOnEnter={false}
-                    selected=""
-                    sendRef={[Function]}
-                  >
-                    <ul
-                      aria-label="Select option"
-                      aria-labelledby={null}
-                      className="pf-c-select__menu"
-                      role="listbox"
-                    >
-                      <SelectOption
-                        className=""
-                        component="button"
-                        data-title="lorem"
-                        data-value="lorem"
-                        id="bG9yZW0tbG9yZW0="
-                        index={0}
-                        inputId="pf-random-id-6-0"
-                        isChecked={false}
-                        isDisabled={false}
-                        isFavorite={null}
-                        isLoad={false}
-                        isLoading={false}
-                        isNoResultsOption={false}
-                        isPlaceholder={false}
-                        isSelected={false}
-                        key=".$bG9yZW0tbG9yZW0=0"
-                        keyHandler={[Function]}
-                        onClick={[Function]}
-                        sendRef={[Function]}
-                        value="lorem"
-                      >
-                        <li
-                          className="pf-c-select__menu-wrapper"
-                          id="bG9yZW0tbG9yZW0="
-                          role="presentation"
-                        >
-                          <button
-                            aria-selected={null}
-                            className="pf-c-select__menu-item"
-                            data-title="lorem"
-                            data-value="lorem"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            role="option"
-                            type="button"
-                          >
-                            lorem
-                          </button>
-                        </li>
-                      </SelectOption>
-                      <SelectOption
-                        className=""
-                        component="button"
-                        data-title="ipsum"
-                        data-value="ipsum"
-                        id="aXBzdW0taXBzdW0="
-                        index={1}
-                        inputId="pf-random-id-6-1"
-                        isChecked={false}
-                        isDisabled={false}
-                        isFavorite={null}
-                        isLoad={false}
-                        isLoading={false}
-                        isNoResultsOption={false}
-                        isPlaceholder={false}
-                        isSelected={false}
-                        key=".$aXBzdW0taXBzdW0=0"
-                        keyHandler={[Function]}
-                        onClick={[Function]}
-                        sendRef={[Function]}
-                        value="ipsum"
-                      >
-                        <li
-                          className="pf-c-select__menu-wrapper"
-                          id="aXBzdW0taXBzdW0="
-                          role="presentation"
-                        >
-                          <button
-                            aria-selected={null}
-                            className="pf-c-select__menu-item"
-                            data-title="ipsum"
-                            data-value="ipsum"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            role="option"
-                            type="button"
-                          >
-                            ipsum
-                          </button>
-                        </li>
-                      </SelectOption>
-                      <SelectOption
-                        className=""
-                        component="button"
-                        data-title="hello"
-                        data-value="hello"
-                        id="aGVsbG8taGVsbG8="
-                        index={2}
-                        inputId="pf-random-id-6-2"
-                        isChecked={false}
-                        isDisabled={false}
-                        isFavorite={null}
-                        isLoad={false}
-                        isLoading={false}
-                        isNoResultsOption={false}
-                        isPlaceholder={false}
-                        isSelected={false}
-                        key=".$aGVsbG8taGVsbG8=0"
-                        keyHandler={[Function]}
-                        onClick={[Function]}
-                        sendRef={[Function]}
-                        value="hello"
-                      >
-                        <li
-                          className="pf-c-select__menu-wrapper"
-                          id="aGVsbG8taGVsbG8="
-                          role="presentation"
-                        >
-                          <button
-                            aria-selected={null}
-                            className="pf-c-select__menu-item"
-                            data-title="hello"
-                            data-value="hello"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            role="option"
-                            type="button"
-                          >
-                            hello
-                          </button>
-                        </li>
-                      </SelectOption>
-                      <SelectOption
-                        className=""
-                        component="button"
-                        data-title="world"
-                        data-value="world"
-                        id="d29ybGQtd29ybGQ="
-                        index={3}
-                        inputId="pf-random-id-6-3"
-                        isChecked={false}
-                        isDisabled={false}
-                        isFavorite={null}
-                        isLoad={false}
-                        isLoading={false}
-                        isNoResultsOption={false}
-                        isPlaceholder={false}
-                        isSelected={false}
-                        key=".$d29ybGQtd29ybGQ=0"
-                        keyHandler={[Function]}
-                        onClick={[Function]}
-                        sendRef={[Function]}
-                        value="world"
-                      >
-                        <li
-                          className="pf-c-select__menu-wrapper"
-                          id="d29ybGQtd29ybGQ="
-                          role="presentation"
-                        >
-                          <button
-                            aria-selected={null}
-                            className="pf-c-select__menu-item"
-                            data-title="world"
-                            data-value="world"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            role="option"
-                            type="button"
-                          >
-                            world
-                          </button>
-                        </li>
-                      </SelectOption>
-                    </ul>
-                  </SelectMenu>
-                </ForwardRef>
-              </div>
-            </FindRefWrapper>
-          </Portal>
-        </Popper>
-      </GenerateId>
-    </Select>
-  </div>
-</Select>
+    lorem
+  </button>,
+  <button
+    aria-selected={null}
+    className="pf-c-select__menu-item"
+    data-title="ipsum"
+    data-value="ipsum"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    role="option"
+    type="button"
+  >
+    ipsum
+  </button>,
+  <button
+    aria-selected={null}
+    className="pf-c-select__menu-item"
+    data-title="hello"
+    data-value="hello"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    role="option"
+    type="button"
+  >
+    hello
+  </button>,
+  <button
+    aria-selected={null}
+    className="pf-c-select__menu-item"
+    data-title="world"
+    data-value="world"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    role="option"
+    type="button"
+  >
+    world
+  </button>,
+]
 `;
 
-exports[`Select Component should return an emulated onchange event: emulated event 1`] = `
+exports[`Select Component should return an emulated onchange event: checkbox emulated event 1`] = `
 Object {
-  "currentTarget": Object {
-    "id": "test",
-    "name": "test",
-    "options": Array [
-      Object {
-        "label": "lorem",
-        "selected": false,
-        "text": "lorem",
-        "textContent": "lorem",
-        "title": "lorem",
-        "value": "lorem",
-      },
-      Object {
-        "label": "ipsum",
-        "selected": false,
-        "text": "ipsum",
-        "textContent": "ipsum",
-        "title": "ipsum",
-        "value": "ipsum",
-      },
-      Object {
-        "label": "hello",
-        "selected": true,
-        "text": "hello",
-        "textContent": "hello",
-        "title": "hello",
-        "value": "hello",
-      },
-      Object {
-        "label": "world",
-        "selected": false,
-        "text": "world",
-        "textContent": "world",
-        "title": "world",
-        "value": "world",
-      },
-    ],
-    "selected": Object {
-      "label": "hello",
-      "selected": true,
-      "text": "hello",
-      "textContent": "hello",
-      "title": "hello",
-      "value": "hello",
-    },
-    "selectedIndex": 2,
-    "type": "select-one",
-    "value": "hello",
-  },
+  "checked": true,
   "id": "test",
   "name": "test",
-  "options": Array [
-    Object {
-      "label": "lorem",
-      "selected": false,
-      "text": "lorem",
-      "textContent": "lorem",
-      "title": "lorem",
-      "value": "lorem",
-    },
-    Object {
-      "label": "ipsum",
-      "selected": false,
-      "text": "ipsum",
-      "textContent": "ipsum",
-      "title": "ipsum",
-      "value": "ipsum",
-    },
-    Object {
-      "label": "hello",
-      "selected": true,
-      "text": "hello",
-      "textContent": "hello",
-      "title": "hello",
-      "value": "hello",
-    },
-    Object {
-      "label": "world",
-      "selected": false,
-      "text": "world",
-      "textContent": "world",
-      "title": "world",
-      "value": "world",
-    },
+  "persist": [Function],
+  "selected": Array [
+    "hello",
+    "world",
   ],
+  "selectedIndex": 3,
+  "type": "select-multiple",
+  "value": "world",
+}
+`;
+
+exports[`Select Component should return an emulated onchange event: default emulated event 1`] = `
+Object {
+  "id": "test",
+  "name": "test",
   "persist": [Function],
   "selected": Object {
     "label": "hello",
@@ -2043,198 +614,7 @@ Object {
     "value": "hello",
   },
   "selectedIndex": 2,
-  "target": Object {
-    "id": "test",
-    "name": "test",
-    "options": Array [
-      Object {
-        "label": "lorem",
-        "selected": false,
-        "text": "lorem",
-        "textContent": "lorem",
-        "title": "lorem",
-        "value": "lorem",
-      },
-      Object {
-        "label": "ipsum",
-        "selected": false,
-        "text": "ipsum",
-        "textContent": "ipsum",
-        "title": "ipsum",
-        "value": "ipsum",
-      },
-      Object {
-        "label": "hello",
-        "selected": true,
-        "text": "hello",
-        "textContent": "hello",
-        "title": "hello",
-        "value": "hello",
-      },
-      Object {
-        "label": "world",
-        "selected": false,
-        "text": "world",
-        "textContent": "world",
-        "title": "world",
-        "value": "world",
-      },
-    ],
-    "selected": Object {
-      "label": "hello",
-      "selected": true,
-      "text": "hello",
-      "textContent": "hello",
-      "title": "hello",
-      "value": "hello",
-    },
-    "selectedIndex": 2,
-    "type": "select-one",
-    "value": "hello",
-  },
   "type": "select-one",
   "value": "hello",
-}
-`;
-
-exports[`Select Component should return an emulated onchange event: emulated event 2`] = `
-Object {
-  "checked": true,
-  "currentTarget": Object {
-    "checked": true,
-    "id": "test",
-    "name": "test",
-    "options": Array [
-      Object {
-        "label": "lorem",
-        "selected": false,
-        "text": "lorem",
-        "textContent": "lorem",
-        "title": "lorem",
-        "value": "lorem",
-      },
-      Object {
-        "label": "ipsum",
-        "selected": false,
-        "text": "ipsum",
-        "textContent": "ipsum",
-        "title": "ipsum",
-        "value": "ipsum",
-      },
-      Object {
-        "label": "hello",
-        "selected": true,
-        "text": "hello",
-        "textContent": "hello",
-        "title": "hello",
-        "value": "hello",
-      },
-      Object {
-        "label": "world",
-        "selected": true,
-        "text": "world",
-        "textContent": "world",
-        "title": "world",
-        "value": "world",
-      },
-    ],
-    "selected": Array [
-      "hello",
-      "world",
-    ],
-    "selectedIndex": 3,
-    "type": "select-multiple",
-    "value": "world",
-  },
-  "id": "test",
-  "name": "test",
-  "options": Array [
-    Object {
-      "label": "lorem",
-      "selected": false,
-      "text": "lorem",
-      "textContent": "lorem",
-      "title": "lorem",
-      "value": "lorem",
-    },
-    Object {
-      "label": "ipsum",
-      "selected": false,
-      "text": "ipsum",
-      "textContent": "ipsum",
-      "title": "ipsum",
-      "value": "ipsum",
-    },
-    Object {
-      "label": "hello",
-      "selected": true,
-      "text": "hello",
-      "textContent": "hello",
-      "title": "hello",
-      "value": "hello",
-    },
-    Object {
-      "label": "world",
-      "selected": true,
-      "text": "world",
-      "textContent": "world",
-      "title": "world",
-      "value": "world",
-    },
-  ],
-  "persist": [Function],
-  "selected": Array [
-    "hello",
-    "world",
-  ],
-  "selectedIndex": 3,
-  "target": Object {
-    "checked": true,
-    "id": "test",
-    "name": "test",
-    "options": Array [
-      Object {
-        "label": "lorem",
-        "selected": false,
-        "text": "lorem",
-        "textContent": "lorem",
-        "title": "lorem",
-        "value": "lorem",
-      },
-      Object {
-        "label": "ipsum",
-        "selected": false,
-        "text": "ipsum",
-        "textContent": "ipsum",
-        "title": "ipsum",
-        "value": "ipsum",
-      },
-      Object {
-        "label": "hello",
-        "selected": true,
-        "text": "hello",
-        "textContent": "hello",
-        "title": "hello",
-        "value": "hello",
-      },
-      Object {
-        "label": "world",
-        "selected": true,
-        "text": "world",
-        "textContent": "world",
-        "title": "world",
-        "value": "world",
-      },
-    ],
-    "selected": Array [
-      "hello",
-      "world",
-    ],
-    "selectedIndex": 3,
-    "type": "select-multiple",
-    "value": "world",
-  },
-  "type": "select-multiple",
-  "value": "world",
 }
 `;

--- a/src/components/form/__tests__/select.test.js
+++ b/src/components/form/__tests__/select.test.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
 import { SelectVariant } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons';
 import { Select, SelectDirection, SelectPosition } from '../select';
 
 describe('Select Component', () => {
-  it('should render a basic component', () => {
+  it('should render a basic component', async () => {
     const props = {
       id: 'test',
       options: [
@@ -14,11 +13,11 @@ describe('Select Component', () => {
       ]
     };
 
-    const component = mount(<Select {...props} />);
+    const component = await mountHookWrapper(<Select {...props} />);
     expect(component.render()).toMatchSnapshot('basic component');
   });
 
-  it('should render a checkbox select', () => {
+  it('should render a checkbox select', async () => {
     const props = {
       id: 'test',
       options: [
@@ -30,30 +29,30 @@ describe('Select Component', () => {
       placeholder: 'multiselect test'
     };
 
-    const component = mount(<Select {...props} />);
+    const component = await mountHookWrapper(<Select {...props} />);
     expect(component.render()).toMatchSnapshot('checkbox select');
   });
 
-  it('should allow alternate array and object options', () => {
+  it('should allow alternate array and object options', async () => {
     const props = {
       id: 'test',
       options: ['lorem', 'ipsum', 'hello', 'world'],
       selectedOptions: ['ipsum']
     };
 
-    const component = mount(<Select {...props} />);
+    const component = await mountHookWrapper(<Select {...props} />);
 
-    expect(component.render()).toMatchSnapshot('string array');
+    expect(component.state('options')).toMatchSnapshot('string array');
 
     component.setProps({
       options: { lorem: 'ipsum', hello: 'world' },
       selectedOptions: ['world', 'ipsum']
     });
 
-    expect(component.render()).toMatchSnapshot('key value object');
+    expect(component.state('options')).toMatchSnapshot('key value object');
   });
 
-  it('should allow plain objects as values, and be able to select options based on values within the object', () => {
+  it('should allow plain objects as values, and be able to select options based on values within the object', async () => {
     const props = {
       id: 'test',
       options: [
@@ -64,11 +63,11 @@ describe('Select Component', () => {
       selectedOptions: ['world']
     };
 
-    const component = mount(<Select {...props} />);
-    expect(component.render()).toMatchSnapshot('select when option values are objects');
+    const component = await mountHookWrapper(<Select {...props} />);
+    expect(component.state('options')).toMatchSnapshot('select when option values are objects');
   });
 
-  it('should allow selected options to match value or title', () => {
+  it('should allow selected options to match value or title', async () => {
     const props = {
       id: 'test',
       options: { lorem: 'ipsum', hello: 'world', dolor: 'set' },
@@ -76,45 +75,61 @@ describe('Select Component', () => {
       variant: SelectVariant.checkbox
     };
 
-    const component = mount(<Select {...props} />);
-    expect(component.render()).toMatchSnapshot('value or title match');
+    const component = await mountHookWrapper(<Select {...props} />);
+    expect(component.state('options')).toMatchSnapshot('value or title match');
   });
 
-  it('should return an emulated onchange event', done => {
+  it('should return an emulated onchange event', async () => {
+    const mockOnSelect = jest.fn();
     const props = {
       id: 'test',
       options: ['lorem', 'ipsum', 'hello', 'world'],
-      selectedOptions: ['ipsum']
+      selectedOptions: ['ipsum'],
+      onSelect: mockOnSelect
     };
 
-    props.onSelect = event => {
-      expect(event).toMatchSnapshot('emulated event');
-      done();
-    };
-
-    const component = mount(<Select {...props} />);
+    const component = await mountHookWrapper(<Select {...props} />);
     component.instance().onSelect({}, 'hello');
+    const {
+      currentTarget: helloCurrentTarget,
+      options: helloOptions,
+      target: helloTarget,
+      ...helloRest
+    } = mockOnSelect.mock.calls[0][0];
+    expect(mockOnSelect).toHaveBeenCalledTimes(1);
+    expect(helloRest).toMatchSnapshot('default emulated event');
 
     component.setProps({
       variant: SelectVariant.checkbox
     });
 
     component.instance().onSelect({}, 'world');
+    const {
+      currentTarget: worldCurrentTarget,
+      options: worldOptions,
+      target: worldTarget,
+      ...worldRest
+    } = mockOnSelect.mock.calls[1][0];
+    expect(mockOnSelect).toHaveBeenCalledTimes(2);
+    expect(worldRest).toMatchSnapshot('checkbox emulated event');
   });
 
-  it('should render an expanded select', () => {
+  it('should render an expanded select', async () => {
     const props = {
       id: 'test',
       options: ['lorem', 'ipsum', 'hello', 'world']
     };
 
-    const component = mount(<Select {...props} />);
-    component.find('button').simulate('click');
+    const component = await mountHookWrapper(<Select {...props} />, {
+      callback: ({ component: comp }) => {
+        comp.find('button').simulate('click');
+      }
+    });
 
-    expect(component).toMatchSnapshot('expanded');
+    expect(component.find('ul.pf-c-select__menu').find('button')).toMatchSnapshot('expanded');
   });
 
-  it('should disable toggle text', () => {
+  it('should disable toggle text', async () => {
     const props = {
       id: 'test',
       options: ['lorem', 'ipsum'],
@@ -122,31 +137,39 @@ describe('Select Component', () => {
       isToggleText: false
     };
 
-    const component = shallow(<Select {...props} />);
-    expect(component).toMatchSnapshot('disabled text');
+    const component = await shallowHookWrapper(<Select {...props} />);
+    expect(component.find('.curiosity-select-pf__no-toggle-text').props().className).toMatchSnapshot('disabled text');
   });
 
-  it('should allow alternate direction and position options', () => {
+  it('should allow alternate direction and position options', async () => {
     const props = {
       id: 'test',
       options: ['lorem', 'ipsum'],
       direction: SelectDirection.up
     };
 
-    const component = shallow(<Select {...props} />);
-    expect(component).toMatchSnapshot('direction up');
+    const component = await shallowHookWrapper(<Select {...props} />);
+    const upLeftProps = component.find('.curiosity-select-pf').props();
+    expect({
+      direction: upLeftProps.direction,
+      className: upLeftProps.className
+    }).toMatchSnapshot('direction up');
 
     component.setProps({ direction: SelectDirection.down, position: SelectPosition.right });
-    expect(component).toMatchSnapshot('position right');
+    const downRightProps = component.find('.curiosity-select-pf').props();
+    expect({
+      direction: downRightProps.direction,
+      className: downRightProps.className
+    }).toMatchSnapshot('position right');
   });
 
-  it('should allow being disabled with missing options', () => {
+  it('should allow being disabled with missing options', async () => {
     const props = {
       id: 'test',
       options: undefined
     };
 
-    const component = shallow(<Select {...props} />);
+    const component = await shallowHookWrapper(<Select {...props} />);
     expect(component).toMatchSnapshot('no options');
 
     component.setProps({
@@ -164,13 +187,13 @@ describe('Select Component', () => {
     expect(component).toMatchSnapshot('options, but disabled');
   });
 
-  it('should allow data- props', () => {
+  it('should allow data- props', async () => {
     const props = {
       'data-lorem': 'ipsum',
       'data-dolor-sit': 'dolor sit'
     };
 
-    const component = mount(<Select {...props} />);
+    const component = await mountHookWrapper(<Select {...props} />);
     expect(component.props()).toMatchSnapshot('data- attributes');
   });
 });

--- a/src/components/form/select.js
+++ b/src/components/form/select.js
@@ -254,33 +254,36 @@ class Select extends React.Component {
      * https://github.com/cssnano/cssnano/issues/1051
      */
     return (
-      <PfSelect
-        className={`curiosity-select${(!isToggleText && '__no-toggle-text') || ''} ${
-          (position === DropdownPosition.right && 'curiosity-select__position-right') || ''
-        } ${className}`}
-        variant={variant}
-        aria-label={ariaLabel}
-        onToggle={this.onToggle}
-        onSelect={this.onSelect}
-        selections={selected}
-        isOpen={isExpanded}
-        toggleIcon={toggleIcon}
-        placeholderText={placeholder}
-        ref={this.selectField}
-        {...pfSelectOptions}
-      >
-        {(options &&
-          options.map(option => (
-            <PfSelectOption
-              key={window.btoa(`${option.title}-${option.value}`)}
-              id={window.btoa(`${option.title}-${option.value}`)}
-              value={option.title}
-              data-value={(_isPlainObject(option.value) && JSON.stringify([option.value])) || option.value}
-              data-title={option.title}
-            />
-          ))) ||
-          []}
-      </PfSelect>
+      <div className="curiosity-select">
+        <PfSelect
+          menuAppendTo="parent"
+          className={`curiosity-select-pf${(!isToggleText && '__no-toggle-text') || ''} ${
+            (position === DropdownPosition.right && 'curiosity-select-pf__position-right') || ''
+          } ${className}`}
+          variant={variant}
+          aria-label={ariaLabel}
+          onToggle={this.onToggle}
+          onSelect={this.onSelect}
+          selections={selected}
+          isOpen={isExpanded}
+          toggleIcon={toggleIcon}
+          placeholderText={placeholder}
+          ref={this.selectField}
+          {...pfSelectOptions}
+        >
+          {(options &&
+            options.map(option => (
+              <PfSelectOption
+                key={window.btoa(`${option.title}-${option.value}`)}
+                id={window.btoa(`${option.title}-${option.value}`)}
+                value={option.title}
+                data-value={(_isPlainObject(option.value) && JSON.stringify([option.value])) || option.value}
+                data-title={option.title}
+              />
+            ))) ||
+            []}
+        </PfSelect>
+      </div>
     );
   }
 }

--- a/src/components/form/select.js
+++ b/src/components/form/select.js
@@ -140,6 +140,9 @@ class Select extends React.Component {
   // FixMe: attributes filtered on PF select component. allow data- attributes
   /**
    * Format options into a consumable array of objects format.
+   * Note: It is understood that for line 151'ish around "updatedOptions" we dump all values regardless
+   * of whether they are plain objects, or not, into updatedOptions. This has been done for speed only,
+   * one less check to perform.
    */
   formatOptions() {
     const { current: domElement = {} } = this.selectField;

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -106,8 +106,18 @@ global.mountHookComponent = async (component, options = {}) => {
     mountedComponent = mount(component, options);
   });
   mountedComponent?.update();
+
+  if (typeof options?.callback === 'function') {
+    await act(async () => {
+      await options?.callback({ component: mountedComponent });
+    });
+    mountedComponent?.update();
+  }
+
   return mountedComponent;
 };
+
+global.mountHookWrapper = global.mountHookComponent;
 
 /**
  * Enzyme for components using hooks.
@@ -123,8 +133,18 @@ global.shallowHookComponent = async (component, options = {}) => {
     mountedComponent = shallow(component, options);
   });
   mountedComponent?.update();
+
+  if (typeof options?.callback === 'function') {
+    await act(async () => {
+      await options?.callback({ component: mountedComponent });
+    });
+    mountedComponent?.update();
+  }
+
   return mountedComponent;
 };
+
+global.shallowHookWrapper = global.shallowHookComponent;
 
 /**
  * Fire a hook, return the result.

--- a/src/styles/_form.scss
+++ b/src/styles/_form.scss
@@ -1,15 +1,20 @@
-.curiosity-select__no-toggle-text {
-  span.pf-c-select__toggle-arrow {
-    margin-left: var(--pf-c-select__toggle-arrow--MarginRight);
+.curiosity-select {
+  position: relative;
+  display: inline-block;
+
+  &-pf__no-toggle-text {
+    span.pf-c-select__toggle-arrow {
+      margin-left: var(--pf-c-select__toggle-arrow--MarginRight);
+    }
+
+    span.pf-c-select__toggle-text {
+      display: none;
+    }
   }
 
-  span.pf-c-select__toggle-text {
-    display: none;
-  }
-}
-
-.curiosity-select__position-right {
-  > .pf-c-select__menu {
-    right: 0
+  &-pf__position-right {
+    > .pf-c-select__menu {
+      right: 0;
+    }
   }
 }

--- a/src/styles/_usage-graph.scss
+++ b/src/styles/_usage-graph.scss
@@ -9,24 +9,32 @@
       }
 
       &__title {
+        flex-grow: 1;
         padding: 0;
+        padding-right: var(--pf-c-card__actions--PaddingLeft);
       }
 
       &__actions {
+        display: flex;
         margin: inherit;
+        margin-left: auto;
+        padding-left: 0;
+
+        @media (max-width: $pf-global--breakpoint--sm) {
+          margin-left: inherit;
+        }
+
+        & > .curiosity-select {
+          width: auto;
+        }
       }
     }
 
     &__total {
-      min-width: 175px;
-      padding-left: var(--pf-global--spacer--sm);
       padding-right: var(--pf-global--spacer--sm);
       text-align: right;
       white-space: normal;
-
-      @media (min-width: $pf-global--breakpoint--sm) {
-        white-space: nowrap;
-      }
+      word-break: break-word;
     }
 
     &__legend-item {

--- a/tests/__snapshots__/code.test.js.snap
+++ b/tests/__snapshots__/code.test.js.snap
@@ -6,6 +6,6 @@ Array [
   "components/inventorySubscriptions/inventorySubscriptions.js:60:        console.warn(\`Sorting can only be performed on select fields, confirm field \${id} is allowed.\`);",
   "redux/common/reduxHelpers.js:250:    console.error(\`Error: Property \${prop} does not exist within the passed state.\`, state);",
   "redux/common/reduxHelpers.js:254:    console.warn(\`Warning: Property \${prop} does not exist within the passed initialState.\`, initialState);",
-  "setupTests.js:210:  console.error = (message, ...args) => {",
+  "setupTests.js:230:  console.error = (message, ...args) => {",
 ]
 `;


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(graphCard): ent-3813 header styling for total display
- fix(select): focused unit testing

### Notes
- ~**THERE IS AN UNINTENDED SIDE-EFFECT THAT HAPPENS WITH THIS UPDATE**. The more we attempt to fix this the worse it gets, see the below animation. PF select we use is right align, apparently it has issues in the Chrome browser due to this fix. We have to debug this accordingly, and we need to continue the push forward. The last commit on CI for ENT-3813 will be removed temporarily while this work happens.~ @mirekdlugosz 
- ~once approved/verified this will be squashed with the prior related commit~ @mirekdlugosz
- There is an issue around using the "popper" package within PF, we've added updates to compensate
- We've gone ahead and squashed the `overflow styling for header total display` commit from #738 into this PR
- at **around** 580px browser width the CSS **attempts** to left align the contents of "total core hours used" and the select/dropdown lists

<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm that the OpenShift Console and OpenShift Dedicated "total core hours used" display behaves by attempting to have the copy on a single line, and only falling back to multi-line when the space is limited

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
### Corrected issue with PF Select

https://user-images.githubusercontent.com/3761375/126174263-22611218-5ce1-4990-afa9-7a530d82ee7d.mp4



<!-- Append a demo/screenshot/animated gif of the solution -->
#### 580'ish pixels
![Screen Shot 2021-07-16 at 3 11 19 PM](https://user-images.githubusercontent.com/3761375/125998119-caf326dc-0a9d-40ab-9a82-0ac41584303a.png)

#### Multiple sizes and behavior
![Screen Shot 2021-07-16 at 3 05 41 PM](https://user-images.githubusercontent.com/3761375/125998156-1541f342-1f1a-4826-9722-c77aef2299d8.png)
![Screen Shot 2021-07-16 at 3 05 29 PM](https://user-images.githubusercontent.com/3761375/125998169-9a740b2b-56e2-4ce5-ac10-6b7b76959000.png)
![Screen Shot 2021-07-16 at 3 05 11 PM](https://user-images.githubusercontent.com/3761375/125998196-32158fda-643a-408f-ba85-c8fdfacdaed4.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-3813
#738 