### PR TITLE
fix(inventoryCardSubscriptionsContext): ent-4572 sort types

### DIFF
--- a/src/components/inventoryCard/__tests__/__snapshots__/inventoryCardContext.test.js.snap
+++ b/src/components/inventoryCard/__tests__/__snapshots__/inventoryCardContext.test.js.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`InventoryCardContext should expect specific sort properties: sort properties 1`] = `
+Object {
+  "CORES": "Cores",
+  "CORE_SECONDS": "Core-seconds",
+  "INSTANCE_HOURS": "Instance-hours",
+  "LAST_SEEN": "last_seen",
+  "NAME": "display_name",
+  "SOCKETS": "Sockets",
+  "STORAGE_GIBIBYTES": "Storage-gibibytes",
+  "TRANSFER_GIBIBYTES": "Transfer-gibibytes",
+}
+`;
+
 exports[`InventoryCardContext should handle an onColumnSort event: onColumnSort event, dispatch 1`] = `
 Array [
   Array [

--- a/src/components/inventoryCard/__tests__/inventoryCardContext.test.js
+++ b/src/components/inventoryCard/__tests__/inventoryCardContext.test.js
@@ -4,11 +4,18 @@ import {
   useOnPageInstances,
   useOnColumnSortInstances
 } from '../inventoryCardContext';
-import { RHSM_API_QUERY_INVENTORY_SORT_DIRECTION_TYPES as SORT_DIRECTION_TYPES } from '../../../services/rhsm/rhsmConstants';
+import {
+  RHSM_API_QUERY_INVENTORY_SORT_DIRECTION_TYPES as SORT_DIRECTION_TYPES,
+  RHSM_API_QUERY_INVENTORY_SORT_TYPES as SORT_TYPES
+} from '../../../services/rhsm/rhsmConstants';
 
 describe('InventoryCardContext', () => {
   it('should return specific properties', () => {
     expect(context).toMatchSnapshot('specific properties');
+  });
+
+  it('should expect specific sort properties', () => {
+    expect(SORT_TYPES).toMatchSnapshot('sort properties');
   });
 
   it('should handle instances inventory API responses', async () => {

--- a/src/components/inventoryCardSubscriptions/__tests__/__snapshots__/inventoryCardSubscriptionsContext.test.js.snap
+++ b/src/components/inventoryCardSubscriptions/__tests__/__snapshots__/inventoryCardSubscriptionsContext.test.js.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`InventoryCardSubscriptionsContext should expect specific sort properties: sort properties 1`] = `
+Object {
+  "NEXT_EVENT_DATE": "next_event_date",
+  "NEXT_EVENT_TYPE": "next_event_type",
+  "QUANTITY": "quantity",
+  "SERVICE_LEVEL": "service_level",
+  "SKU": "sku",
+  "USAGE": "usage",
+}
+`;
+
 exports[`InventoryCardSubscriptionsContext should handle an onColumnSort event: onColumnSort event, dispatch 1`] = `
 Array [
   Array [

--- a/src/components/inventoryCardSubscriptions/__tests__/inventoryCardSubscriptionsContext.test.js
+++ b/src/components/inventoryCardSubscriptions/__tests__/inventoryCardSubscriptionsContext.test.js
@@ -4,11 +4,18 @@ import {
   useOnPageSubscriptions,
   useOnColumnSortSubscriptions
 } from '../inventoryCardSubscriptionsContext';
-import { RHSM_API_QUERY_INVENTORY_SORT_DIRECTION_TYPES as SORT_DIRECTION_TYPES } from '../../../services/rhsm/rhsmConstants';
+import {
+  RHSM_API_QUERY_INVENTORY_SORT_DIRECTION_TYPES as SORT_DIRECTION_TYPES,
+  RHSM_API_QUERY_INVENTORY_SUBSCRIPTIONS_SORT_TYPES as SORT_TYPES
+} from '../../../services/rhsm/rhsmConstants';
 
 describe('InventoryCardSubscriptionsContext', () => {
   it('should return specific properties', () => {
     expect(context).toMatchSnapshot('specific properties');
+  });
+
+  it('should expect specific sort properties', () => {
+    expect(SORT_TYPES).toMatchSnapshot('sort properties');
   });
 
   it('should handle instances inventory API responses', async () => {

--- a/src/components/inventoryCardSubscriptions/inventoryCardSubscriptionsContext.js
+++ b/src/components/inventoryCardSubscriptions/inventoryCardSubscriptionsContext.js
@@ -5,7 +5,7 @@ import { reduxActions, reduxTypes, storeHooks } from '../../redux';
 import { useProduct, useProductInventorySubscriptionsQuery } from '../productView/productViewContext';
 import {
   RHSM_API_QUERY_INVENTORY_SORT_DIRECTION_TYPES as SORT_DIRECTION_TYPES,
-  RHSM_API_QUERY_INVENTORY_SORT_TYPES as SORT_TYPES,
+  RHSM_API_QUERY_INVENTORY_SUBSCRIPTIONS_SORT_TYPES as SORT_TYPES,
   RHSM_API_QUERY_SET_TYPES
 } from '../../services/rhsm/rhsmConstants';
 import { helpers } from '../../common';


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(inventoryCardSubscriptionsContext): ent-4572 sort types

### Notes
- **this issue/bug is currently limited to the `stage-beta` environment ONLY** see #857 
- Hosts/Instances sort types used as limiters on Subscriptions table sort... this corrects the limiting types. And applies a test type check for both hosts/instances and subscriptions inventory.
   - @mirekdlugosz @ntkathole  
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm the sort for Subscriptions inventory tables correctly applies column sorting queries

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-4572