### PR TITLE
feat(inventoryCardSubscriptions): ent-4772 product_name sort

### DIFF
--- a/src/components/inventoryCardSubscriptions/__tests__/__snapshots__/inventoryCardSubscriptionsContext.test.js.snap
+++ b/src/components/inventoryCardSubscriptions/__tests__/__snapshots__/inventoryCardSubscriptionsContext.test.js.snap
@@ -4,9 +4,11 @@ exports[`InventoryCardSubscriptionsContext should expect specific sort propertie
 Object {
   "NEXT_EVENT_DATE": "next_event_date",
   "NEXT_EVENT_TYPE": "next_event_type",
+  "PRODUCT_NAME": "product_name",
   "QUANTITY": "quantity",
   "SERVICE_LEVEL": "service_level",
   "SKU": "sku",
+  "TOTAL_CAPACITY": "total_capacity",
   "USAGE": "usage",
 }
 `;

--- a/src/components/productView/__tests__/__snapshots__/productViewContext.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productViewContext.test.js.snap
@@ -85,7 +85,7 @@ Object {
   "initialSubscriptionsInventoryFilters": Array [
     Object {
       "id": "productName",
-      "isSortable": false,
+      "isSortable": true,
       "isWrappable": true,
     },
     Object {
@@ -104,7 +104,7 @@ Object {
       "cellWidth": 15,
       "header": [Function],
       "id": "totalCapacity",
-      "isSortable": false,
+      "isSortable": true,
       "isWrappable": true,
     },
     Object {
@@ -207,7 +207,7 @@ Object {
   "initialSubscriptionsInventoryFilters": Array [
     Object {
       "id": "productName",
-      "isSortable": false,
+      "isSortable": true,
       "isWrappable": true,
     },
     Object {
@@ -226,7 +226,7 @@ Object {
       "cellWidth": 15,
       "header": [Function],
       "id": "totalCapacity",
-      "isSortable": false,
+      "isSortable": true,
       "isWrappable": true,
     },
     Object {

--- a/src/components/productView/__tests__/__snapshots__/productViewOpenShiftContainer.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productViewOpenShiftContainer.test.js.snap
@@ -99,7 +99,7 @@ exports[`ProductViewOpenShiftContainer Component should render a basic component
           "initialSubscriptionsInventoryFilters": Array [
             Object {
               "id": "productName",
-              "isSortable": false,
+              "isSortable": true,
               "isWrappable": true,
             },
             Object {
@@ -118,7 +118,7 @@ exports[`ProductViewOpenShiftContainer Component should render a basic component
               "cellWidth": 15,
               "header": [Function],
               "id": "totalCapacity",
-              "isSortable": false,
+              "isSortable": true,
               "isWrappable": true,
             },
             Object {

--- a/src/components/router/__tests__/__snapshots__/redirect.test.js.snap
+++ b/src/components/router/__tests__/__snapshots__/redirect.test.js.snap
@@ -116,7 +116,7 @@ Object {
       "initialSubscriptionsInventoryFilters": Array [
         Object {
           "id": "productName",
-          "isSortable": false,
+          "isSortable": true,
           "isWrappable": true,
         },
         Object {
@@ -135,7 +135,7 @@ Object {
           "cellWidth": 15,
           "header": [Function],
           "id": "totalCapacity",
-          "isSortable": false,
+          "isSortable": true,
           "isWrappable": true,
         },
         Object {

--- a/src/config/product.openshiftContainer.js
+++ b/src/config/product.openshiftContainer.js
@@ -177,7 +177,7 @@ const config = {
   initialSubscriptionsInventoryFilters: [
     {
       id: 'productName',
-      isSortable: false,
+      isSortable: true,
       isWrappable: true
     },
     {
@@ -195,7 +195,7 @@ const config = {
     {
       id: 'totalCapacity',
       header: data => translate('curiosity-inventory.header', { context: ['subscriptions', data?.uom?.value] }),
-      isSortable: false,
+      isSortable: true,
       cellWidth: 15,
       isWrappable: true
     },

--- a/src/config/product.rhel.js
+++ b/src/config/product.rhel.js
@@ -193,7 +193,7 @@ const config = {
   initialSubscriptionsInventoryFilters: [
     {
       id: 'productName',
-      isSortable: false,
+      isSortable: true,
       isWrappable: true
     },
     {
@@ -211,7 +211,7 @@ const config = {
     {
       id: 'totalCapacity',
       header: data => translate('curiosity-inventory.header', { context: ['subscriptions', data?.uom?.value] }),
-      isSortable: false,
+      isSortable: true,
       cellWidth: 10,
       isWrappable: true
     },

--- a/src/config/product.rhosak.js
+++ b/src/config/product.rhosak.js
@@ -183,7 +183,7 @@ const config = {
   initialSubscriptionsInventoryFilters: [
     {
       id: 'productName',
-      isSortable: false,
+      isSortable: true,
       isWrappable: true
     },
     {
@@ -201,7 +201,7 @@ const config = {
     {
       id: 'totalCapacity',
       header: data => translate('curiosity-inventory.header', { context: ['subscriptions', data?.uom?.value] }),
-      isSortable: false,
+      isSortable: true,
       cellWidth: 10,
       isWrappable: true
     },

--- a/src/services/rhsm/__tests__/__snapshots__/rhsmConstants.test.js.snap
+++ b/src/services/rhsm/__tests__/__snapshots__/rhsmConstants.test.js.snap
@@ -51,9 +51,11 @@ Object {
   "RHSM_API_QUERY_INVENTORY_SUBSCRIPTIONS_SORT_TYPES": Object {
     "NEXT_EVENT_DATE": "next_event_date",
     "NEXT_EVENT_TYPE": "next_event_type",
+    "PRODUCT_NAME": "product_name",
     "QUANTITY": "quantity",
     "SERVICE_LEVEL": "service_level",
     "SKU": "sku",
+    "TOTAL_CAPACITY": "total_capacity",
     "USAGE": "usage",
   },
   "RHSM_API_QUERY_SET_INVENTORY_TYPES": Object {
@@ -215,9 +217,11 @@ Object {
     "RHSM_API_QUERY_INVENTORY_SUBSCRIPTIONS_SORT_TYPES": Object {
       "NEXT_EVENT_DATE": "next_event_date",
       "NEXT_EVENT_TYPE": "next_event_type",
+      "PRODUCT_NAME": "product_name",
       "QUANTITY": "quantity",
       "SERVICE_LEVEL": "service_level",
       "SKU": "sku",
+      "TOTAL_CAPACITY": "total_capacity",
       "USAGE": "usage",
     },
     "RHSM_API_QUERY_SET_INVENTORY_TYPES": Object {
@@ -380,9 +384,11 @@ Object {
     "RHSM_API_QUERY_INVENTORY_SUBSCRIPTIONS_SORT_TYPES": Object {
       "NEXT_EVENT_DATE": "next_event_date",
       "NEXT_EVENT_TYPE": "next_event_type",
+      "PRODUCT_NAME": "product_name",
       "QUANTITY": "quantity",
       "SERVICE_LEVEL": "service_level",
       "SKU": "sku",
+      "TOTAL_CAPACITY": "total_capacity",
       "USAGE": "usage",
     },
     "RHSM_API_QUERY_SET_INVENTORY_TYPES": Object {
@@ -549,9 +555,11 @@ Object {
   "RHSM_API_QUERY_INVENTORY_SUBSCRIPTIONS_SORT_TYPES": Object {
     "NEXT_EVENT_DATE": "next_event_date",
     "NEXT_EVENT_TYPE": "next_event_type",
+    "PRODUCT_NAME": "product_name",
     "QUANTITY": "quantity",
     "SERVICE_LEVEL": "service_level",
     "SKU": "sku",
+    "TOTAL_CAPACITY": "total_capacity",
     "USAGE": "usage",
   },
   "RHSM_API_QUERY_SET_INVENTORY_TYPES": Object {

--- a/src/services/rhsm/rhsmConstants.js
+++ b/src/services/rhsm/rhsmConstants.js
@@ -211,15 +211,17 @@ const RHSM_API_QUERY_INVENTORY_SORT_DIRECTION_TYPES = {
 /**
  * RHSM API query/search parameter SORT type values for SUBSCRIPTIONS.
  *
- * @type {{QUANTITY: string, USAGE: string, NEXT_EVENT_TYPE: string, NEXT_EVENT_DATE: string, SKU: string,
- *     SERVICE_LEVEL: string}}
+ * @type {{QUANTITY: string, USAGE: string, NEXT_EVENT_TYPE: string, NEXT_EVENT_DATE: string,
+ *     TOTAL_CAPACITY: string, PRODUCT_NAME: string, SKU: string, SERVICE_LEVEL: string}}
  */
 const RHSM_API_QUERY_INVENTORY_SUBSCRIPTIONS_SORT_TYPES = {
   NEXT_EVENT_DATE: 'next_event_date',
   NEXT_EVENT_TYPE: 'next_event_type',
+  PRODUCT_NAME: 'product_name',
   QUANTITY: 'quantity',
   SKU: 'sku',
   SERVICE_LEVEL: 'service_level',
+  TOTAL_CAPACITY: 'total_capacity',
   USAGE: 'usage'
 };
 
@@ -276,24 +278,35 @@ const RHSM_API_QUERY_SET_TYPES = {
  * RHSM constants.
  *
  * @type {{RHSM_API_QUERY_SET_TALLY_CAPACITY_TYPES: {GRANULARITY: string, USAGE: string, END_DATE: string, SLA: string,
- *     START_DATE: string}, RHSM_API_RESPONSE_DATA: string, RHSM_API_PATH_PRODUCT_TYPES: {RHEL_ARM: string,
- *     OPENSHIFT_METRICS: string, SATELLITE: string, RHEL_WORKSTATION: string, RHOSAK: string, RHEL_COMPUTE_NODE: string,
- *     RHEL_X86: string, OPENSHIFT: string, SATELLITE_SERVER: string, OPENSHIFT_DEDICATED_METRICS: string,
- *     RHEL_DESKTOP: string, RHEL: string, SATELLITE_CAPSULE: string, RHEL_SERVER: string, RHEL_IBM_Z: string,
- *     RHEL_IBM_POWER: string}, RHSM_API_PATH_METRIC_TYPES: {CORES: string, STORAGE_GIBIBYTES: string, SOCKETS: string,
- *     INSTANCE_HOURS: string, TRANSFER_GIBIBYTES: string, CORE_SECONDS: string},
- *     RHSM_API_RESPONSE_TALLY_DATA_TYPES: {DATE: string, HAS_DATA: string, VALUE: string},
+ *     START_DATE: string}, RHSM_API_RESPONSE_DATA: string, RHSM_API_QUERY_INVENTORY_SORT_TYPES: {CORES: string,
+ *     CORE_HOURS: string, HARDWARE: string, SOCKETS: string, MEASUREMENT: string, LAST_SEEN: string, NAME: string},
+ *     RHSM_API_PATH_PRODUCT_TYPES: {RHEL_ARM: string, OPENSHIFT_METRICS: string, SATELLITE: string,
+ *     RHEL_WORKSTATION: string, RHOSAK: string, RHEL_COMPUTE_NODE: string, RHEL_X86: string, OPENSHIFT: string,
+ *     SATELLITE_SERVER: string, OPENSHIFT_DEDICATED_METRICS: string, RHEL_DESKTOP: string, RHEL: string,
+ *     SATELLITE_CAPSULE: string, RHEL_SERVER: string, RHEL_IBM_Z: string, RHEL_IBM_POWER: string},
+ *     RHSM_API_PATH_METRIC_TYPES: {CORES: string, STORAGE_GIBIBYTES: string, SOCKETS: string, INSTANCE_HOURS: string,
+ *     TRANSFER_GIBIBYTES: string, CORE_SECONDS: string}, RHSM_API_RESPONSE_TALLY_DATA_TYPES: {DATE: string,
+ *     HAS_DATA: string, VALUE: string}, RHSM_API_RESPONSE_INSTANCES_META_TYPES: {MEASUREMENTS: string, PRODUCT: string,
+ *     COUNT: string}, RHSM_API_RESPONSE_INSTANCES_DATA_TYPES: {MEASUREMENTS: string, SUBSCRIPTION_MANAGER_ID: string,
+ *     INVENTORY_ID: string, NUMBER_OF_GUESTS: string, DISPLAY_NAME: string, LAST_SEEN: string},
  *     RHSM_API_RESPONSE_SLA_TYPES: {PREMIUM: string, SELF: string, NONE: string, STANDARD: string},
  *     RHSM_API_QUERY_USAGE_TYPES: {UNSPECIFIED: string, DISASTER: string, DEVELOPMENT: string, PRODUCTION: string},
  *     RHSM_API_RESPONSE_ERROR_CODE_TYPES: {GENERIC: string, OPTIN: string}, RHSM_API_QUERY_SLA_TYPES: {PREMIUM: string,
- *     SELF: string, NONE: string, STANDARD: string}, RHSM_API_RESPONSE_TALLY_META_TYPES: {TOTAL_MONTHLY: string,
- *     DATE: string, HAS_CLOUDIGRADE_DATA: string, PRODUCT: string, HAS_CLOUDIGRADE_MISMATCH: string, HAS_DATA: string,
- *     METRIC_ID: string, COUNT: string, VALUE: string}, RHSM_API_QUERY_UOM_TYPES: {CORES: string, SOCKETS: string},
+ *     SELF: string, NONE: string, STANDARD: string}, RHSM_API_QUERY_SET_INVENTORY_TYPES: {UOM: string, USAGE: string,
+ *     DIRECTION: string, SORT: string, END_DATE: string, OFFSET: string, SLA: string, LIMIT: string, START_DATE: string,
+ *     DISPLAY_NAME: string}, RHSM_API_RESPONSE_META_TYPES: {PRODUCT: string, COUNT: string},
+ *     RHSM_API_RESPONSE_TALLY_META_TYPES: {TOTAL_MONTHLY: string, DATE: string, PRODUCT: string,
+ *     HAS_CLOUDIGRADE_DATA: string, HAS_CLOUDIGRADE_MISMATCH: string, HAS_DATA: string, METRIC_ID: string,
+ *     COUNT: string, VALUE: string}, RHSM_API_QUERY_UOM_TYPES: {CORES: string, SOCKETS: string},
  *     RHSM_API_QUERY_GRANULARITY_TYPES: {WEEKLY: string, QUARTERLY: string, DAILY: string, MONTHLY: string},
  *     RHSM_API_RESPONSE_META: string, RHSM_API_RESPONSE_UOM_TYPES: {CORES: string, SOCKETS: string},
  *     RHSM_API_RESPONSE_GRANULARITY_TYPES: {WEEKLY: string, QUARTERLY: string, DAILY: string, MONTHLY: string},
- *     RHSM_API_QUERY_SET_TYPES: {GRANULARITY: string, USAGE: string, END_DATE: string, SLA: string, START_DATE: string},
- *     RHSM_API_RESPONSE_USAGE_TYPES: {UNSPECIFIED: string, DISASTER: string, DEVELOPMENT: string, PRODUCTION: string}}}
+ *     RHSM_API_QUERY_SET_TYPES: {UOM: string, GRANULARITY: string, USAGE: string, DIRECTION: string, SORT: string,
+ *     END_DATE: string, OFFSET: string, SLA: string, LIMIT: string, START_DATE: string, DISPLAY_NAME: string},
+ *     RHSM_API_QUERY_INVENTORY_SUBSCRIPTIONS_SORT_TYPES: {QUANTITY: string, USAGE: string, NEXT_EVENT_TYPE: string,
+ *     NEXT_EVENT_DATE: string, TOTAL_CAPACITY: string, PRODUCT_NAME: string, SKU: string, SERVICE_LEVEL: string},
+ *     RHSM_API_RESPONSE_USAGE_TYPES: {UNSPECIFIED: string, DISASTER: string, DEVELOPMENT: string, PRODUCTION: string},
+ *     RHSM_API_QUERY_INVENTORY_SORT_DIRECTION_TYPES: {ASCENDING: string, DESCENDING: string}}}
  */
 const rhsmConstants = {
   RHSM_API_PATH_PRODUCT_TYPES,

--- a/src/types/__tests__/__snapshots__/index.test.js.snap
+++ b/src/types/__tests__/__snapshots__/index.test.js.snap
@@ -130,9 +130,11 @@ Object {
       "RHSM_API_QUERY_SUBSCRIPTIONS_SORT_TYPES": Object {
         "NEXT_EVENT_DATE": "next_event_date",
         "NEXT_EVENT_TYPE": "next_event_type",
+        "PRODUCT_NAME": "product_name",
         "QUANTITY": "quantity",
         "SERVICE_LEVEL": "service_level",
         "SKU": "sku",
+        "TOTAL_CAPACITY": "total_capacity",
         "USAGE": "usage",
       },
       "RHSM_API_QUERY_TYPES": Object {
@@ -367,9 +369,11 @@ Object {
       "RHSM_API_QUERY_SUBSCRIPTIONS_SORT_TYPES": Object {
         "NEXT_EVENT_DATE": "next_event_date",
         "NEXT_EVENT_TYPE": "next_event_type",
+        "PRODUCT_NAME": "product_name",
         "QUANTITY": "quantity",
         "SERVICE_LEVEL": "service_level",
         "SKU": "sku",
+        "TOTAL_CAPACITY": "total_capacity",
         "USAGE": "usage",
       },
       "RHSM_API_QUERY_TYPES": Object {
@@ -603,9 +607,11 @@ Object {
     "RHSM_API_QUERY_SUBSCRIPTIONS_SORT_TYPES": Object {
       "NEXT_EVENT_DATE": "next_event_date",
       "NEXT_EVENT_TYPE": "next_event_type",
+      "PRODUCT_NAME": "product_name",
       "QUANTITY": "quantity",
       "SERVICE_LEVEL": "service_level",
       "SKU": "sku",
+      "TOTAL_CAPACITY": "total_capacity",
       "USAGE": "usage",
     },
     "RHSM_API_QUERY_TYPES": Object {
@@ -843,9 +849,11 @@ Object {
     "RHSM_API_QUERY_SUBSCRIPTIONS_SORT_TYPES": Object {
       "NEXT_EVENT_DATE": "next_event_date",
       "NEXT_EVENT_TYPE": "next_event_type",
+      "PRODUCT_NAME": "product_name",
       "QUANTITY": "quantity",
       "SERVICE_LEVEL": "service_level",
       "SKU": "sku",
+      "TOTAL_CAPACITY": "total_capacity",
       "USAGE": "usage",
     },
     "RHSM_API_QUERY_TYPES": Object {


### PR DESCRIPTION


## What's included
<!-- Summary of changes/additions -->
- feat(inventoryCardSubscriptions): ent-4772 product_name sort
   * config, allow sort on products, openshift, rhel, rhosak
   * rhsmConstants, expand sort for product_name, total_capacity

<!-- ### Notes -->
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. navigate to a product that displays the subscriptions inventory: RHEL et all, OpenShift Container (left column), and/or RHOSAK
1. confirm column sorting is active and working for `Product -> product_name` and `Sockets/Cores -> total_capacity`

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
![Screen Shot 2022-02-24 at 10 32 24 AM](https://user-images.githubusercontent.com/3761375/155558905-da37a55d-4b74-45c6-935d-40af33987287.png)

    
![product_name_sort](https://user-images.githubusercontent.com/3761375/155559109-14355bc3-0773-4653-b828-9d1a5aff3fd1.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-4772