### PR TITLE
fix(graphCardMetricTotals): ent-4366 data-test attributes

### DIFF
--- a/src/components/graphCard/__tests__/__snapshots__/graphCardMetricTotals.test.js.snap
+++ b/src/components/graphCard/__tests__/__snapshots__/graphCardMetricTotals.test.js.snap
@@ -26,6 +26,7 @@ exports[`GraphCardMetricTotals Component should handle multiple display states: 
     >
       <Card
         className="curiosity-usage-graph__totals-column-card blur"
+        data-test="graphDailyTotalCard"
       >
         <CardTitle>
           t(curiosity-graph.cardHeadingMetric_dailyTotal, {"context":""})
@@ -55,6 +56,7 @@ exports[`GraphCardMetricTotals Component should handle multiple display states: 
       </Card>
       <Card
         className="curiosity-usage-graph__totals-column-card blur"
+        data-test="graphMonthlyTotalCard"
       >
         <CardTitle>
           t(curiosity-graph.cardHeadingMetric_monthlyTotal, {"context":""})
@@ -134,6 +136,7 @@ exports[`GraphCardMetricTotals Component should handle multiple display states: 
     >
       <Card
         className="curiosity-usage-graph__totals-column-card "
+        data-test="graphDailyTotalCard"
       >
         <CardTitle>
           t(curiosity-graph.cardHeadingMetric_dailyTotal, {"context":""})
@@ -165,6 +168,7 @@ exports[`GraphCardMetricTotals Component should handle multiple display states: 
       </Card>
       <Card
         className="curiosity-usage-graph__totals-column-card "
+        data-test="graphMonthlyTotalCard"
       >
         <CardTitle>
           t(curiosity-graph.cardHeadingMetric_monthlyTotal, {"context":""})
@@ -246,6 +250,7 @@ exports[`GraphCardMetricTotals Component should handle multiple display states: 
     >
       <Card
         className="curiosity-usage-graph__totals-column-card "
+        data-test="graphDailyTotalCard"
       >
         <CardTitle>
           t(curiosity-graph.cardHeadingMetric_dailyTotal, {"context":""})
@@ -285,6 +290,7 @@ exports[`GraphCardMetricTotals Component should handle multiple display states: 
       </Card>
       <Card
         className="curiosity-usage-graph__totals-column-card "
+        data-test="graphMonthlyTotalCard"
       >
         <CardTitle>
           t(curiosity-graph.cardHeadingMetric_monthlyTotal, {"context":""})
@@ -374,6 +380,7 @@ exports[`GraphCardMetricTotals Component should render a basic component: basic 
     >
       <Card
         className="curiosity-usage-graph__totals-column-card blur"
+        data-test="graphDailyTotalCard"
       >
         <CardTitle>
           t(curiosity-graph.cardHeadingMetric_dailyTotal, {"context":""})
@@ -403,6 +410,7 @@ exports[`GraphCardMetricTotals Component should render a basic component: basic 
       </Card>
       <Card
         className="curiosity-usage-graph__totals-column-card blur"
+        data-test="graphMonthlyTotalCard"
       >
         <CardTitle>
           t(curiosity-graph.cardHeadingMetric_monthlyTotal, {"context":""})

--- a/src/components/graphCard/graphCardMetricTotals.js
+++ b/src/components/graphCard/graphCardMetricTotals.js
@@ -49,7 +49,10 @@ const GraphCardMetricTotals = ({
     <Flex className="curiosity-usage-graph__totals">
       <Flex flex={{ default: 'flex_1' }} direction={{ default: 'column' }} alignSelf={{ default: 'alignSelfStretch' }}>
         <FlexItem className="curiosity-usage-graph__totals-column">
-          <Card className={`curiosity-usage-graph__totals-column-card ${(error && 'blur') || ''}`}>
+          <Card
+            data-test="graphDailyTotalCard"
+            className={`curiosity-usage-graph__totals-column-card ${(error && 'blur') || ''}`}
+          >
             <CardTitle>
               {t('curiosity-graph.cardHeadingMetric_dailyTotal', {
                 context: [isCurrent && 'current', metricId],
@@ -92,7 +95,10 @@ const GraphCardMetricTotals = ({
               </CardFooter>
             </MinHeight>
           </Card>
-          <Card className={`curiosity-usage-graph__totals-column-card ${(error && 'blur') || ''}`}>
+          <Card
+            data-test="graphMonthlyTotalCard"
+            className={`curiosity-usage-graph__totals-column-card ${(error && 'blur') || ''}`}
+          >
             <CardTitle>
               {t('curiosity-graph.cardHeadingMetric_monthlyTotal', {
                 context: [isCurrent && 'current', metricId],


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(graphCardMetricTotals): ent-4366 data-test attributes

### Notes
- there are no visual, or behavioral, changes associated with this update
- applies `data-test` attributes to the graph display associated with RHOSAK daily and monthly total cards @mirekdlugosz @ntkathole 
   - the top/first/daily card has the attribute `data-test="graphDailyTotalCard"`
   - the bottom/second/monthly card has the attribute `data-test="graphMonthlyTotalCard"`
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-4366