### PR TITLE
fix(chartHelpers): ent-4366 adjust yaxis domain for small values

### DIFF
--- a/src/components/chart/__tests__/__snapshots__/chartHelpers.test.js.snap
+++ b/src/components/chart/__tests__/__snapshots__/chartHelpers.test.js.snap
@@ -36,6 +36,18 @@ Object {
 }
 `;
 
+exports[`ChartHelpers should generate domain ranges: domain, maxY less than 0.1 1`] = `
+Object {
+  "domain": Object {
+    "y": Array [
+      0,
+      0.0125,
+    ],
+  },
+  "padding": Object {},
+}
+`;
+
 exports[`ChartHelpers should generate domain ranges: domain, maxY number 1`] = `
 Object {
   "domain": Object {

--- a/src/components/chart/__tests__/chartHelpers.test.js
+++ b/src/components/chart/__tests__/chartHelpers.test.js
@@ -62,6 +62,10 @@ describe('ChartHelpers', () => {
       dolor: 100
     };
     expect(chartHelpers.generateDomains(options)).toMatchSnapshot('domain, maxY object');
+
+    options.maxY = 0.01;
+
+    expect(chartHelpers.generateDomains(options)).toMatchSnapshot('domain, maxY less than 0.1');
   });
 
   it('should generate element props', () => {

--- a/src/components/chart/chartHelpers.js
+++ b/src/components/chart/chartHelpers.js
@@ -59,10 +59,10 @@ const generateDomains = ({ maxY, padding = {} } = {}) => {
 
   if (Object.values(maxY).length) {
     generatedDomain.y = [0, 1.25];
-  } else if (maxY >= 0.01) {
+  } else if (maxY >= 0.1) {
     const floored = Math.pow(10, Math.floor(Math.log10(maxY || 10)));
     generatedDomain.y = [0, Math.ceil((maxY + 1) / floored) * floored];
-  } else if (maxY < 0.01) {
+  } else if (maxY < 0.1) {
     generatedDomain.y = [0, maxY + maxY / 4 || 10];
   } else {
     generatedDomain.y = [0, 10];


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(chartHelpers): ent-4366 adjust yaxis domain for small values

### Notes
- Clean up PR targeted at a better UX
- Adjusts the y axis domain range for smaller values. Our cutoff for displaying small values was `0.01` we moved it to `0.1` because during testing a value came through in the graph rightttttt above `0.01` just enough to not fire the logic and just enough to look really minuscule on the graph
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. find an account that has a max Y value for the entire month above and below `0.1`... the graph should adjust accordingly. If there are any other Y values greater those will be used instead.

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-4366