### PR TITLE
chore(build): dependabot limit PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 1
     target-branch: "ci"
     versioning-strategy: increase
     allow:
@@ -15,6 +15,7 @@ updates:
       - dependency-name: "@redhat-cloud-services/frontend*"
       - dependency-name: "*i18next*"
       - dependency-name: "victory*"
+      - dependency-name: "react-router*"
     labels:
       - "build"
 


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- chore(build): dependabot limit PRs

### Notes
- since we do a once a month/sometimes twice a month NPM update ... limiting this to about 4ish PRs a month
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
... it's pfm
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing