### PR TITLE
fix(graphCardMetricTotals): ent-4366 expand data-test

### DIFF
--- a/src/components/graphCard/__tests__/__snapshots__/graphCardMetricTotals.test.js.snap
+++ b/src/components/graphCard/__tests__/__snapshots__/graphCardMetricTotals.test.js.snap
@@ -3,6 +3,7 @@
 exports[`GraphCardMetricTotals Component should handle multiple display states: error 1`] = `
 <Flex
   className="curiosity-usage-graph__totals"
+  data-test="graphMetricTotals"
 >
   <Flex
     alignSelf={
@@ -113,6 +114,7 @@ exports[`GraphCardMetricTotals Component should handle multiple display states: 
 exports[`GraphCardMetricTotals Component should handle multiple display states: fulfilled 1`] = `
 <Flex
   className="curiosity-usage-graph__totals"
+  data-test="graphMetricTotals"
 >
   <Flex
     alignSelf={
@@ -227,6 +229,7 @@ exports[`GraphCardMetricTotals Component should handle multiple display states: 
 exports[`GraphCardMetricTotals Component should handle multiple display states: pending 1`] = `
 <Flex
   className="curiosity-usage-graph__totals"
+  data-test="graphMetricTotals"
 >
   <Flex
     alignSelf={
@@ -357,6 +360,7 @@ exports[`GraphCardMetricTotals Component should handle multiple display states: 
 exports[`GraphCardMetricTotals Component should render a basic component: basic 1`] = `
 <Flex
   className="curiosity-usage-graph__totals"
+  data-test="graphMetricTotals"
 >
   <Flex
     alignSelf={

--- a/src/components/graphCard/__tests__/__snapshots__/graphCardMetricTotals.test.js.snap
+++ b/src/components/graphCard/__tests__/__snapshots__/graphCardMetricTotals.test.js.snap
@@ -3,7 +3,7 @@
 exports[`GraphCardMetricTotals Component should handle multiple display states: error 1`] = `
 <Flex
   className="curiosity-usage-graph__totals"
-  data-test="graphMetricTotals"
+  data-test="graphMetricTotals-"
 >
   <Flex
     alignSelf={
@@ -114,7 +114,7 @@ exports[`GraphCardMetricTotals Component should handle multiple display states: 
 exports[`GraphCardMetricTotals Component should handle multiple display states: fulfilled 1`] = `
 <Flex
   className="curiosity-usage-graph__totals"
-  data-test="graphMetricTotals"
+  data-test="graphMetricTotals-"
 >
   <Flex
     alignSelf={
@@ -229,7 +229,7 @@ exports[`GraphCardMetricTotals Component should handle multiple display states: 
 exports[`GraphCardMetricTotals Component should handle multiple display states: pending 1`] = `
 <Flex
   className="curiosity-usage-graph__totals"
-  data-test="graphMetricTotals"
+  data-test="graphMetricTotals-"
 >
   <Flex
     alignSelf={
@@ -360,7 +360,7 @@ exports[`GraphCardMetricTotals Component should handle multiple display states: 
 exports[`GraphCardMetricTotals Component should render a basic component: basic 1`] = `
 <Flex
   className="curiosity-usage-graph__totals"
-  data-test="graphMetricTotals"
+  data-test="graphMetricTotals-"
 >
   <Flex
     alignSelf={

--- a/src/components/graphCard/graphCardMetricTotals.js
+++ b/src/components/graphCard/graphCardMetricTotals.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Card, CardBody, CardFooter, CardTitle, Flex, FlexItem } from '@patternfly/react-core';
 import moment from 'moment';
+import _camelCase from 'lodash/camelCase';
 import { useProductGraphTallyQuery } from '../productView/productViewContext';
 import { useMetricsSelector } from './graphCardContext';
 import { MinHeight } from '../minHeight/minHeight';
@@ -46,7 +47,7 @@ const GraphCardMetricTotals = ({
   const dailyValue = isCurrent ? currentValue : lastValue;
 
   return (
-    <Flex data-test="graphMetricTotals" className="curiosity-usage-graph__totals">
+    <Flex data-test={`graphMetricTotals-${_camelCase(metricId)}`} className="curiosity-usage-graph__totals">
       <Flex flex={{ default: 'flex_1' }} direction={{ default: 'column' }} alignSelf={{ default: 'alignSelfStretch' }}>
         <FlexItem className="curiosity-usage-graph__totals-column">
           <Card

--- a/src/components/graphCard/graphCardMetricTotals.js
+++ b/src/components/graphCard/graphCardMetricTotals.js
@@ -46,7 +46,7 @@ const GraphCardMetricTotals = ({
   const dailyValue = isCurrent ? currentValue : lastValue;
 
   return (
-    <Flex className="curiosity-usage-graph__totals">
+    <Flex data-test="graphMetricTotals" className="curiosity-usage-graph__totals">
       <Flex flex={{ default: 'flex_1' }} direction={{ default: 'column' }} alignSelf={{ default: 'alignSelfStretch' }}>
         <FlexItem className="curiosity-usage-graph__totals-column">
           <Card


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(graphCardMetricTotals): ent-4366 expand data-test

### Notes
- applies a `data-test="graphMetricTotals"` attribute to the div surrounding daily, monthly, and the graph display for individual metric displays, currently used in RHOSAK. @mirekdlugosz @ntkathole 
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm the data-test attribute appears in the surrounding div

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-4366