### PR TITLE
feat(rhosak): ent-4499 activate subs table

### DIFF
--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -644,6 +644,10 @@ Array [
         "key": "curiosity-inventory.measurement",
         "match": "translate('curiosity-inventory.measurement', { context: RHSM_API_PATH_METRIC_TYPES.INSTANCE_HOURS, total: helpers.numberDisplay(total?.value)",
       },
+      Object {
+        "key": "curiosity-inventory.header",
+        "match": "translate('curiosity-inventory.header', { context: ['subscriptions', data?.uom?.value] })",
+      },
     ],
   },
   Object {

--- a/src/config/__tests__/__snapshots__/product.rhosak.test.js.snap
+++ b/src/config/__tests__/__snapshots__/product.rhosak.test.js.snap
@@ -217,6 +217,138 @@ Object {
 }
 `;
 
+exports[`Product RHOSAK config should apply subscriptions inventory configuration: filtered 1`] = `
+Object {
+  "cells": Array [
+    Object {
+      "title": "lorem",
+    },
+    Object {
+      "title": "hello world",
+    },
+    Object {
+      "title": "",
+    },
+    Object {
+      "title": "",
+    },
+    Object {
+      "title": "",
+    },
+  ],
+  "columnHeaders": Array [
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"productName\\"})",
+      "transforms": Array [],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"serviceLevel\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"quantity\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"subscriptions\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"nextEventDate\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
+  ],
+  "data": Object {
+    "nextEventDate": Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"nextEventDate\\"})",
+      "value": "lorem date obj",
+    },
+    "productName": Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"productName\\"})",
+      "value": "lorem",
+    },
+    "serviceLevel": Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"serviceLevel\\"})",
+      "value": "hello world",
+    },
+  },
+}
+`;
+
+exports[`Product RHOSAK config should apply subscriptions inventory configuration: filtered, fallback display 1`] = `
+Object {
+  "cells": Array [
+    Object {
+      "title": "lorem",
+    },
+    Object {
+      "title": "",
+    },
+    Object {
+      "title": "",
+    },
+    Object {
+      "title": "",
+    },
+    Object {
+      "title": "",
+    },
+  ],
+  "columnHeaders": Array [
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"productName\\"})",
+      "transforms": Array [],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"serviceLevel\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"quantity\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"subscriptions\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"nextEventDate\\"})",
+      "transforms": Array [
+        [Function],
+      ],
+    },
+  ],
+  "data": Object {
+    "nextEventDate": Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"nextEventDate\\"})",
+      "value": null,
+    },
+    "productName": Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"productName\\"})",
+      "value": "lorem",
+    },
+    "serviceLevel": Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"serviceLevel\\"})",
+      "value": null,
+    },
+  },
+}
+`;
+
 exports[`Product RHOSAK config should handle a custom yAxisTickFormat for floating points: yAxisTickFormat 1`] = `
 Object {
   "0.00001345": "0.00001",

--- a/src/config/__tests__/product.rhosak.test.js
+++ b/src/config/__tests__/product.rhosak.test.js
@@ -81,4 +81,39 @@ describe('Product RHOSAK config', () => {
 
     expect(inventoryQuery[RHSM_API_QUERY_SET_TYPES.DIRECTION] === SORT_DIRECTION_TYPES.DESCENDING).toBe(true);
   });
+
+  it('should apply subscriptions inventory configuration', () => {
+    const {
+      initialSubscriptionsInventoryFilters: initialFilters,
+      inventorySubscriptionsQuery: inventoryQuery
+    } = config;
+
+    const inventoryData = {
+      productName: 'lorem',
+      serviceLevel: 'hello world',
+      nextEventDate: 'lorem date obj'
+    };
+
+    const filteredInventoryData = parseRowCellsListData({
+      filters: initialFilters,
+      cellData: inventoryData
+    });
+
+    expect(filteredInventoryData).toMatchSnapshot('filtered');
+
+    const fallbackInventoryData = {
+      ...inventoryData,
+      serviceLevel: null,
+      nextEventDate: null
+    };
+
+    const fallbackFilteredInventoryData = parseRowCellsListData({
+      filters: initialFilters,
+      cellData: fallbackInventoryData
+    });
+
+    expect(fallbackFilteredInventoryData).toMatchSnapshot('filtered, fallback display');
+
+    expect(inventoryQuery[RHSM_API_QUERY_SET_TYPES.DIRECTION] === SORT_DIRECTION_TYPES.DESCENDING).toBe(true);
+  });
 });

--- a/src/config/product.rhosak.js
+++ b/src/config/product.rhosak.js
@@ -9,6 +9,8 @@ import {
 } from '@patternfly/react-tokens';
 import { Button } from '@patternfly/react-core';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
+import moment from 'moment';
+import { RHSM_API_QUERY_SUBSCRIPTIONS_SORT_TYPES } from '../types/rhsmApiTypes';
 import {
   RHSM_API_QUERY_INVENTORY_SORT_DIRECTION_TYPES as SORT_DIRECTION_TYPES,
   RHSM_API_QUERY_INVENTORY_SORT_TYPES,
@@ -50,7 +52,12 @@ const config = {
     [RHSM_API_QUERY_SET_TYPES.LIMIT]: 100,
     [RHSM_API_QUERY_SET_TYPES.OFFSET]: 0
   },
-  inventorySubscriptionsQuery: {},
+  inventorySubscriptionsQuery: {
+    [RHSM_API_QUERY_SET_TYPES.SORT]: RHSM_API_QUERY_SUBSCRIPTIONS_SORT_TYPES.NEXT_EVENT_DATE,
+    [RHSM_API_QUERY_SET_TYPES.DIRECTION]: SORT_DIRECTION_TYPES.DESCENDING,
+    [RHSM_API_QUERY_SET_TYPES.LIMIT]: 100,
+    [RHSM_API_QUERY_SET_TYPES.OFFSET]: 0
+  },
   initialGraphFilters: [
     {
       id: RHSM_API_PATH_METRIC_TYPES.TRANSFER_GIBIBYTES,
@@ -168,6 +175,43 @@ const config = {
       id: INVENTORY_TYPES.LAST_SEEN,
       cell: ({ [INVENTORY_TYPES.LAST_SEEN]: lastSeen }) =>
         (lastSeen?.value && <DateFormat date={lastSeen?.value} />) || '',
+      isSortable: true,
+      isWrappable: true,
+      cellWidth: 15
+    }
+  ],
+  initialSubscriptionsInventoryFilters: [
+    {
+      id: 'productName',
+      isSortable: false,
+      isWrappable: true
+    },
+    {
+      id: 'serviceLevel',
+      isSortable: true,
+      isWrappable: true,
+      cellWidth: 15
+    },
+    {
+      id: 'quantity',
+      isSortable: true,
+      cellWidth: 10,
+      isWrappable: true
+    },
+    {
+      id: 'totalCapacity',
+      header: data => translate('curiosity-inventory.header', { context: ['subscriptions', data?.uom?.value] }),
+      isSortable: false,
+      cellWidth: 10,
+      isWrappable: true
+    },
+    {
+      id: 'nextEventDate',
+      cell: data =>
+        (data?.nextEventDate?.value &&
+          helpers.isDate(data?.nextEventDate?.value) &&
+          moment.utc(data?.nextEventDate?.value).format('YYYY-DD-MM')) ||
+        '',
       isSortable: true,
       isWrappable: true,
       cellWidth: 15


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- feat(rhosak): ent-4499 activate subs table

<!-- ### Notes -->
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. login and confirm the RHOSAK product display shows a subscriptions inventory tab, and subsequent table

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-4499
#854 