### PR TITLE
fix(productView): ent-4247 disable take a tour header button

### DIFF
--- a/src/components/pageLayout/pageHeader.js
+++ b/src/components/pageLayout/pageHeader.js
@@ -7,6 +7,10 @@ import { helpers } from '../../common';
 import { translate } from '../i18n/i18n';
 
 /**
+ * ToDo: Review removing the "includeTour" prop and associated button code.
+ * ...instead of disabling it, ENT-4247
+ */
+/**
  * Render a platform page header.
  *
  * @param {object} props

--- a/src/components/productView/__tests__/__snapshots__/productView.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productView.test.js.snap
@@ -5,7 +5,7 @@ exports[`ProductView Component should allow custom product views: custom graphCa
   className=""
 >
   <PageHeader
-    includeTour={true}
+    includeTour={false}
     productLabel="lorem ipsum product label"
     t={[Function]}
   >
@@ -138,7 +138,7 @@ exports[`ProductView Component should allow custom product views: custom toolbar
   className=""
 >
   <PageHeader
-    includeTour={true}
+    includeTour={false}
     productLabel="lorem ipsum product label"
     t={[Function]}
   >
@@ -215,7 +215,7 @@ exports[`ProductView Component should allow custom product views: custom toolbar
   className=""
 >
   <PageHeader
-    includeTour={true}
+    includeTour={false}
     productLabel="lorem ipsum product label"
     t={[Function]}
   >
@@ -292,7 +292,7 @@ exports[`ProductView Component should render a non-connected component: non-conn
   className=""
 >
   <PageHeader
-    includeTour={true}
+    includeTour={false}
     productLabel="lorem ipsum product label"
     t={[Function]}
   >

--- a/src/components/productView/__tests__/__snapshots__/productViewMissing.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productViewMissing.test.js.snap
@@ -21,7 +21,7 @@ exports[`ProductViewMissing Component should render a non-connected component: n
   className="curiosity-missing-view"
 >
   <PageHeader
-    includeTour={true}
+    includeTour={false}
     productLabel="missing"
     t={[Function]}
   >
@@ -151,7 +151,7 @@ exports[`ProductViewMissing Component should render a predictable set of product
   className="curiosity-missing-view"
 >
   <PageHeader
-    includeTour={true}
+    includeTour={false}
     productLabel="missing"
     t={[Function]}
   >

--- a/src/components/productView/__tests__/__snapshots__/productViewOpenShiftContainer.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productViewOpenShiftContainer.test.js.snap
@@ -5,7 +5,7 @@ exports[`ProductViewOpenShiftContainer Component should render a non-connected c
   className=""
 >
   <PageHeader
-    includeTour={true}
+    includeTour={false}
     productLabel="lorem ipsum product label"
     t={[Function]}
   >

--- a/src/components/productView/productView.js
+++ b/src/components/productView/productView.js
@@ -109,7 +109,7 @@ const ProductView = ({ routeDetail, t, toolbarGraph, toolbarGraphDescription, to
 
   return (
     <PageLayout>
-      <PageHeader productLabel={productLabel} includeTour>
+      <PageHeader productLabel={productLabel}>
         {t(`curiosity-view.title`, { appName: helpers.UI_DISPLAY_NAME, context: productLabel })}
       </PageHeader>
       <PageMessages>

--- a/src/components/productView/productViewMissing.js
+++ b/src/components/productView/productViewMissing.js
@@ -49,9 +49,7 @@ const ProductViewMissing = ({ availableProductsRedirect, t }) => {
 
   return (
     <PageLayout className="curiosity-missing-view">
-      <PageHeader productLabel="missing" includeTour>
-        {t(`curiosity-view.title`, { appName: helpers.UI_DISPLAY_NAME })}
-      </PageHeader>
+      <PageHeader productLabel="missing">{t(`curiosity-view.title`, { appName: helpers.UI_DISPLAY_NAME })}</PageHeader>
       <PageSection isFilled>
         <Gallery hasGutter>
           {availableProducts.map(product => (

--- a/src/components/productView/productViewOpenShiftContainer.js
+++ b/src/components/productView/productViewOpenShiftContainer.js
@@ -162,7 +162,7 @@ const ProductViewOpenShiftContainer = ({ routeDetail, t }) => {
 
   return (
     <PageLayout>
-      <PageHeader productLabel={viewProductLabel} includeTour>
+      <PageHeader productLabel={viewProductLabel}>
         {t(`curiosity-view.title`, { appName: helpers.UI_DISPLAY_NAME, context: viewProductLabel })}
       </PageHeader>
       <PageColumns>{productConfig.map(config => renderProduct(config, uomValue))}</PageColumns>


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
fix(productView): ent-4247 disable take a tour header button

### Notes
- Issues with Pendo being applied after page load combined with a UX/design request to remove the header button means... we've disabled the "Take a tour" button from all existing products. The ability to display the button is still there and will be targeted for removal in a subsequent release.
   - @mirekdlugosz 

<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm all products **NO longer have** the "Take a tour" button within the page view header

![Screen Shot 2021-08-23 at 4 36 24 PM](https://user-images.githubusercontent.com/3761375/130516000-be67ffa8-1bac-471c-82af-5e8f4e47f857.png)


<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-4247