### PR TITLE
fix(productView): ent-3352 subs table active check

### DIFF
--- a/src/components/productView/__tests__/__snapshots__/productView.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productView.test.js.snap
@@ -116,12 +116,100 @@ exports[`ProductView Component should allow custom product views: custom graphCa
           viewId="dolor sit"
         />
       </InventoryTab>
+    </Connect(InventoryTabs)>
+  </PageSection>
+</PageLayout>
+`;
+
+exports[`ProductView Component should allow custom product views: custom tabs, subscriptions table 1`] = `
+<PageLayout
+  className=""
+>
+  <PageHeader
+    includeTour={false}
+    productLabel="lorem ipsum product label"
+    t={[Function]}
+  >
+    t(curiosity-view.title, {"appName":"Subscriptions","context":"lorem ipsum product label"})
+  </PageHeader>
+  <PageMessages
+    className=""
+  >
+    <Connect(BannerMessages)
+      productId="lorem ipsum"
+      query={Object {}}
+      viewId="dolor sit"
+    />
+  </PageMessages>
+  <PageToolbar
+    className=""
+  >
+    dolor sit
+  </PageToolbar>
+  <PageSection
+    className=""
+  >
+    <Connect(GraphCard)
+      cardTitle={
+        <React.Fragment>
+          t(curiosity-graph.cardHeading, {"context":"lorem ipsum"})
+          <Tooltip
+            content={
+              <p>
+                t(curiosity-graph.cardHeadingDescription, {"context":"lorem ipsum"})
+              </p>
+            }
+            distance={5}
+            enableFlip={false}
+            entryDelay={100}
+            exitDelay={0}
+            position="top"
+          >
+            <sup
+              className="curiosity-icon__info"
+            >
+              <InfoCircleIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+              />
+            </sup>
+          </Tooltip>
+        </React.Fragment>
+      }
+      key="graph_lorem ipsum"
+      productId="lorem ipsum"
+      productLabel="lorem ipsum product label"
+      query={Object {}}
+      viewId="dolor sit"
+    />
+  </PageSection>
+  <PageSection
+    className=""
+  >
+    <Connect(InventoryTabs)
+      key="inventory_lorem ipsum"
+      productId="lorem ipsum"
+    >
+      <InventoryTab
+        active={false}
+        key="inventory_hosts_lorem ipsum"
+        title="t(curiosity-inventory.tabHosts, {\\"context\\":\\"noInstances_lorem ipsum\\"})"
+      >
+        <Connect(InventoryList)
+          key="inv_lorem ipsum"
+          productId="lorem ipsum"
+          query={Object {}}
+          viewId="dolor sit"
+        />
+      </InventoryTab>
       <InventoryTab
         active={false}
         key="inventory_subs_lorem ipsum"
         title="t(curiosity-inventory.tabSubscriptions, {\\"context\\":\\"lorem ipsum\\"})"
       >
         <Connect(InventorySubscriptions)
+          filterInventoryData={Array []}
           key="subs_lorem ipsum"
           productId="lorem ipsum"
           query={Object {}}
@@ -193,18 +281,6 @@ exports[`ProductView Component should allow custom product views: custom toolbar
           viewId="dolor sit"
         />
       </InventoryTab>
-      <InventoryTab
-        active={false}
-        key="inventory_subs_lorem ipsum"
-        title="t(curiosity-inventory.tabSubscriptions, {\\"context\\":\\"lorem ipsum\\"})"
-      >
-        <Connect(InventorySubscriptions)
-          key="subs_lorem ipsum"
-          productId="lorem ipsum"
-          query={Object {}}
-          viewId="dolor sit"
-        />
-      </InventoryTab>
     </Connect(InventoryTabs)>
   </PageSection>
 </PageLayout>
@@ -265,18 +341,6 @@ exports[`ProductView Component should allow custom product views: custom toolbar
       >
         <Connect(InventoryList)
           key="inv_lorem ipsum"
-          productId="lorem ipsum"
-          query={Object {}}
-          viewId="dolor sit"
-        />
-      </InventoryTab>
-      <InventoryTab
-        active={false}
-        key="inventory_subs_lorem ipsum"
-        title="t(curiosity-inventory.tabSubscriptions, {\\"context\\":\\"lorem ipsum\\"})"
-      >
-        <Connect(InventorySubscriptions)
-          key="subs_lorem ipsum"
           productId="lorem ipsum"
           query={Object {}}
           viewId="dolor sit"
@@ -376,18 +440,6 @@ exports[`ProductView Component should render a non-connected component: non-conn
       >
         <Connect(InventoryList)
           key="inv_lorem ipsum"
-          productId="lorem ipsum"
-          query={Object {}}
-          viewId="dolor sit"
-        />
-      </InventoryTab>
-      <InventoryTab
-        active={false}
-        key="inventory_subs_lorem ipsum"
-        title="t(curiosity-inventory.tabSubscriptions, {\\"context\\":\\"lorem ipsum\\"})"
-      >
-        <Connect(InventorySubscriptions)
-          key="subs_lorem ipsum"
           productId="lorem ipsum"
           query={Object {}}
           viewId="dolor sit"

--- a/src/components/productView/__tests__/productView.test.js
+++ b/src/components/productView/__tests__/productView.test.js
@@ -61,5 +61,15 @@ describe('ProductView Component', () => {
     });
 
     expect(component).toMatchSnapshot('custom toolbar, toolbarProduct');
+
+    component.setProps({
+      ...props,
+      routeDetail: {
+        ...props.routeDetail,
+        productConfig: [{ lorem: 'ipsum', initialSubscriptionsInventoryFilters: [] }]
+      }
+    });
+
+    expect(component).toMatchSnapshot('custom tabs, subscriptions table');
   });
 });

--- a/src/components/productView/productView.js
+++ b/src/components/productView/productView.js
@@ -162,18 +162,20 @@ const ProductView = ({ routeDetail, t, toolbarGraph, toolbarGraphDescription, to
               viewId={viewId}
             />
           </InventoryTab>
-          <InventoryTab
-            key={`inventory_subs_${productId}`}
-            title={t('curiosity-inventory.tabSubscriptions', { context: productId })}
-          >
-            <ConnectedInventorySubscriptions
-              key={`subs_${productId}`}
-              filterInventoryData={initialSubscriptionsInventoryFilters}
-              productId={productId}
-              query={initialInventorySubscriptionsQuery}
-              viewId={viewId}
-            />
-          </InventoryTab>
+          {initialSubscriptionsInventoryFilters && (
+            <InventoryTab
+              key={`inventory_subs_${productId}`}
+              title={t('curiosity-inventory.tabSubscriptions', { context: productId })}
+            >
+              <ConnectedInventorySubscriptions
+                key={`subs_${productId}`}
+                filterInventoryData={initialSubscriptionsInventoryFilters}
+                productId={productId}
+                query={initialInventorySubscriptionsQuery}
+                viewId={viewId}
+              />
+            </InventoryTab>
+          )}
         </InventoryTabs>
       </PageSection>
     </PageLayout>


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(productView): ent-3352 subs table active check

### Notes
- Minor logic adjustment to make sure products such as OpenShift Dedicated on demand don't display the current subs table
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. navigate towards https://ci.foo.redhat.com/beta/openshift/subscriptions/openshift-dedicated and confirm the current subs table no longer displays

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-3352 
ent-4376