### PR TITLE
feat(rhosak): ent-4689 activate billing provider

### DIFF
--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -649,6 +649,10 @@ Array [
         "match": "translate('curiosity-graph.label_axisX', { context: GRANULARITY_TYPES.DAILY })",
       },
       Object {
+        "key": "",
+        "match": "translate(\`curiosity-inventory.measurement_\${INVENTORY_TYPES.BILLING_PROVIDER}\`, { context: provider?.value })",
+      },
+      Object {
         "key": "curiosity-inventory.header",
         "match": "translate('curiosity-inventory.header', { context: ['tooltip', RHSM_API_PATH_METRIC_TYPES.TRANSFER_GIBIBYTES] })",
       },

--- a/src/config/__tests__/__snapshots__/product.rhosak.test.js.snap
+++ b/src/config/__tests__/__snapshots__/product.rhosak.test.js.snap
@@ -7,6 +7,9 @@ Object {
       "title": "lorem ipsum",
     },
     Object {
+      "title": "t(curiosity-inventory.measurement_billing_provider, {})",
+    },
+    Object {
       "title": "t(curiosity-inventory.measurement, {\\"context\\":\\"Transfer-gibibytes\\",\\"total\\":\\"0.00035\\"})",
     },
     Object {
@@ -25,6 +28,12 @@ Object {
     Object {
       "title": "t(curiosity-inventory.header, {\\"context\\":\\"display_name\\"})",
       "transforms": Array [],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"billing_provider\\"})",
+      "transforms": Array [
+        [Function],
+      ],
     },
     Object {
       "title": <Tooltip
@@ -110,6 +119,9 @@ Object {
       </Button>,
     },
     Object {
+      "title": "t(curiosity-inventory.measurement_billing_provider, {})",
+    },
+    Object {
       "title": "t(curiosity-inventory.measurement, {\\"context\\":\\"Transfer-gibibytes\\",\\"total\\":\\"0.00035\\"})",
     },
     Object {
@@ -128,6 +140,12 @@ Object {
     Object {
       "title": "t(curiosity-inventory.header, {\\"context\\":\\"display_name\\"})",
       "transforms": Array [],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"billing_provider\\"})",
+      "transforms": Array [
+        [Function],
+      ],
     },
     Object {
       "title": <Tooltip

--- a/src/config/product.rhosak.js
+++ b/src/config/product.rhosak.js
@@ -141,6 +141,16 @@ const config = {
       isSortable: true
     },
     {
+      id: INVENTORY_TYPES.BILLING_PROVIDER,
+      cell: ({ [INVENTORY_TYPES.BILLING_PROVIDER]: provider }) =>
+        translate(`curiosity-inventory.measurement_${INVENTORY_TYPES.BILLING_PROVIDER}`, {
+          context: provider?.value
+        }),
+      isSortable: true,
+      isWrappable: false,
+      cellWidth: 15
+    },
+    {
       id: RHSM_API_PATH_METRIC_TYPES.TRANSFER_GIBIBYTES,
       header: {
         tooltip: () =>
@@ -244,6 +254,11 @@ const config = {
     }
   ],
   initialToolbarFilters: [
+    {
+      id: RHSM_API_QUERY_SET_TYPES.BILLING_PROVIDER
+    }
+  ],
+  initialSecondaryToolbarFilters: [
     {
       id: 'rangedMonthly'
     }

--- a/src/services/rhsm/__tests__/__snapshots__/rhsmConstants.test.js.snap
+++ b/src/services/rhsm/__tests__/__snapshots__/rhsmConstants.test.js.snap
@@ -82,6 +82,7 @@ Object {
     "USAGE": "usage",
   },
   "RHSM_API_QUERY_SET_TALLY_CAPACITY_TYPES": Object {
+    "BILLING_PROVIDER": "billing_provider",
     "END_DATE": "ending",
     "GRANULARITY": "granularity",
     "SLA": "sla",
@@ -275,6 +276,7 @@ Object {
       "USAGE": "usage",
     },
     "RHSM_API_QUERY_SET_TALLY_CAPACITY_TYPES": Object {
+      "BILLING_PROVIDER": "billing_provider",
       "END_DATE": "ending",
       "GRANULARITY": "granularity",
       "SLA": "sla",
@@ -469,6 +471,7 @@ Object {
       "USAGE": "usage",
     },
     "RHSM_API_QUERY_SET_TALLY_CAPACITY_TYPES": Object {
+      "BILLING_PROVIDER": "billing_provider",
       "END_DATE": "ending",
       "GRANULARITY": "granularity",
       "SLA": "sla",
@@ -667,6 +670,7 @@ Object {
     "USAGE": "usage",
   },
   "RHSM_API_QUERY_SET_TALLY_CAPACITY_TYPES": Object {
+    "BILLING_PROVIDER": "billing_provider",
     "END_DATE": "ending",
     "GRANULARITY": "granularity",
     "SLA": "sla",

--- a/src/services/rhsm/rhsmConstants.js
+++ b/src/services/rhsm/rhsmConstants.js
@@ -296,9 +296,10 @@ const RHSM_API_QUERY_SET_INVENTORY_TYPES = {
 /**
  * RHSM query parameter options for TALLY, CAPACITY endpoints.
  *
- * @type {{GRANULARITY: string, USAGE: string, END_DATE: string, SLA: string, START_DATE: string }}
+ * @type {{GRANULARITY: string, USAGE: string, END_DATE: string, SLA: string, START_DATE: string, BILLING_PROVIDER: string}}
  */
 const RHSM_API_QUERY_SET_TALLY_CAPACITY_TYPES = {
+  BILLING_PROVIDER: 'billing_provider',
   END_DATE: 'ending',
   GRANULARITY: 'granularity',
   SLA: 'sla',
@@ -321,8 +322,8 @@ const RHSM_API_QUERY_SET_TYPES = {
  * RHSM constants.
  *
  * @type {{RHSM_API_QUERY_SET_TALLY_CAPACITY_TYPES: {GRANULARITY: string, USAGE: string, END_DATE: string, SLA: string,
- *     START_DATE: string}, RHSM_API_RESPONSE_DATA: string, RHSM_API_PATH_METRIC_TYPES: {CORES: string, STORAGE_GIBIBYTES: string,
- *     SOCKETS: string, INSTANCE_HOURS: string, TRANSFER_GIBIBYTES: string, CORE_SECONDS: string},
+ *     START_DATE: string, BILLING_PROVIDER: string}, RHSM_API_RESPONSE_DATA: string, RHSM_API_PATH_METRIC_TYPES: {CORES: string,
+ *     STORAGE_GIBIBYTES: string, SOCKETS: string, INSTANCE_HOURS: string, TRANSFER_GIBIBYTES: string, CORE_SECONDS: string},
  *     RHSM_API_RESPONSE_TALLY_DATA_TYPES: {DATE: string, HAS_DATA: string, VALUE: string},
  *     RHSM_API_RESPONSE_INSTANCES_META_TYPES: {MEASUREMENTS: string, PRODUCT: string, COUNT: string},
  *     RHSM_API_RESPONSE_INSTANCES_DATA_TYPES: {MEASUREMENTS: string, BILLING_ACCOUNT_ID: string, SUBSCRIPTION_MANAGER_ID: string,
@@ -330,26 +331,25 @@ const RHSM_API_QUERY_SET_TYPES = {
  *     RHSM_API_RESPONSE_SLA_TYPES: {PREMIUM: string, SELF: string, NONE: string, STANDARD: string},
  *     RHSM_API_RESPONSE_META_TYPES: {PRODUCT: string, COUNT: string}, RHSM_API_RESPONSE_ERRORS_CODE_TYPES: {GENERIC: string,
  *     OPTIN: string}, RHSM_API_QUERY_GRANULARITY_TYPES: {WEEKLY: string, QUARTERLY: string, DAILY: string, MONTHLY: string},
- *     RHSM_API_RESPONSE_UOM_TYPES: {CORES: string, SOCKETS: string},
- *     RHSM_API_QUERY_INVENTORY_SORT_DIRECTION_TYPES: {ASCENDING: string, DESCENDING: string},
- *     RHSM_API_QUERY_INVENTORY_SORT_TYPES: {CORES: string, STORAGE_GIBIBYTES: string, SOCKETS: string, INSTANCE_HOURS: string,
- *     TRANSFER_GIBIBYTES: string, BILLING_PROVIDER: string, CORE_SECONDS: string, LAST_SEEN: string, NAME: string},
- *     RHSM_API_PATH_PRODUCT_TYPES: {RHEL_ARM: string, OPENSHIFT_METRICS: string, SATELLITE: string, RHEL_WORKSTATION: string,
- *     RHOSAK: string, RHEL_COMPUTE_NODE: string, RHEL_X86: string, OPENSHIFT: string, SATELLITE_SERVER: string,
- *     OPENSHIFT_DEDICATED_METRICS: string, RHEL_DESKTOP: string, RHEL: string, SATELLITE_CAPSULE: string, RHEL_SERVER: string,
- *     RHEL_IBM_Z: string, RHEL_IBM_POWER: string}, RHSM_API_RESPONSE_BILLING_PROVIDER_TYPES: {AZURE: string, GCP: string,
- *     RED_HAT: string, NONE: string, AWS: string, ORACLE: string}, RHSM_API_RESPONSE_ERRORS_TYPES: {CODE: string},
- *     RHSM_API_QUERY_BILLING_PROVIDER_TYPES: {AZURE: string, GCP: string, RED_HAT: string, NONE: string, AWS: string,
- *     ORACLE: string}, RHSM_API_QUERY_USAGE_TYPES: {UNSPECIFIED: string, DISASTER: string, DEVELOPMENT: string,
- *     PRODUCTION: string}, RHSM_API_QUERY_SLA_TYPES: {PREMIUM: string, SELF: string, NONE: string, STANDARD: string},
- *     RHSM_API_QUERY_SET_INVENTORY_TYPES: {UOM: string, BILLING_ACCOUNT_ID: string, USAGE: string, DIRECTION: string,
- *     SORT: string, END_DATE: string, OFFSET: string, SLA: string, LIMIT: string, START_DATE: string, BILLING_PROVIDER: string,
+ *     RHSM_API_RESPONSE_UOM_TYPES: {CORES: string, SOCKETS: string}, RHSM_API_QUERY_INVENTORY_SORT_DIRECTION_TYPES: {ASCENDING: string,
+ *     DESCENDING: string}, RHSM_API_QUERY_INVENTORY_SORT_TYPES: {CORES: string, STORAGE_GIBIBYTES: string, SOCKETS: string,
+ *     INSTANCE_HOURS: string, TRANSFER_GIBIBYTES: string, BILLING_PROVIDER: string, CORE_SECONDS: string, LAST_SEEN: string,
+ *     NAME: string}, RHSM_API_PATH_PRODUCT_TYPES: {RHEL_ARM: string, OPENSHIFT_METRICS: string, SATELLITE: string,
+ *     RHEL_WORKSTATION: string, RHOSAK: string, RHEL_COMPUTE_NODE: string, RHEL_X86: string, OPENSHIFT: string,
+ *     SATELLITE_SERVER: string, OPENSHIFT_DEDICATED_METRICS: string, RHEL_DESKTOP: string, RHEL: string, SATELLITE_CAPSULE: string,
+ *     RHEL_SERVER: string, RHEL_IBM_Z: string, RHEL_IBM_POWER: string}, RHSM_API_RESPONSE_BILLING_PROVIDER_TYPES: {AZURE: string,
+ *     GCP: string, RED_HAT: string, NONE: string, AWS: string, ORACLE: string}, RHSM_API_RESPONSE_ERRORS_TYPES: {CODE: string},
+ *     RHSM_API_QUERY_BILLING_PROVIDER_TYPES: {AZURE: string, GCP: string, RED_HAT: string, NONE: string, AWS: string, ORACLE: string},
+ *     RHSM_API_QUERY_USAGE_TYPES: {UNSPECIFIED: string, DISASTER: string, DEVELOPMENT: string, PRODUCTION: string},
+ *     RHSM_API_QUERY_SLA_TYPES: {PREMIUM: string, SELF: string, NONE: string, STANDARD: string},
+ *     RHSM_API_QUERY_SET_INVENTORY_TYPES: {UOM: string, BILLING_ACCOUNT_ID: string, USAGE: string, DIRECTION: string, SORT: string,
+ *     END_DATE: string, OFFSET: string, SLA: string, LIMIT: string, START_DATE: string, BILLING_PROVIDER: string,
  *     DISPLAY_NAME: string}, RHSM_API_RESPONSE_ERRORS: string, RHSM_API_RESPONSE_TALLY_META_TYPES: {TOTAL_MONTHLY: string,
  *     DATE: string, PRODUCT: string, HAS_CLOUDIGRADE_DATA: string, HAS_CLOUDIGRADE_MISMATCH: string, HAS_DATA: string,
  *     METRIC_ID: string, COUNT: string, VALUE: string}, RHSM_API_QUERY_UOM_TYPES: {CORES: string, SOCKETS: string},
  *     RHSM_API_RESPONSE_META: string, RHSM_API_RESPONSE_GRANULARITY_TYPES: {WEEKLY: string, QUARTERLY: string, DAILY: string,
- *     MONTHLY: string}, RHSM_API_QUERY_SET_TYPES: {UOM: string, GRANULARITY: string, USAGE: string, DIRECTION: string,
- *     SORT: string, END_DATE: string, OFFSET: string, SLA: string, LIMIT: string, START_DATE: string, DISPLAY_NAME: string},
+ *     MONTHLY: string}, RHSM_API_QUERY_SET_TYPES: {UOM: string, GRANULARITY: string, USAGE: string, DIRECTION: string, SORT: string,
+ *     END_DATE: string, OFFSET: string, SLA: string, LIMIT: string, START_DATE: string, DISPLAY_NAME: string},
  *     RHSM_API_QUERY_INVENTORY_SUBSCRIPTIONS_SORT_TYPES: {QUANTITY: string, USAGE: string, NEXT_EVENT_TYPE: string,
  *     NEXT_EVENT_DATE: string, TOTAL_CAPACITY: string, PRODUCT_NAME: string, SKU: string, SERVICE_LEVEL: string},
  *     RHSM_API_RESPONSE_USAGE_TYPES: {UNSPECIFIED: string, DISASTER: string, DEVELOPMENT: string, PRODUCTION: string}}}

--- a/src/types/__tests__/__snapshots__/index.test.js.snap
+++ b/src/types/__tests__/__snapshots__/index.test.js.snap
@@ -76,6 +76,7 @@ Object {
         "TALLY_SYNC": "enable_tally_sync",
       },
       "RHSM_API_QUERY_SET_REPORT_CAPACITY_TYPES": Object {
+        "BILLING_PROVIDER": "billing_provider",
         "END_DATE": "ending",
         "GRANULARITY": "granularity",
         "SLA": "sla",
@@ -291,6 +292,7 @@ Object {
         "TALLY_SYNC": "enable_tally_sync",
       },
       "RHSM_API_QUERY_SET_REPORT_CAPACITY_TYPES": Object {
+        "BILLING_PROVIDER": "billing_provider",
         "END_DATE": "ending",
         "GRANULARITY": "granularity",
         "SLA": "sla",
@@ -505,6 +507,7 @@ Object {
       "TALLY_SYNC": "enable_tally_sync",
     },
     "RHSM_API_QUERY_SET_REPORT_CAPACITY_TYPES": Object {
+      "BILLING_PROVIDER": "billing_provider",
       "END_DATE": "ending",
       "GRANULARITY": "granularity",
       "SLA": "sla",
@@ -723,6 +726,7 @@ Object {
       "TALLY_SYNC": "enable_tally_sync",
     },
     "RHSM_API_QUERY_SET_REPORT_CAPACITY_TYPES": Object {
+      "BILLING_PROVIDER": "billing_provider",
       "END_DATE": "ending",
       "GRANULARITY": "granularity",
       "SLA": "sla",


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- feat(rhosak): ent-4689 activate billing provider
   * product config rhosak, add secondary toolbar field config
- fix(toolbarFieldBillingProvider): ent-4689 tally query
   * rhsmConstants, allow tally-capacity access billing provider

### Notes
- Applies product configuration to RHOSAK for the visual aspect for #893 
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm the RHOSAK product display applies the UX/design associated with ENT-4689

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
UPDATED screenshots
![Screen Shot 2022-05-23 at 12 23 09 PM](https://user-images.githubusercontent.com/3761375/169864341-0bc146d6-2855-40c5-abe6-eda29f9bbe54.png)
![Screen Shot 2022-05-23 at 12 23 19 PM](https://user-images.githubusercontent.com/3761375/169864362-60a87039-23fe-4721-8a63-52808a93fab1.png)


OUTDATED screenshots
<!-- Append a demo/screenshot/animated gif of the solution -->
What it looks like when the configuration for RHOSAK is applied
![Screen Shot 2022-02-08 at 12 45 10 AM](https://user-images.githubusercontent.com/3761375/153008847-17085d35-1db4-410f-9a73-9985aac5ca2f.png)

What inventory activation would resemble when the configuration for RHOSAK is applied
![Screen Shot 2022-02-17 at 5 21 33 PM (2)](https://user-images.githubusercontent.com/3761375/154580842-bd9b2bf6-043a-4cf7-9a91-c0bd84917c99.png)

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-4689
relates #883 #893
