### PR TITLE
Ent-4669 clean up, test updates

### DIFF
--- a/src/components/authentication/__tests__/__snapshots__/authentication.test.js.snap
+++ b/src/components/authentication/__tests__/__snapshots__/authentication.test.js.snap
@@ -92,7 +92,6 @@ exports[`Authentication Component should render a component error: error 1`] = `
       className=""
     >
       <PageHeader
-        includeTour={false}
         key=".0"
         productLabel={null}
         t={[Function]}
@@ -138,11 +137,6 @@ exports[`Authentication Component should render a component error: error 1`] = `
                       </Title>
                     </PageHeaderTitle>
                   </div>
-                </FlexItem>
-                <FlexItem>
-                  <div
-                    className=""
-                  />
                 </FlexItem>
               </div>
             </Flex>

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -282,10 +282,6 @@ Array [
     "file": "./src/components/pageLayout/pageHeader.js",
     "keys": Array [
       Object {
-        "key": "curiosity-optin.buttonTour",
-        "match": "t('curiosity-optin.buttonTour')",
-      },
-      Object {
         "key": "curiosity-view.subtitle",
         "match": "t(\`curiosity-view.subtitle\`, { appName: helpers.UI_DISPLAY_NAME, context: productLabel }, [ <Button isInline component=\\"a\\" variant=\\"link\\" icon={<ExternalLinkAltIcon />} iconPosition=\\"right\\" target=\\"_blank\\" href={helpers.UI_LINK_LEARN_MORE} /> ])",
       },

--- a/src/components/inventoryCard/__tests__/__snapshots__/inventoryCardContext.test.js.snap
+++ b/src/components/inventoryCard/__tests__/__snapshots__/inventoryCardContext.test.js.snap
@@ -13,6 +13,27 @@ Object {
 }
 `;
 
+exports[`InventoryCardContext should handle a store response with useGetInstancesInventory: store response 1`] = `
+Object {
+  "data": Array [
+    Object {
+      "data": Array [
+        Object {
+          "lorem": "ipsum",
+        },
+        Object {
+          "dolor": "sit",
+        },
+      ],
+      "meta": Object {},
+    },
+  ],
+  "error": false,
+  "fulfilled": true,
+  "pending": false,
+}
+`;
+
 exports[`InventoryCardContext should handle an onColumnSort event: onColumnSort event, dispatch 1`] = `
 Array [
   Array [
@@ -65,7 +86,7 @@ Array [
 ]
 `;
 
-exports[`InventoryCardContext should handle instances inventory API responses: inventory, cancelled 1`] = `
+exports[`InventoryCardContext should handle variations in instances inventory API responses: inventory, cancelled 1`] = `
 Object {
   "data": Object {},
   "error": undefined,
@@ -74,7 +95,7 @@ Object {
 }
 `;
 
-exports[`InventoryCardContext should handle instances inventory API responses: inventory, disabled 1`] = `
+exports[`InventoryCardContext should handle variations in instances inventory API responses: inventory, disabled 1`] = `
 Object {
   "data": Object {},
   "error": undefined,
@@ -83,7 +104,7 @@ Object {
 }
 `;
 
-exports[`InventoryCardContext should handle instances inventory API responses: inventory, error 1`] = `
+exports[`InventoryCardContext should handle variations in instances inventory API responses: inventory, error 1`] = `
 Object {
   "data": Object {},
   "error": true,
@@ -92,7 +113,7 @@ Object {
 }
 `;
 
-exports[`InventoryCardContext should handle instances inventory API responses: inventory, fulfilled 1`] = `
+exports[`InventoryCardContext should handle variations in instances inventory API responses: inventory, fulfilled 1`] = `
 Object {
   "data": Object {},
   "error": undefined,
@@ -101,7 +122,7 @@ Object {
 }
 `;
 
-exports[`InventoryCardContext should handle instances inventory API responses: inventory, pending 1`] = `
+exports[`InventoryCardContext should handle variations in instances inventory API responses: inventory, pending 1`] = `
 Object {
   "data": Object {},
   "error": undefined,

--- a/src/components/inventoryCard/__tests__/inventoryCard.test.js
+++ b/src/components/inventoryCard/__tests__/inventoryCard.test.js
@@ -6,7 +6,7 @@ import { RHSM_API_QUERY_TYPES } from '../../../types/rhsmApiTypes';
 describe('InventoryCard Component', () => {
   it('should render a basic component', async () => {
     const props = {
-      useProduct: () => ({ productId: 'lorem' }),
+      useProductInventoryConfig: () => ({ filters: [], settings: {} }),
       useProductInventoryQuery: () => ({
         [RHSM_API_QUERY_TYPES.LIMIT]: 10,
         [RHSM_API_QUERY_TYPES.OFFSET]: 0
@@ -23,7 +23,7 @@ describe('InventoryCard Component', () => {
   it('should return an empty render when disabled', async () => {
     const props = {
       isDisabled: true,
-      useProduct: () => ({ productId: 'lorem' }),
+      useProductInventoryConfig: () => ({ filters: [], settings: {} }),
       useProductInventoryQuery: () => ({
         [RHSM_API_QUERY_TYPES.LIMIT]: 10,
         [RHSM_API_QUERY_TYPES.OFFSET]: 0
@@ -47,7 +47,7 @@ describe('InventoryCard Component', () => {
 
   it('should handle multiple display states, error, pending, fulfilled', async () => {
     const props = {
-      useProduct: () => ({ productId: 'lorem' }),
+      useProductInventoryConfig: () => ({ filters: [], settings: {} }),
       useProductInventoryQuery: () => ({
         lorem: 'ipsum'
       }),
@@ -90,7 +90,7 @@ describe('InventoryCard Component', () => {
 
   it('should handle variations in data', async () => {
     const props = {
-      useProduct: () => ({ productId: 'lorem' }),
+      useProductInventoryConfig: () => ({ filters: [], settings: {} }),
       useProductInventoryQuery: () => ({
         [RHSM_API_QUERY_TYPES.LIMIT]: 10,
         [RHSM_API_QUERY_TYPES.OFFSET]: 0
@@ -121,7 +121,7 @@ describe('InventoryCard Component', () => {
 
   it('should handle expandable guests data', async () => {
     const props = {
-      useProduct: () => ({ productId: 'lorem' }),
+      useProductInventoryConfig: () => ({ filters: [], settings: {} }),
       useProductInventoryQuery: () => ({
         [RHSM_API_QUERY_TYPES.LIMIT]: 10,
         [RHSM_API_QUERY_TYPES.OFFSET]: 0

--- a/src/components/inventoryCard/__tests__/inventoryCardContext.test.js
+++ b/src/components/inventoryCard/__tests__/inventoryCardContext.test.js
@@ -18,7 +18,30 @@ describe('InventoryCardContext', () => {
     expect(SORT_TYPES).toMatchSnapshot('sort properties');
   });
 
-  it('should handle instances inventory API responses', async () => {
+  it('should handle a store response with useGetInstancesInventory', async () => {
+    const { result } = await shallowHook(
+      () =>
+        useGetInstancesInventory({
+          useProduct: () => ({ productId: 'lorem' })
+        }),
+      {
+        state: {
+          inventory: {
+            instancesInventory: {
+              lorem: {
+                fulfilled: true,
+                data: [{ data: [{ lorem: 'ipsum' }, { dolor: 'sit' }], meta: {} }]
+              }
+            }
+          }
+        }
+      }
+    );
+
+    expect(result).toMatchSnapshot('store response');
+  });
+
+  it('should handle variations in instances inventory API responses', async () => {
     const { result: errorResponse } = shallowHook(() =>
       useGetInstancesInventory({
         useProduct: () => ({ productId: 'lorem' }),

--- a/src/components/inventoryCardSubscriptions/__tests__/__snapshots__/inventoryCardSubscriptionsContext.test.js.snap
+++ b/src/components/inventoryCardSubscriptions/__tests__/__snapshots__/inventoryCardSubscriptionsContext.test.js.snap
@@ -13,6 +13,27 @@ Object {
 }
 `;
 
+exports[`InventoryCardSubscriptionsContext should handle a store response with useGetSubscriptionsInventory: store response 1`] = `
+Object {
+  "data": Array [
+    Object {
+      "data": Array [
+        Object {
+          "lorem": "ipsum",
+        },
+        Object {
+          "dolor": "sit",
+        },
+      ],
+      "meta": Object {},
+    },
+  ],
+  "error": false,
+  "fulfilled": true,
+  "pending": false,
+}
+`;
+
 exports[`InventoryCardSubscriptionsContext should handle an onColumnSort event: onColumnSort event, dispatch 1`] = `
 Array [
   Array [
@@ -65,7 +86,7 @@ Array [
 ]
 `;
 
-exports[`InventoryCardSubscriptionsContext should handle instances inventory API responses: inventory, cancelled 1`] = `
+exports[`InventoryCardSubscriptionsContext should handle variations in instances inventory API responses: inventory, cancelled 1`] = `
 Object {
   "data": Object {},
   "error": undefined,
@@ -74,7 +95,7 @@ Object {
 }
 `;
 
-exports[`InventoryCardSubscriptionsContext should handle instances inventory API responses: inventory, disabled 1`] = `
+exports[`InventoryCardSubscriptionsContext should handle variations in instances inventory API responses: inventory, disabled 1`] = `
 Object {
   "data": Object {},
   "error": undefined,
@@ -83,7 +104,7 @@ Object {
 }
 `;
 
-exports[`InventoryCardSubscriptionsContext should handle instances inventory API responses: inventory, error 1`] = `
+exports[`InventoryCardSubscriptionsContext should handle variations in instances inventory API responses: inventory, error 1`] = `
 Object {
   "data": Object {},
   "error": true,
@@ -92,7 +113,7 @@ Object {
 }
 `;
 
-exports[`InventoryCardSubscriptionsContext should handle instances inventory API responses: inventory, fulfilled 1`] = `
+exports[`InventoryCardSubscriptionsContext should handle variations in instances inventory API responses: inventory, fulfilled 1`] = `
 Object {
   "data": Object {},
   "error": undefined,
@@ -101,7 +122,7 @@ Object {
 }
 `;
 
-exports[`InventoryCardSubscriptionsContext should handle instances inventory API responses: inventory, pending 1`] = `
+exports[`InventoryCardSubscriptionsContext should handle variations in instances inventory API responses: inventory, pending 1`] = `
 Object {
   "data": Object {},
   "error": undefined,

--- a/src/components/inventoryCardSubscriptions/__tests__/inventoryCardSubscriptions.test.js
+++ b/src/components/inventoryCardSubscriptions/__tests__/inventoryCardSubscriptions.test.js
@@ -5,7 +5,7 @@ import { RHSM_API_QUERY_TYPES } from '../../../types/rhsmApiTypes';
 describe('InventoryCardSubscriptions Component', () => {
   it('should render a basic component', async () => {
     const props = {
-      useProduct: () => ({ productId: 'lorem' }),
+      useProductInventoryConfig: () => ({ filters: [], settings: {} }),
       useProductInventoryQuery: () => ({
         [RHSM_API_QUERY_TYPES.LIMIT]: 10,
         [RHSM_API_QUERY_TYPES.OFFSET]: 0

--- a/src/components/inventoryCardSubscriptions/__tests__/inventoryCardSubscriptionsContext.test.js
+++ b/src/components/inventoryCardSubscriptions/__tests__/inventoryCardSubscriptionsContext.test.js
@@ -18,7 +18,30 @@ describe('InventoryCardSubscriptionsContext', () => {
     expect(SORT_TYPES).toMatchSnapshot('sort properties');
   });
 
-  it('should handle instances inventory API responses', async () => {
+  it('should handle a store response with useGetSubscriptionsInventory', async () => {
+    const { result } = await shallowHook(
+      () =>
+        useGetSubscriptionsInventory({
+          useProduct: () => ({ productId: 'lorem' })
+        }),
+      {
+        state: {
+          inventory: {
+            subscriptionsInventory: {
+              lorem: {
+                fulfilled: true,
+                data: [{ data: [{ lorem: 'ipsum' }, { dolor: 'sit' }], meta: {} }]
+              }
+            }
+          }
+        }
+      }
+    );
+
+    expect(result).toMatchSnapshot('store response');
+  });
+
+  it('should handle variations in instances inventory API responses', async () => {
     const { result: errorResponse } = shallowHook(() =>
       useGetSubscriptionsInventory({
         useProduct: () => ({ productId: 'lorem' }),

--- a/src/components/inventoryCardSubscriptions/inventoryCardSubscriptions.js
+++ b/src/components/inventoryCardSubscriptions/inventoryCardSubscriptions.js
@@ -27,24 +27,7 @@ import { helpers } from '../../common';
  * @fires onUpdateInventoryData
  * @returns {Node}
  */
-const InventoryCardSubscriptions = ({
-  isDisabled,
-  useGetInventory: useAliasGetInventory,
-  useOnPage: useAliasOnPage,
-  useOnColumnSort: useAliasOnColumnSort,
-  useProductInventoryConfig: useAliasProductInventoryConfig,
-  useProductInventoryQuery: useAliasProductInventoryQuery
-}) => (
-  <InventoryCard
-    cardActions={null}
-    isDisabled={isDisabled}
-    useGetInventory={useAliasGetInventory}
-    useOnPage={useAliasOnPage}
-    useOnColumnSort={useAliasOnColumnSort}
-    useProductInventoryConfig={useAliasProductInventoryConfig}
-    useProductInventoryQuery={useAliasProductInventoryQuery}
-  />
-);
+const InventoryCardSubscriptions = ({ ...props }) => <InventoryCard cardActions={null} {...props} />;
 
 /**
  * Prop types.

--- a/src/components/loader/__tests__/__snapshots__/loader.test.js.snap
+++ b/src/components/loader/__tests__/__snapshots__/loader.test.js.snap
@@ -73,7 +73,6 @@ exports[`Loader Component should handle variant loader components: variant: titl
   className=""
 >
   <PageHeader
-    includeTour={false}
     productLabel={null}
     t={[Function]}
   >

--- a/src/components/messageView/__tests__/__snapshots__/messageView.test.js.snap
+++ b/src/components/messageView/__tests__/__snapshots__/messageView.test.js.snap
@@ -5,7 +5,6 @@ exports[`MessageView Component should have fallback conditions for all props: fa
   className=""
 >
   <PageHeader
-    includeTour={false}
     productLabel={null}
     t={[Function]}
   >
@@ -27,7 +26,6 @@ exports[`MessageView Component should render a non-connected component: non-conn
   className=""
 >
   <PageHeader
-    includeTour={false}
     productLabel={null}
     t={[Function]}
   >
@@ -62,7 +60,6 @@ exports[`MessageView Component should render children when provided: children di
   className=""
 >
   <PageHeader
-    includeTour={false}
     productLabel={null}
     t={[Function]}
   >

--- a/src/components/pageLayout/__tests__/__snapshots__/pageHeader.test.js.snap
+++ b/src/components/pageLayout/__tests__/__snapshots__/pageHeader.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`PageHeader Component should render a basic component: basic 1`] = `
 <PageHeader
-  includeTour={false}
   productLabel={null}
   t={[Function]}
 >
@@ -58,11 +57,6 @@ exports[`PageHeader Component should render a basic component: basic 1`] = `
               </PageHeaderTitle>
             </div>
           </FlexItem>
-          <FlexItem>
-            <div
-              className=""
-            />
-          </FlexItem>
         </div>
       </Flex>
     </section>
@@ -72,7 +66,6 @@ exports[`PageHeader Component should render a basic component: basic 1`] = `
 
 exports[`PageHeader Component should render string node types: string 1`] = `
 <PageHeader
-  includeTour={false}
   productLabel={null}
   t={[Function]}
 >
@@ -118,11 +111,6 @@ exports[`PageHeader Component should render string node types: string 1`] = `
               </PageHeaderTitle>
             </div>
           </FlexItem>
-          <FlexItem>
-            <div
-              className=""
-            />
-          </FlexItem>
         </div>
       </Flex>
     </section>
@@ -132,7 +120,6 @@ exports[`PageHeader Component should render string node types: string 1`] = `
 
 exports[`PageHeader Component should render the subtitle when viewId is provided: with subtitle 1`] = `
 <PageHeader
-  includeTour={false}
   productLabel="RHEL"
   t={[Function]}
 >
@@ -178,162 +165,11 @@ exports[`PageHeader Component should render the subtitle when viewId is provided
               </PageHeaderTitle>
             </div>
           </FlexItem>
-          <FlexItem>
-            <div
-              className=""
-            />
-          </FlexItem>
         </div>
       </Flex>
       <p>
         t(curiosity-view.subtitle, {"appName":"Subscriptions","context":"RHEL"}, [object Object])
       </p>
-    </section>
-  </PageHeader>
-</PageHeader>
-`;
-
-exports[`PageHeader Component should render the tour button when includeTour is provided: consistent html output for Pendo CSS selector 1`] = `
-<section
-  class="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
-  widget-type="InsightsPageHeader"
->
-  <div
-    class="pf-l-flex pf-m-justify-content-space-between-on-sm"
-  >
-    <div
-      class=""
-    >
-      <h1
-        class="pf-c-title pf-m-2xl pf-u-mb-sm"
-        data-ouia-component-id="OUIA-Generated-Title-4"
-        data-ouia-component-type="PF4/Title"
-        data-ouia-safe="true"
-        widget-type="InsightsPageHeaderTitle"
-      >
-        lorem
-      </h1>
-    </div>
-    <div
-      class=""
-    >
-      <button
-        aria-disabled="false"
-        class="pf-c-button pf-m-link pf-m-inline uxui-curiosity__button-tour"
-        data-ouia-component-id="OUIA-Generated-Button-link-1"
-        data-ouia-component-type="PF4/Button"
-        data-ouia-safe="true"
-        type="button"
-      >
-        <span
-          class="pf-c-label pf-m-blue"
-        >
-          <span
-            class="pf-c-label__content"
-          >
-            t(curiosity-optin.buttonTour)
-          </span>
-        </span>
-      </button>
-    </div>
-  </div>
-</section>
-`;
-
-exports[`PageHeader Component should render the tour button when includeTour is provided: with tour button 1`] = `
-<PageHeader
-  includeTour={true}
-  productLabel={null}
-  t={[Function]}
->
-  <PageHeader>
-    <section
-      className="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
-      widget-type="InsightsPageHeader"
-    >
-      <Flex
-        justifyContent={
-          Object {
-            "sm": "justifyContentSpaceBetween",
-          }
-        }
-      >
-        <div
-          className="pf-l-flex pf-m-justify-content-space-between-on-sm"
-        >
-          <FlexItem>
-            <div
-              className=""
-            >
-              <PageHeaderTitle
-                className="pf-u-mb-sm"
-                title="lorem"
-              >
-                <Title
-                  className="pf-u-mb-sm"
-                  headingLevel="h1"
-                  size="2xl"
-                  widget-type="InsightsPageHeaderTitle"
-                >
-                  <h1
-                    className="pf-c-title pf-m-2xl pf-u-mb-sm"
-                    data-ouia-component-id="OUIA-Generated-Title-4"
-                    data-ouia-component-type="PF4/Title"
-                    data-ouia-safe={true}
-                    widget-type="InsightsPageHeaderTitle"
-                  >
-                    lorem
-                  </h1>
-                </Title>
-              </PageHeaderTitle>
-            </div>
-          </FlexItem>
-          <FlexItem>
-            <div
-              className=""
-            >
-              <Button
-                className="uxui-curiosity__button-tour"
-                isInline={true}
-                variant="link"
-              >
-                <ButtonBase
-                  className="uxui-curiosity__button-tour"
-                  innerRef={null}
-                  isInline={true}
-                  variant="link"
-                >
-                  <button
-                    aria-disabled={false}
-                    aria-label={null}
-                    className="pf-c-button pf-m-link pf-m-inline uxui-curiosity__button-tour"
-                    data-ouia-component-id="OUIA-Generated-Button-link-1"
-                    data-ouia-component-type="PF4/Button"
-                    data-ouia-safe={true}
-                    disabled={false}
-                    role={null}
-                    type="button"
-                  >
-                    <Label
-                      color="blue"
-                    >
-                      <span
-                        className="pf-c-label pf-m-blue"
-                      >
-                        <span
-                          className="pf-c-label__content"
-                        >
-                          t(curiosity-optin.buttonTour)
-                        </span>
-                      </span>
-                    </Label>
-                  </button>
-                </ButtonBase>
-              </Button>
-            </div>
-          </FlexItem>
-        </div>
-      </Flex>
     </section>
   </PageHeader>
 </PageHeader>

--- a/src/components/pageLayout/__tests__/__snapshots__/pageLayout.test.js.snap
+++ b/src/components/pageLayout/__tests__/__snapshots__/pageLayout.test.js.snap
@@ -31,7 +31,6 @@ exports[`PageLayout Component should render header and section children: multipl
   className=""
 >
   <PageHeader
-    includeTour={false}
     key=".1"
     productLabel={null}
     t={[Function]}
@@ -77,11 +76,6 @@ exports[`PageLayout Component should render header and section children: multipl
                   </Title>
                 </PageHeaderTitle>
               </div>
-            </FlexItem>
-            <FlexItem>
-              <div
-                className=""
-              />
             </FlexItem>
           </div>
         </Flex>

--- a/src/components/pageLayout/__tests__/pageHeader.test.js
+++ b/src/components/pageLayout/__tests__/pageHeader.test.js
@@ -22,10 +22,4 @@ describe('PageHeader Component', () => {
     const component = mount(<PageHeader productLabel="RHEL">lorem</PageHeader>);
     expect(component).toMatchSnapshot('with subtitle');
   });
-
-  it('should render the tour button when includeTour is provided', () => {
-    const component = mount(<PageHeader includeTour>lorem</PageHeader>);
-    expect(component).toMatchSnapshot('with tour button');
-    expect(component.render()).toMatchSnapshot('consistent html output for Pendo CSS selector');
-  });
 });

--- a/src/components/pageLayout/pageHeader.js
+++ b/src/components/pageLayout/pageHeader.js
@@ -1,37 +1,25 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { PageHeader as RcsPageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components/PageHeader';
-import { Button, Flex, FlexItem, Label as PfLabel } from '@patternfly/react-core';
+import { Button, Flex, FlexItem } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { helpers } from '../../common';
 import { translate } from '../i18n/i18n';
 
 /**
- * ToDo: Review removing the "includeTour" prop and associated button code.
- * ...instead of disabling it, ENT-4247
- */
-/**
  * Render a platform page header.
  *
  * @param {object} props
  * @param {Node} props.children
- * @param {boolean} props.includeTour
  * @param {string} props.productLabel
  * @param {Function} props.t
  * @returns {Node}
  */
-const PageHeader = ({ children, includeTour, productLabel, t }) => (
+const PageHeader = ({ children, productLabel, t }) => (
   <RcsPageHeader>
     <Flex justifyContent={{ sm: 'justifyContentSpaceBetween' }}>
       <FlexItem>
         <PageHeaderTitle title={children} className="pf-u-mb-sm" />
-      </FlexItem>
-      <FlexItem>
-        {includeTour && (
-          <Button variant="link" className="uxui-curiosity__button-tour" isInline>
-            <PfLabel color="blue">{t('curiosity-optin.buttonTour')}</PfLabel>
-          </Button>
-        )}
       </FlexItem>
     </Flex>
     {productLabel && (
@@ -55,11 +43,10 @@ const PageHeader = ({ children, includeTour, productLabel, t }) => (
 /**
  * Prop types.
  *
- * @type {{children: Node, includeTour: boolean, productLabel: string, t: Function}}
+ * @type {{children: React.ReactNode, productLabel: string, t: Function}}
  */
 PageHeader.propTypes = {
   children: PropTypes.node.isRequired,
-  includeTour: PropTypes.bool,
   productLabel: PropTypes.string,
   t: PropTypes.func
 };
@@ -70,7 +57,6 @@ PageHeader.propTypes = {
  * @type {{includeTour: boolean, productLabel: null, t: translate}}
  */
 PageHeader.defaultProps = {
-  includeTour: false,
   productLabel: null,
   t: translate
 };

--- a/src/components/productView/__tests__/__snapshots__/productView.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productView.test.js.snap
@@ -5,7 +5,6 @@ exports[`ProductView Component should allow custom inventory displays via config
   className=""
 >
   <PageHeader
-    includeTour={false}
     productLabel="lorem ipsum product label"
     t={[Function]}
   >
@@ -158,7 +157,6 @@ exports[`ProductView Component should allow custom product views via props: cust
   className=""
 >
   <PageHeader
-    includeTour={false}
     productLabel="lorem ipsum product label"
     t={[Function]}
   >
@@ -295,7 +293,6 @@ exports[`ProductView Component should allow custom product views via props: cust
   className=""
 >
   <PageHeader
-    includeTour={false}
     productLabel="lorem ipsum product label"
     t={[Function]}
   >
@@ -380,7 +377,6 @@ exports[`ProductView Component should render a basic component: basic 1`] = `
   className=""
 >
   <PageHeader
-    includeTour={false}
     productLabel="lorem ipsum product label"
     t={[Function]}
   >
@@ -495,7 +491,6 @@ exports[`ProductView Component should render nothing if path and product paramet
   className=""
 >
   <PageHeader
-    includeTour={false}
     productLabel={null}
     t={[Function]}
   >

--- a/src/components/productView/__tests__/__snapshots__/productViewMissing.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productViewMissing.test.js.snap
@@ -21,7 +21,6 @@ exports[`ProductViewMissing Component should render a non-connected component: n
   className="curiosity-missing-view"
 >
   <PageHeader
-    includeTour={false}
     productLabel="missing"
     t={[Function]}
   >
@@ -187,7 +186,6 @@ exports[`ProductViewMissing Component should render a predictable set of product
   className="curiosity-missing-view"
 >
   <PageHeader
-    includeTour={false}
     productLabel="missing"
     t={[Function]}
   >

--- a/src/components/productView/__tests__/__snapshots__/productViewOpenShiftContainer.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productViewOpenShiftContainer.test.js.snap
@@ -5,7 +5,6 @@ exports[`ProductViewOpenShiftContainer Component should render a basic component
   className=""
 >
   <PageHeader
-    includeTour={false}
     productLabel="lorem ipsum product label"
     t={[Function]}
   >

--- a/src/services/common/__tests__/__snapshots__/helpers.test.js.snap
+++ b/src/services/common/__tests__/__snapshots__/helpers.test.js.snap
@@ -28,12 +28,24 @@ Object {
 }
 `;
 
+exports[`Service Helpers should support applying data to a supplied callback: passDataToCallback, error 1`] = `
+Object {
+  "data": Array [
+    Object {
+      "dolor": "sit",
+    },
+  ],
+  "error": [Error: hello world],
+}
+`;
+
 exports[`Service Helpers should support applying data to a supplied callback: passDataToCallback, success 1`] = `
 Array [
   Array [
     Object {
       "hello": "world",
     },
+    "lorem ipsum",
   ],
 ]
 `;

--- a/src/services/common/__tests__/__snapshots__/serviceConfig.test.js.snap
+++ b/src/services/common/__tests__/__snapshots__/serviceConfig.test.js.snap
@@ -13,12 +13,12 @@ Array [
 
 exports[`ServiceConfig should handle caching service calls: cached responses, emulated 304 1`] = `
 Array [
-  "1. method=get, status=200, desc=initial call",
-  "2. method=get, status=304, desc=repeat 1st call and config",
-  "3. method=get, status=200, desc=updated config",
-  "4. method=post, status=200, desc=attempt post method",
-  "5. method=get, status=304, desc=repeat 3rd call and config",
-  "6. method=get, status=200, desc=no caching",
+  "1. method=get, status=200, cacheId=eyJ0aW1lb3V0Ijo2MDAwMCwidXJsIjoiL3Rlc3QvIiwicGFyYW1zIjoiW1tcImRvbG9yXCIsXCJzaXRcIl0sW1wibG9yZW1cIixcImlwc3VtXCJdXSIsImV4cG9zZUNhY2hlSWQiOnRydWUsImNhY2hlUmVzcG9uc2UiOnRydWUsIm1ldGhvZCI6ImdldCJ9, desc=initial call",
+  "2. method=get, status=304, cacheId=eyJ0aW1lb3V0Ijo2MDAwMCwidXJsIjoiL3Rlc3QvIiwicGFyYW1zIjoiW1tcImRvbG9yXCIsXCJzaXRcIl0sW1wibG9yZW1cIixcImlwc3VtXCJdXSIsImV4cG9zZUNhY2hlSWQiOnRydWUsImNhY2hlUmVzcG9uc2UiOnRydWUsIm1ldGhvZCI6ImdldCJ9, desc=repeat 1st call and config",
+  "3. method=get, status=200, cacheId=eyJ0aW1lb3V0Ijo2MDAwMCwidXJsIjoiL3Rlc3QvIiwicGFyYW1zIjoiW1tcImxvcmVtXCIsXCJpcHN1bVwiXV0iLCJleHBvc2VDYWNoZUlkIjp0cnVlLCJjYWNoZVJlc3BvbnNlIjp0cnVlLCJtZXRob2QiOiJnZXQifQ==, desc=updated config",
+  "4. method=post, status=200, cacheId=null, desc=attempt post method",
+  "5. method=get, status=304, cacheId=eyJ0aW1lb3V0Ijo2MDAwMCwidXJsIjoiL3Rlc3QvIiwicGFyYW1zIjoiW1tcImxvcmVtXCIsXCJpcHN1bVwiXV0iLCJleHBvc2VDYWNoZUlkIjp0cnVlLCJjYWNoZVJlc3BvbnNlIjp0cnVlLCJtZXRob2QiOiJnZXQifQ==, desc=repeat 3rd call and config",
+  "6. method=get, status=200, cacheId=null, desc=no caching",
 ]
 `;
 

--- a/src/services/common/__tests__/helpers.test.js
+++ b/src/services/common/__tests__/helpers.test.js
@@ -51,17 +51,29 @@ describe('Service Helpers', () => {
   it('should support applying data to a supplied callback', () => {
     const mockSchema = jest.fn();
 
-    serviceHelpers.passDataToCallback({ hello: 'world' }, mockSchema);
+    serviceHelpers.passDataToCallback(mockSchema, { hello: 'world' }, 'lorem ipsum');
 
     expect(mockSchema.mock.calls).toMatchSnapshot('passDataToCallback, success');
 
     mockSchema.mockClear();
+
+    expect(
+      serviceHelpers.passDataToCallback(
+        () => {
+          throw new Error('hello world');
+        },
+        { dolor: 'sit' }
+      )
+    ).toMatchSnapshot('passDataToCallback, error');
   });
 
   it('should attempt to apply a Joi schema to a response', () => {
     const mockValidate = jest.fn().mockImplementation(response => ({ value: response }));
 
-    serviceHelpers.schemaResponse({ schema: { validate: mockValidate }, response: { lorem_ipsum: 'dolor_sit' } });
+    serviceHelpers.schemaResponse({
+      schema: { validate: mockValidate },
+      response: { lorem_ipsum: 'dolor_sit' }
+    });
     expect(mockValidate.mock.calls).toMatchSnapshot('schemaResponse, parameters');
 
     expect(
@@ -71,5 +83,7 @@ describe('Service Helpers', () => {
         casing: 'camel'
       })
     ).toMatchSnapshot('schemaResponse, camelCasing');
+
+    mockValidate.mockClear();
   });
 });

--- a/src/services/common/__tests__/serviceConfig.test.js
+++ b/src/services/common/__tests__/serviceConfig.test.js
@@ -106,7 +106,9 @@ describe('ServiceConfig', () => {
       params: { lorem: 'ipsum', dolor: 'sit' },
       exposeCacheId: true
     });
-    responses.push(`1. method=get, status=${responseOne.status}, desc=initial call`);
+    responses.push(
+      `1. method=get, status=${responseOne.status}, cacheId=${responseOne.request.config.cacheId}, desc=initial call`
+    );
 
     // Second, call the same endpoint with same params, expect a cached response, emulated 304
     const responseTwo = await serviceConfig.axiosServiceCall({
@@ -115,7 +117,9 @@ describe('ServiceConfig', () => {
       params: { lorem: 'ipsum', dolor: 'sit' },
       exposeCacheId: true
     });
-    responses.push(`2. method=get, status=${responseTwo.status}, desc=repeat 1st call and config`);
+    responses.push(
+      `2. method=get, status=${responseTwo.status}, cacheId=${responseTwo.request.config.cacheId}, desc=repeat 1st call and config`
+    );
 
     // Third, updating config creates a new cache
     const responseThree = await serviceConfig.axiosServiceCall({
@@ -124,7 +128,9 @@ describe('ServiceConfig', () => {
       params: { lorem: 'ipsum' },
       exposeCacheId: true
     });
-    responses.push(`3. method=get, status=${responseThree.status}, desc=updated config`);
+    responses.push(
+      `3. method=get, status=${responseThree.status}, cacheId=${responseThree.request.config.cacheId}, desc=updated config`
+    );
 
     // Fourth, confirm cache isn't created for other methods, i.e. post
     const responseFour = await serviceConfig.axiosServiceCall({
@@ -134,7 +140,9 @@ describe('ServiceConfig', () => {
       params: { lorem: 'ipsum' },
       exposeCacheId: true
     });
-    responses.push(`4. method=post, status=${responseFour.status}, desc=attempt post method`);
+    responses.push(
+      `4. method=post, status=${responseFour.status}, cacheId=${responseFour.request.config.cacheId}, desc=attempt post method`
+    );
 
     // Fifth, confirm cache exists from responseThree
     const responseFive = await serviceConfig.axiosServiceCall({
@@ -143,7 +151,9 @@ describe('ServiceConfig', () => {
       params: { lorem: 'ipsum' },
       exposeCacheId: true
     });
-    responses.push(`5. method=get, status=${responseFive.status}, desc=repeat 3rd call and config`);
+    responses.push(
+      `5. method=get, status=${responseFive.status}, cacheId=${responseFive.request.config.cacheId}, desc=repeat 3rd call and config`
+    );
 
     // Six, don't use a cache
     const responseSix = await serviceConfig.axiosServiceCall({
@@ -152,7 +162,9 @@ describe('ServiceConfig', () => {
       params: { lorem: 'ipsum' },
       exposeCacheId: true
     });
-    responses.push(`6. method=get, status=${responseSix.status}, desc=no caching`);
+    responses.push(
+      `6. method=get, status=${responseSix.status}, cacheId=${responseSix.request.config.cacheId}, desc=no caching`
+    );
 
     expect(responses).toMatchSnapshot('cached responses, emulated 304');
   });

--- a/src/services/common/helpers.js
+++ b/src/services/common/helpers.js
@@ -60,16 +60,16 @@ const camelCase = obj => {
 /**
  * Apply data to a callback, pass original data on error.
  *
- * @param {object} data
  * @param {Function} callback
+ * @param {Array} data
  * @returns {{data: *, error}}
  */
-const passDataToCallback = (data, callback) => {
+const passDataToCallback = (callback, ...data) => {
   let error;
   let updatedData = data;
 
   try {
-    updatedData = callback(data);
+    updatedData = callback(...data);
   } catch (e) {
     error = e;
   }

--- a/src/services/common/serviceConfig.js
+++ b/src/services/common/serviceConfig.js
@@ -134,8 +134,9 @@ const axiosServiceCall = async (
       transformers[0] = response => {
         const updatedResponse = { ...response };
         const { data, error: normalizeError } = serviceHelpers.passDataToCallback(
+          successTransform,
           updatedResponse.data,
-          successTransform
+          updatedResponse.config
         );
 
         if (!normalizeError) {
@@ -155,8 +156,9 @@ const axiosServiceCall = async (
         }
 
         const { data, error: normalizeError } = serviceHelpers.passDataToCallback(
+          errorTransform,
           updatedResponse?.data || updatedResponse?.message,
-          errorTransform
+          updatedResponse.config
         );
 
         if (!normalizeError) {


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(pageHeader): clean up unused take a tour
- fix(inventoryCardSubscriptions): clean up props, inventory tests
- feat(serviceConfig,helpers): ent-4669 pass config for transformers

### Notes
- minor non-visual clean up of components, tests
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm products render as expected

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-4669