### PR TITLE
build(dev): local run, content security policy update

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,13 +2,3 @@ DEV_PORT=3000
 DEV_BRANCH=stage-stable
 
 REACT_APP_ENV=development
-
-REACT_APP_SERVICES_RHSM_VERSION=http://localhost:5000/api/rhsm-subscriptions/v1/version
-REACT_APP_SERVICES_RHSM_REPORT=http://localhost:5000/api/rhsm-subscriptions/v1/tally/products/
-REACT_APP_SERVICES_RHSM_TALLY=http://localhost:5000/api/rhsm-subscriptions/v1/tally/products/{0}/{1}
-REACT_APP_SERVICES_RHSM_CAPACITY=http://localhost:5000/api/rhsm-subscriptions/v1/capacity/products/
-REACT_APP_SERVICES_RHSM_INVENTORY=http://localhost:5000/api/rhsm-subscriptions/v1/hosts/products/
-REACT_APP_SERVICES_RHSM_INVENTORY_GUESTS=//localhost:5000/api/rhsm-subscriptions/v1/hosts/{0}/guests
-REACT_APP_SERVICES_RHSM_INVENTORY_INSTANCES=//localhost:5000/api/rhsm-subscriptions/v1/instances/products/
-REACT_APP_SERVICES_RHSM_INVENTORY_SUBSCRIPTIONS=//localhost:5000/api/rhsm-subscriptions/v1/subscriptions/products/
-REACT_APP_SERVICES_RHSM_OPTIN=http://localhost:5000/api/rhsm-subscriptions/v1/opt-in

--- a/config/spandx.config.js
+++ b/config/spandx.config.js
@@ -1,12 +1,25 @@
 /**
- * Set proxy routes.
+ * Set dev run routes.
+ *
+ * @returns {object}
+ */
+const setDevRoutes = () => ({
+  routes: {
+    '/api/rhsm-subscriptions': {
+      host: `http://localhost:5000`
+    }
+  }
+});
+
+/**
+ * Set proxy run routes.
  *
  * @param {object} params
  * @param {string} params.DEV_PORT
  * @param {string} params.BETA_PREFIX
  * @returns {object}
  */
-const setProxyRoutes = ({ DEV_PORT, BETA_PREFIX = '' }) => ({
+const setProxyRoutes = ({ DEV_PORT, BETA_PREFIX = '' } = {}) => ({
   routes: {
     '/locales': {
       host: `https://localhost:${DEV_PORT}${BETA_PREFIX}/apps/subscriptions`
@@ -14,4 +27,4 @@ const setProxyRoutes = ({ DEV_PORT, BETA_PREFIX = '' }) => ({
   }
 });
 
-module.exports = setProxyRoutes;
+module.exports = { setDevRoutes, setProxyRoutes };

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -1,6 +1,7 @@
 const config = require('@redhat-cloud-services/frontend-components-config');
 const { setHtmlPlugin, setReplacePlugin, setCommonPlugins } = require('./build.plugins');
 const { setupDotenvFilesForEnv } = require('./build.dotenv');
+const { setDevRoutes } = require('./spandx.config');
 
 const { _BUILD_RELATIVE_DIRNAME, DEV_BRANCH, DEV_PORT } = setupDotenvFilesForEnv({ env: process.env.NODE_ENV });
 
@@ -12,6 +13,7 @@ const { config: webpackConfig, plugins } = config({
   env: (/(prod|stage|qa|ci)(-stable|-beta)$/.test(DEV_BRANCH) && DEV_BRANCH) || 'prod-stable',
   port: Number.parseInt(DEV_PORT, 10),
   rootFolder: _BUILD_RELATIVE_DIRNAME,
+  routes: setDevRoutes(),
   standalone: true,
   useProxy: false,
   htmlPlugin: setHtmlPlugin(),

--- a/config/webpack.proxy.config.js
+++ b/config/webpack.proxy.config.js
@@ -1,7 +1,7 @@
 const config = require('@redhat-cloud-services/frontend-components-config');
 const { setHtmlPlugin, setReplacePlugin, setCommonPlugins } = require('./build.plugins');
 const { setupDotenvFilesForEnv } = require('./build.dotenv');
-const setProxyRoutes = require('./spandx.config');
+const { setProxyRoutes } = require('./spandx.config');
 
 const { _BUILD_RELATIVE_DIRNAME, DEV_BRANCH, DEV_PORT } = setupDotenvFilesForEnv({
   env: 'proxy'


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- build(dev): local run, content security policy update

### Notes
- A chroming update applied a content security policy meta tag that breaks the local dev run. This compensates for it... see https://github.com/RedHatInsights/insights-chrome/pull/1733 
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. confirm the mock API setup comes through and the pages render without error

<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Related to https://github.com/RedHatInsights/insights-chrome/pull/1733 
Ongoing