### PR TITLE
build(dev,proxy): ent-3643 activate chrome2 for local run

### DIFF
--- a/.env
+++ b/.env
@@ -31,9 +31,6 @@ REACT_APP_CONFIG_SERVICE_LOCALES=${UI_DEPLOY_PATH_PREFIX}/apps/subscriptions/loc
 REACT_APP_CONFIG_SERVICE_LOCALES_PATH=${UI_DEPLOY_PATH_PREFIX}/apps/subscriptions/locales/{{lng}}.json
 REACT_APP_CONFIG_SERVICE_LOCALES_EXPIRE=604800000
 
-REACT_APP_INCLUDE_CONTENT_HEADER=<esi:include src="${UI_DEPLOY_PATH_PREFIX}/apps/chrome/snippets/head.html" />
-REACT_APP_INCLUDE_CONTENT_BODY=<esi:include src="${UI_DEPLOY_PATH_PREFIX}/apps/chrome/snippets/body.html" />
-
 REACT_APP_SERVICES_RHSM_VERSION=/api/rhsm-subscriptions/v1/version
 REACT_APP_SERVICES_RHSM_REPORT=/api/rhsm-subscriptions/v1/tally/products/
 REACT_APP_SERVICES_RHSM_CAPACITY=/api/rhsm-subscriptions/v1/capacity/products/

--- a/.env.development
+++ b/.env.development
@@ -1,8 +1,7 @@
 DEV_PORT=3000
-DEV_BRANCH=prod-stable
+DEV_BRANCH=ci-beta
 
 REACT_APP_ENV=development
-REACT_APP_UI_DEPLOY_PATH_PREFIX=/beta
 
 REACT_APP_CONFIG_SERVICE_LOCALES=/locales/locales.json
 REACT_APP_CONFIG_SERVICE_LOCALES_PATH=/locales/{{lng}}.json

--- a/.env.proxy
+++ b/.env.proxy
@@ -1,5 +1,5 @@
 DEV_PORT=443
-DEV_BRANCH=ci-stable
+DEV_BRANCH=ci-beta
 
 REACT_APP_ENV=review
 

--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 #
 #
-# Release a branch
+# Release a branch. APP_BUILD_DIR should be updated at the Travis configuration level.
 release()
 {
   local DEPLOY_BRANCH=$1
+  local BUILD_DIR=$APP_BUILD_DIR
 
   printf "${YELLOW}PUSHING ${DEPLOY_BRANCH}${NOCOLOR}\n"
-  rm -rf ./dist/.git
+  rm -rf "./${BUILD_DIR}/.git"
   .travis/release.sh "${DEPLOY_BRANCH}"
   printf "${GREEN}COMPLETED ${DEPLOY_BRANCH}${NOCOLOR}\n"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,7 @@ It is required that all work is handled through GitHub's fork and pull workflow.
 ### Releases and Tagging
 1. Merging a PR into `master` is considered production ready.
 1. Merging a PR into `master` doesn't require tagging and [CHANGELOG.md](./CHANGELOG.md) updates.
+1. Running `$ yarn release` after commits are merged into `master` generates the release commit and [CHANGELOG.md](./CHANGELOG.md). You may need to update/pull tags prior to running this command. This commit should be pushed towards `master`. This release commit is currently used as a purposeful block and may be automated in the future. [The commit message is recognized in the release script](./.travis/custom_release.sh#L41). This commit format controls when files are pushed towards production stable, and gives development a fallback when something goes wrong.
 1. Tagging and `CHANGELOG.md` updates should be coordinated against a consistent release cycle, and can take place at an independent time.
 1. Tagging should make use of semver.
 1. Manipulating tags against commits directly should be avoided in favor of a semantic version increment, iteration.

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -13,7 +13,7 @@ const { config: webpackConfig, plugins } = config({
   env: (/(prod|qa|ci)(-stable|-beta)$/.test(DEV_BRANCH) && DEV_BRANCH) || 'prod-stable',
   port: Number.parseInt(DEV_PORT, 10),
   rootFolder: _BUILD_RELATIVE_DIRNAME,
-  skipChrome2: true,
+  skipChrome2: false,
   standalone: true,
   useProxy: false,
   htmlPlugin: setHtmlPlugin(),

--- a/config/webpack.proxy.config.js
+++ b/config/webpack.proxy.config.js
@@ -21,7 +21,7 @@ const { config: webpackConfig, plugins } = config({
   port: Number.parseInt(DEV_PORT, 10),
   rootFolder: _BUILD_RELATIVE_DIRNAME,
   routes: setProxyRoutes({ DEV_PORT, BETA_PREFIX }),
-  skipChrome2: true,
+  skipChrome2: false,
   standalone: false,
   useCloud: (!/prod-(beta|stable)$/.test(DEV_BRANCH) && true) ?? false,
   useProxy: true,


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- build(dev,proxy): ent-3643 activate chrome2 for local run

### Notes
- activates chrome2 for local run, dependent on https://github.com/RedHatInsights/cloud-services-config/pull/841
- Setting the default branches for proxy and local development towards `ci-beta`. Originally we had them set towards environments where the Curiosity Chrome 2 implementation hasn't happened yet. These can be altered at any future point.
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. confirm Subscriptions and product facets display and function


### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm Subscriptions and product facets display and function

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-3643
#756 
#753 