### PR TITLE
refactor(userServices): ent-4669 locale func

### DIFF
--- a/src/common/__tests__/__snapshots__/helpers.test.js.snap
+++ b/src/common/__tests__/__snapshots__/helpers.test.js.snap
@@ -34,6 +34,7 @@ Object {
   "UI_PATH": "/apps/subscriptions/",
   "UI_VERSION": "0.0.0.0000000",
   "UI_WINDOW_ID": "curiosity",
+  "aggregatedError": [Function],
   "browserExpose": [Function],
   "generateId": [Function],
   "isDate": [Function],
@@ -74,6 +75,7 @@ Object {
   "UI_PATH": "/apps/subscriptions/",
   "UI_VERSION": "0.0.0.0000000",
   "UI_WINDOW_ID": "curiosity",
+  "aggregatedError": [Function],
   "browserExpose": [Function],
   "generateId": [Function],
   "isDate": [Function],
@@ -83,6 +85,18 @@ Object {
   "noopPromise": Promise {},
   "noopTranslate": [Function],
   "numberDisplay": [Function],
+}
+`;
+
+exports[`Helpers should handle use aggregate error, or fallback: emulated aggregate error 1`] = `
+Object {
+  "aggregated": [AggregateError: testing aggregated],
+  "errors": Array [
+    [Error: lorem ipsum],
+    [Error: dolor sit],
+  ],
+  "isEmulated": true,
+  "name": "AggregateError",
 }
 `;
 
@@ -114,6 +128,7 @@ Object {
   "UI_PATH": "/apps/subscriptions/",
   "UI_VERSION": "0.0.0.0000000",
   "UI_WINDOW_ID": "curiosity",
+  "aggregatedError": [Function],
   "browserExpose": [Function],
   "generateId": [Function],
   "isDate": [Function],

--- a/src/common/__tests__/helpers.test.js
+++ b/src/common/__tests__/helpers.test.js
@@ -5,6 +5,25 @@ describe('Helpers', () => {
     expect(helpers).toMatchSnapshot('helpers');
   });
 
+  /**
+   * ToDo: review this test for writing against actual AggregateError
+   * Right now we're purposefully using the fallback to this test.
+   */
+  it('should handle use aggregate error, or fallback', () => {
+    const aggregateError = window.AggregateError;
+    window.AggregateError = undefined;
+    const aggregated = helpers.aggregatedError(
+      [new Error('lorem ipsum'), new Error('dolor sit')],
+      'testing aggregated'
+    );
+    expect({
+      aggregated,
+      ...aggregated
+    }).toMatchSnapshot('emulated aggregate error');
+
+    window.AggregateError = aggregateError;
+  });
+
   it('should support generated IDs', () => {
     expect(helpers.generateId()).toBe('generatedid-');
     expect(helpers.generateId('lorem')).toBe('lorem-');

--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -1,6 +1,30 @@
 import numbro from 'numbro';
 
 /**
+ * Fill for AggregatedError
+ *
+ * @param {Array|*} errors An array of errors
+ * @param {string|*} message
+ * @param {object} options
+ * @param {string} options.name
+ * @returns {Error|window.AggregateError<Error>}
+ */
+const aggregatedError = (errors, message, { name = 'AggregateError' } = {}) => {
+  const { AggregateError, Error } = window;
+  let err;
+
+  if (AggregateError) {
+    err = new AggregateError(errors, message);
+  } else {
+    err = new Error(message);
+    err.name = name;
+    err.errors = (Array.isArray(errors) && errors) || [errors];
+    err.isEmulated = true;
+  }
+  return err;
+};
+
+/**
  * Generate a random'ish ID.
  *
  * @param {string} prefix
@@ -297,6 +321,7 @@ const browserExpose = (obj = {}, options) => {
 };
 
 const helpers = {
+  aggregatedError,
   browserExpose,
   generateId,
   isDate,

--- a/src/services/common/__tests__/__snapshots__/helpers.test.js.snap
+++ b/src/services/common/__tests__/__snapshots__/helpers.test.js.snap
@@ -24,6 +24,7 @@ Object {
   "camelCase": [Function],
   "passDataToCallback": [Function],
   "schemaResponse": [Function],
+  "timeoutFunctionCancel": [Function],
 }
 `;
 
@@ -48,5 +49,12 @@ Object {
       ],
     },
   ],
