### PR TITLE
fix(chartHelpers): ent-4135 custom x, y values, filter NaN and undefined

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
       - dependency-name: "@patternfly/*"
       - dependency-name: "@redhat-cloud-services/frontend*"
       - dependency-name: "*i18next*"
-      - dependency-name: "victory-*"
+      - dependency-name: "victory*"
     labels:
       - "build"
 

--- a/src/components/chart/__tests__/__snapshots__/chartHelpers.test.js.snap
+++ b/src/components/chart/__tests__/__snapshots__/chartHelpers.test.js.snap
@@ -56,6 +56,21 @@ Object {
 }
 `;
 
+exports[`ChartHelpers should generate element props: custom valueFormats 1`] = `
+Object {
+  "xValueNaN": 0,
+  "xValueNull": null,
+  "xValueNumber": 0,
+  "xValueString": "lorem",
+  "xValueUndefined": 0,
+  "yValueNaN": 0,
+  "yValueNull": null,
+  "yValueNumber": 0,
+  "yValueString": "ipsum",
+  "yValueUndefined": 0,
+}
+`;
+
 exports[`ChartHelpers should generate element props: props 1`] = `
 Object {
   "elements": Array [

--- a/src/components/chart/__tests__/chartHelpers.test.js
+++ b/src/components/chart/__tests__/chartHelpers.test.js
@@ -110,6 +110,61 @@ describe('ChartHelpers', () => {
     };
 
     expect(chartHelpers.generateElementsProps(options)).toMatchSnapshot('props');
+
+    const customOptions = {
+      dataSets: [
+        {
+          id: 'lorem',
+          data: [
+            { x: 0, y: 10 },
+            { x: 1, y: 10 },
+            { x: 2, y: 10 },
+            { x: 3, y: 10 },
+            { x: 4, y: 10 },
+            { x: 5, y: 10 }
+          ]
+        }
+      ]
+    };
+
+    const { x: xValueNumber, y: yValueNumber } = chartHelpers.generateElementsProps({
+      ...customOptions,
+      xValueFormat: () => 0,
+      yValueFormat: () => 0
+    })?.elementsById.lorem.props;
+    const { x: xValueNaN, y: yValueNaN } = chartHelpers.generateElementsProps({
+      ...customOptions,
+      xValueFormat: () => Number.NaN,
+      yValueFormat: () => Number.NaN
+    })?.elementsById.lorem.props;
+    const { x: xValueUndefined, y: yValueUndefined } = chartHelpers.generateElementsProps({
+      ...customOptions,
+      xValueFormat: () => undefined,
+      yValueFormat: () => undefined
+    })?.elementsById.lorem.props;
+    const { x: xValueNull, y: yValueNull } = chartHelpers.generateElementsProps({
+      ...customOptions,
+      xValueFormat: () => null,
+      yValueFormat: () => null
+    })?.elementsById.lorem.props;
+    const { x: xValueString, y: yValueString } = chartHelpers.generateElementsProps({
+      ...customOptions,
+      xValueFormat: () => 'lorem',
+      yValueFormat: () => 'ipsum'
+    })?.elementsById.lorem.props;
+
+    expect({
+      xValueNumber: xValueNumber(),
+      yValueNumber: yValueNumber(),
+      xValueNaN: xValueNaN(),
+      yValueNaN: yValueNaN(),
+      xValueUndefined: xValueUndefined(),
+      yValueUndefined: yValueUndefined(),
+      xValueNull: xValueNull(),
+      yValueNull: yValueNull(),
+      xValueString: xValueString(),
+      yValueString: yValueString()
+    }).toMatchSnapshot('custom valueFormats');
   });
 
   it('should generate tooltip data/content', () => {

--- a/src/components/chart/chartHelpers.js
+++ b/src/components/chart/chartHelpers.js
@@ -141,16 +141,28 @@ const generateElementsProps = ({ dataSets = [], maxX, maxY, xValueFormat, yValue
         style: { ...(dataSet.style || {}), ...dataColorStroke },
         themeColor: dataSet.themeColor,
         themeVariant: dataSet.themeVariant,
-        x: (xValueFormat && (datum => xValueFormat({ datum, maxX }))) || undefined,
-        y:
-          (yValueFormat &&
-            (datum =>
-              yValueFormat({
-                datum,
-                isMultiAxis: typeof maxY !== 'number',
-                maxY: typeof maxY === 'number' ? maxY : maxY?.[dataSet.id]
-              }))) ||
-          (datum => (typeof maxY === 'number' ? datum.y : datum.y / maxY?.[dataSet.id]))
+        x:
+          (xValueFormat &&
+            (datum => {
+              const xValue = xValueFormat({ datum, maxX });
+              return xValue === undefined || Number.isNaN(xValue) ? 0 : xValue;
+            })) ||
+          undefined,
+        y: datum => {
+          let yValue;
+
+          if (yValueFormat) {
+            yValue = yValueFormat({
+              datum,
+              isMultiAxis: typeof maxY !== 'number',
+              maxY: typeof maxY === 'number' ? maxY : maxY?.[dataSet.id]
+            });
+          } else {
+            yValue = typeof maxY === 'number' ? datum.y : datum.y / maxY?.[dataSet.id];
+          }
+
+          return yValue === undefined || Number.isNaN(yValue) ? 0 : yValue;
+        }
       };
 
       const props = { ...chartElementProps };


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(chartHelpers): ent-4135 custom x, y values, filter NaN and undefined
- chore(build): dependabot ignore victory packages

### Notes
- custom x and y formatting caused a non-blocking error when returning `NaN` or `undefined`. this fix filters those values out and converts them to zero. `null` is still a valid return value
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. review the test update to make sure it's covering the scenarios for number, string, undefined, and null
1. tests should come back clean

<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. navigate to OpenShift Dedicated metrics
1. confirm that viewing a "dual axis" graph under OpenShift Dedicated metrics or OpenShift metrics no longer throws a console error on graphs that have zero as there max y axis value


### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. navigate to OpenShift Dedicated metrics
1. confirm that viewing a "dual axis" graph under OpenShift Dedicated metrics or OpenShift metrics no longer throws a console error on graphs that have zero as there max y axis value

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-4135