### PR TITLE
fix(rhsmSchemas): ent-4366 graph total display mismatch

### DIFF
--- a/src/common/dateHelpers.js
+++ b/src/common/dateHelpers.js
@@ -13,7 +13,7 @@ const getCurrentDate = () =>
   (helpers.DEV_MODE &&
     process.env.REACT_APP_DEBUG_DEFAULT_DATETIME &&
     moment.utc(process.env.REACT_APP_DEBUG_DEFAULT_DATETIME).toDate()) ||
-  new Date();
+  moment.utc().toDate();
 
 /**
  * Set a date range based on a granularity type.

--- a/src/services/rhsm/rhsmSchemas.js
+++ b/src/services/rhsm/rhsmSchemas.js
@@ -63,7 +63,7 @@ const instancesItem = Joi.object({
   display_name: Joi.string().optional().allow(null),
   measurements: Joi.array().default([]),
   subscription_manager_id: Joi.string().optional().allow(null),
-  last_seen: Joi.date().allow(null)
+  last_seen: Joi.date().utc().allow(null)
 })
   .unknown(true)
   .default();
@@ -85,7 +85,7 @@ const instancesResponseSchema = Joi.object().keys({
  * @type {*} Joi schema
  */
 const tallyItem = Joi.object({
-  date: Joi.date().allow(null),
+  date: Joi.date().utc().allow(null),
   has_data: Joi.boolean().optional().allow(null),
   value: Joi.number().allow(null).default(0)
 })

--- a/src/services/rhsm/rhsmTranformers.js
+++ b/src/services/rhsm/rhsmTranformers.js
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import {
   RHSM_API_RESPONSE_INSTANCES_DATA_TYPES as INSTANCES_DATA_TYPES,
   RHSM_API_RESPONSE_INSTANCES_META_TYPES as INSTANCES_META_TYPES,
@@ -52,13 +53,7 @@ const rhsmTally = response => {
   const updatedResponse = {};
   const { [rhsmConstants.RHSM_API_RESPONSE_DATA]: data = [], [rhsmConstants.RHSM_API_RESPONSE_META]: meta = {} } =
     response || {};
-  /**
-   * FixMe: this is a potential bug
-   * Under RHOSAK this can't be seen because we're using a monthly range. However, under something like RHEL
-   * where a "quarterly range" that spans a year+ days of the month repeat. We need to match the full date
-   * instead of just the day.
-   */
-  const currentDay = dateHelpers.getCurrentDate()?.getDate();
+  const currentDay = moment.utc(dateHelpers.getCurrentDate()).format('MM-D-YYYY');
 
   updatedResponse.data = data.map(
     (
@@ -69,7 +64,7 @@ const rhsmTally = response => {
       y: value,
       date,
       hasData,
-      isCurrentDate: date?.getDate() === currentDay
+      isCurrentDate: moment.utc(date).format('MM-D-YYYY') === currentDay
     })
   );
 


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(rhsmSchemas): ent-4366 graph total display mismatch
   * dateHelpers, utc base
   * rhsmSchemas, adjust for utc date
   * rhsmTransformers, month-day-year check for current date

### Notes
- Appears there may be a display issue associated with the "Today's [metric total]". We came across an issue where the UTC date in the graph is not aligning correctly to the total for "Today's". This aims to correct that and align the dates based on UTC
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screen Shot 2021-11-18 at 5 21 44 PM (2)](https://user-images.githubusercontent.com/3761375/142506301-6f22db64-6237-4824-b121-2191b1d8fd37.png)



## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-4366