+}
+`;
+
+exports[`Service Helpers should support cancelling function calls: timeout error 1`] = `
+Object {
+  "error": "dolor sit error",
+  "success": "lorem ipsum success",
 }
 `;

--- a/src/services/common/__tests__/helpers.test.js
+++ b/src/services/common/__tests__/helpers.test.js
@@ -5,6 +5,33 @@ describe('Service Helpers', () => {
     expect(serviceHelpers).toMatchSnapshot('serviceHelpers');
   });
 
+  it('should support cancelling function calls', async () => {
+    const mockTimeout = async (successMessage, errorMessage, pause, timeout) => {
+      const testFn = async () => {
+        await new Promise(resolve => {
+          window.setTimeout(resolve, pause);
+        });
+
+        return successMessage;
+      };
+
+      let value;
+
+      try {
+        value = await serviceHelpers.timeoutFunctionCancel(testFn, { timeout, errorMessage });
+      } catch (e) {
+        value = e.message;
+      }
+
+      return value;
+    };
+
+    const success = await mockTimeout('lorem ipsum success', 'dolor sit error', 50, 100);
+    const error = await mockTimeout('lorem ipsum success', 'dolor sit error', 100, 50);
+
+    expect({ success, error }).toMatchSnapshot('timeout error');
+  });
+
   it('should support camel casing obj keys', () => {
     expect(
       serviceHelpers.camelCase({

--- a/src/services/common/helpers.js
+++ b/src/services/common/helpers.js
@@ -3,6 +3,37 @@ import _isPlainObject from 'lodash/isPlainObject';
 import { helpers } from '../../common';
 
 /**
+ * A timeout cancel for function calls.
+ *
+ * @param {Function} func Callback to be executed or cancelled
+ * @param {object} options
+ * @param {number} options.timeout Function timeout in milliseconds
+ * @param {string} options.errorMessage What the error message will read
+ * @returns {Promise<*>}
+ */
+const timeoutFunctionCancel = (func, { timeout = 3000, errorMessage = 'function timeout' } = {}) => {
+  let clearTimer;
+
+  const timer = () =>
+    new Promise((_, reject) => {
+      clearTimer = window.setTimeout(reject, timeout, new Error(errorMessage));
+    });
+
+  const updatedFunc = async () => {
+    const response = await func();
+    window.clearTimeout(clearTimer);
+    return response;
+  };
+
+  const execFunction = () =>
+    Promise.race([timer(), updatedFunc()]).finally(() => {
+      window.clearTimeout(clearTimer);
+    });
+
+  return execFunction();
+};
+
+/**
  * Return objects with the keys camelCased. Normally applied to an array of objects.
  *
  * @param {object|Array|*} obj
@@ -81,7 +112,15 @@ const schemaResponse = ({ casing, convert = true, id = null, response, schema } 
 const serviceHelpers = {
   camelCase,
   passDataToCallback,
-  schemaResponse
+  schemaResponse,
+  timeoutFunctionCancel
 };
 
-export { serviceHelpers as default, serviceHelpers, camelCase, passDataToCallback, schemaResponse };
+export {
+  serviceHelpers as default,
+  serviceHelpers,
+  camelCase,
+  passDataToCallback,
+  schemaResponse,
+  timeoutFunctionCancel
+};

--- a/src/services/common/serviceConfig.js
+++ b/src/services/common/serviceConfig.js
@@ -12,7 +12,7 @@ const globalXhrTimeout = Number.parseInt(process.env.REACT_APP_AJAX_TIMEOUT, 10)
  * Cache Axios service call cancel tokens.
  *
  * @private
- * @type {object}
+ * @type {{}}
  */
 const globalCancelTokens = {};
 
@@ -70,7 +70,7 @@ const axiosServiceCall = async (
   // account for alterations to transforms, and other config props
   const cacheId =
     (updatedConfig.cacheResponse === true &&
-      `${btoa(
+      `${window.btoa(
         JSON.stringify(updatedConfig, (key, value) => {
           if (value !== updatedConfig && _isPlainObject(value)) {
             return (Object.entries(value).sort(([a], [b]) => a.localeCompare(b)) || []).toString();
@@ -183,14 +183,14 @@ const axiosServiceCall = async (
 
   if (typeof updatedConfig.url === 'function') {
     const emulateCallback = updatedConfig.url;
-    updatedConfig.url = '/';
+    updatedConfig.url = '/emulated';
 
-    let message = `success, emulated`;
+    let message = 'success, emulated';
     let emulatedResponse;
     let isSuccess = true;
 
     try {
-      emulatedResponse = await emulateCallback();
+      emulatedResponse = await serviceHelpers.timeoutFunctionCancel(emulateCallback, { timeout: xhrTimeout });
     } catch (e) {
       isSuccess = false;
       message = e.message || e;

--- a/src/services/user/__tests__/__snapshots__/userServices.test.js.snap
+++ b/src/services/user/__tests__/__snapshots__/userServices.test.js.snap
@@ -2,27 +2,21 @@
 
 exports[`UserServices should return a specific locale cookie value 1`] = `
 Object {
-  "data": Object {
-    "key": "English",
-    "value": "en-US",
-  },
+  "key": "English",
+  "value": "en-US",
 }
 `;
 
 exports[`UserServices should return default locale if no locale cookie is present 1`] = `
 Object {
-  "data": Object {
-    "key": "English",
-    "value": "en-US",
-  },
+  "key": "English",
+  "value": "en-US",
 }
 `;
 
 exports[`UserServices should return the default locale with an invalid ISO_639 code 1`] = `
 Object {
-  "data": Object {
-    "key": "English",
-    "value": "en-US",
-  },
+  "key": "English",
+  "value": "en-US",
 }
 `;

--- a/src/services/user/__tests__/userServices.test.js
+++ b/src/services/user/__tests__/userServices.test.js
@@ -18,12 +18,11 @@ describe('UserServices', () => {
   });
 
   it('should export a specific number of methods and classes', () => {
-    expect(Object.keys(userServices)).toHaveLength(5);
+    expect(Object.keys(userServices)).toHaveLength(4);
   });
 
   it('should have specific methods', () => {
     expect(userServices.getLocale).toBeDefined();
-    expect(userServices.logoutUser).toBeDefined();
     expect(userServices.deleteAccountOptIn).toBeDefined();
     expect(userServices.getAccountOptIn).toBeDefined();
     expect(userServices.updateAccountOptIn).toBeDefined();
@@ -43,20 +42,20 @@ describe('UserServices', () => {
   it('should return default locale if no locale cookie is present', async () => {
     const response = await userServices.getLocale();
 
-    expect(response).toMatchSnapshot();
+    expect(response.data).toMatchSnapshot();
   });
 
   it('should return a specific locale cookie value', async () => {
     Cookies.get = jest.fn().mockImplementation(() => 'en_US');
     const response = await userServices.getLocale();
 
-    expect(response).toMatchSnapshot();
+    expect(response.data).toMatchSnapshot();
   });
 
   it('should return the default locale with an invalid ISO_639 code', async () => {
     Cookies.get = jest.fn().mockImplementation(() => 'test_US');
     const response = await userServices.getLocale();
 
-    expect(response).toMatchSnapshot();
+    expect(response.data).toMatchSnapshot();
   });
 });

--- a/src/services/user/userServices.js
+++ b/src/services/user/userServices.js
@@ -4,40 +4,35 @@ import { serviceCall } from '../config';
 import { helpers } from '../../common';
 
 /**
- * Return a platform locale value from a cookie.
- *
- * @private
- * @returns {{value: string, key: string | null}|null}
+ * ToDo: Review moving the getLocale function under platformServices.
+ * Also review using window.navigator.language as the primary pull for language.
  */
-const getLocaleFromCookie = () => {
-  const value = (Cookies.get(process.env.REACT_APP_CONFIG_SERVICE_LOCALES_COOKIE) || '').replace('_', '-');
-  const key = (value && LocaleCode.getLanguageName(value)) || null;
-
-  return (key && { value, key }) || null;
-};
-
 /**
- * Return platform locale.
+ * Return a browser locale, or fallback towards the platform locale cookie
  *
- * @returns {Promise<{data: void}>}
+ * @returns {Promise<*>}
  */
 const getLocale = () => {
-  const defaultLocale = {
+  const defaultLang = {
     value: helpers.UI_LOCALE_DEFAULT,
     key: helpers.UI_LOCALE_DEFAULT_DESC
   };
+  const parseLang = value => {
+    const key = (value && LocaleCode.getLanguageName(value)) || null;
+    return (key && { value, key }) || undefined;
+  };
 
-  return new Promise(resolve =>
-    resolve({
-      data: getLocaleFromCookie() || defaultLocale
-    })
-  );
-};
+  return serviceCall({
+    url: async () => {
+      const cookieLang = await (Cookies.get(process.env.REACT_APP_CONFIG_SERVICE_LOCALES_COOKIE) || '').replace(
+        '_',
+        '-'
+      );
 
-const logoutUser = () =>
-  new Promise(resolve => {
-    resolve({});
+      return parseLang(cookieLang) || defaultLang;
+    }
   });
+};
 
 /**
  * @apiMock {DelayResponse} 2000
@@ -243,19 +238,11 @@ const updateAccountOptIn = (params = {}) =>
     params
   });
 
-const userServices = { getLocale, logoutUser, deleteAccountOptIn, getAccountOptIn, updateAccountOptIn };
+const userServices = { getLocale, deleteAccountOptIn, getAccountOptIn, updateAccountOptIn };
 
 /**
  * Expose services to the browser's developer console.
  */
 helpers.browserExpose({ userServices });
 
-export {
-  userServices as default,
-  userServices,
-  getLocale,
-  logoutUser,
-  deleteAccountOptIn,
-  getAccountOptIn,
-  updateAccountOptIn
-};
+export { userServices as default, userServices, getLocale, deleteAccountOptIn, getAccountOptIn, updateAccountOptIn };

--- a/tests/__snapshots__/code.test.js.snap
+++ b/tests/__snapshots__/code.test.js.snap
@@ -8,6 +8,6 @@ Array [
   "components/inventoryCardSubscriptions/inventoryCardSubscriptionsContext.js:127:        console.warn(\`Sorting can only be performed on select fields, confirm field \${id} is allowed.\`);",
   "redux/common/reduxHelpers.js:282:    console.error(\`Error: Property \${prop} does not exist within the passed state.\`, state);",
   "redux/common/reduxHelpers.js:286:    console.warn(\`Warning: Property \${prop} does not exist within the passed initialState.\`, initialState);",
-  "services/common/helpers.js:64:    console.error(",
+  "services/common/helpers.js:95:    console.error(",
 ]
 `;


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- refactor(userServices): ent-4669 locale func
- feat(serviceConfig): ent-4669 timeout for emulated call
- feat(helpers): ent-4669 aggregate error

### Notes
- minor helper updates, broken out from the larger session work to provide some incremental updates
- no visual changes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm GUI loads without direct error


### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. confirm tests come back clean

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-4669