### PR TITLE
fix(config): ent-3230 unlimited quantity, use aria-label

### DIFF
--- a/src/components/chart/__tests__/__snapshots__/chartIcon.test.js.snap
+++ b/src/components/chart/__tests__/__snapshots__/chartIcon.test.js.snap
@@ -49,6 +49,7 @@ exports[`ChartIcon Component should handle basic icons, variations in settings: 
   className="curiosity-chartarea__icon curiosity-chartarea__icon-eye"
 >
   <EyeIcon
+    aria-label="hello world"
     color="currentColor"
     noVerticalAlign={false}
     size="md"
@@ -75,7 +76,6 @@ exports[`ChartIcon Component should handle basic icons, variations in settings: 
   className="curiosity-chartarea__icon curiosity-chartarea__icon-infinity"
 >
   <span
-    aria-label="lorem ipsum infinity"
     className="curiosity-icon__f-infinity"
     style={
       Object {

--- a/src/components/chart/__tests__/chartIcon.test.js
+++ b/src/components/chart/__tests__/chartIcon.test.js
@@ -15,7 +15,8 @@ describe('ChartIcon Component', () => {
       {
         size: 'md',
         symbol: 'eye',
-        title: 'lorem ipsum eye'
+        title: 'lorem ipsum eye',
+        'aria-label': 'hello world'
       },
       {
         size: 'md',

--- a/src/components/chart/chartIcon.js
+++ b/src/components/chart/chartIcon.js
@@ -34,12 +34,12 @@ const getSize = size => {
  * @param {string} props.symbol
  * @param {string} props.size
  * @param {string} props.title
- * @returns {Node}
+ * @returns {React.ReactNode}
  */
-const ChartIcon = ({ fill, symbol, size, title }) => {
-  const svgProps = {};
-  const iconProps = { size, title };
-  const fontProps = { style: { fontSize: getSize(size) }, title, 'aria-label': title };
+const ChartIcon = ({ fill, symbol, size, title, ...props }) => {
+  const svgProps = { ...props };
+  const iconProps = { size, title, ...props };
+  const fontProps = { style: { fontSize: getSize(size) }, title, ...props };
   const emSvgSize = getSize(size);
 
   if (title) {
@@ -106,6 +106,11 @@ const ChartIcon = ({ fill, symbol, size, title }) => {
   return <span className={`curiosity-chartarea__icon curiosity-chartarea__icon-${symbol}`}>{setIcon()}</span>;
 };
 
+/**
+ * Prop types.
+ *
+ * @type {{symbol: string, size: string, fill: string, title: string}}
+ */
 ChartIcon.propTypes = {
   fill: PropTypes.string,
   size: PropTypes.oneOf([...Object.keys(IconSize)]),
@@ -113,6 +118,11 @@ ChartIcon.propTypes = {
   title: PropTypes.string
 };
 
+/**
+ * Default props.
+ *
+ * @type {{symbol: string, size: string, fill: null, title: null}}
+ */
 ChartIcon.defaultProps = {
   fill: null,
   size: 'sm',

--- a/src/config/__tests__/__snapshots__/product.openshiftContainer.test.js.snap
+++ b/src/config/__tests__/__snapshots__/product.openshiftContainer.test.js.snap
@@ -298,10 +298,11 @@ Object {
         position="top"
       >
         <ChartIcon
+          aria-label="t(curiosity-inventory.label, {\\"context\\":\\"hasInfiniteQuantity\\"})"
           fill={null}
           size="sm"
           symbol="infinity"
-          title="t(curiosity-inventory.label, {\\"context\\":\\"hasInfiniteQuantity\\"})"
+          title={null}
         />
       </Tooltip>,
     },
@@ -387,10 +388,11 @@ Object {
         position="top"
       >
         <ChartIcon
+          aria-label="t(curiosity-inventory.label, {\\"context\\":\\"hasInfiniteQuantity\\"})"
           fill={null}
           size="sm"
           symbol="infinity"
-          title="t(curiosity-inventory.label, {\\"context\\":\\"hasInfiniteQuantity\\"})"
+          title={null}
         />
       </Tooltip>,
     },

--- a/src/config/__tests__/__snapshots__/product.rhel.test.js.snap
+++ b/src/config/__tests__/__snapshots__/product.rhel.test.js.snap
@@ -330,10 +330,11 @@ Object {
         position="top"
       >
         <ChartIcon
+          aria-label="t(curiosity-inventory.label, {\\"context\\":\\"hasInfiniteQuantity\\"})"
           fill={null}
           size="sm"
           symbol="infinity"
-          title="t(curiosity-inventory.label, {\\"context\\":\\"hasInfiniteQuantity\\"})"
+          title={null}
         />
       </Tooltip>,
     },
@@ -419,10 +420,11 @@ Object {
         position="top"
       >
         <ChartIcon
+          aria-label="t(curiosity-inventory.label, {\\"context\\":\\"hasInfiniteQuantity\\"})"
           fill={null}
           size="sm"
           symbol="infinity"
-          title="t(curiosity-inventory.label, {\\"context\\":\\"hasInfiniteQuantity\\"})"
+          title={null}
         />
       </Tooltip>,
     },

--- a/src/config/__tests__/__snapshots__/product.rhosak.test.js.snap
+++ b/src/config/__tests__/__snapshots__/product.rhosak.test.js.snap
@@ -278,10 +278,11 @@ Object {
         position="top"
       >
         <ChartIcon
+          aria-label="t(curiosity-inventory.label, {\\"context\\":\\"hasInfiniteQuantity\\"})"
           fill={null}
           size="sm"
           symbol="infinity"
-          title="t(curiosity-inventory.label, {\\"context\\":\\"hasInfiniteQuantity\\"})"
+          title={null}
         />
       </Tooltip>,
     },
@@ -367,10 +368,11 @@ Object {
         position="top"
       >
         <ChartIcon
+          aria-label="t(curiosity-inventory.label, {\\"context\\":\\"hasInfiniteQuantity\\"})"
           fill={null}
           size="sm"
           symbol="infinity"
-          title="t(curiosity-inventory.label, {\\"context\\":\\"hasInfiniteQuantity\\"})"
+          title={null}
         />
       </Tooltip>,
     },

--- a/src/config/product.openshiftContainer.js
+++ b/src/config/product.openshiftContainer.js
@@ -203,7 +203,7 @@ const config = {
           const content = translate('curiosity-inventory.label', { context: ['hasInfiniteQuantity', uom?.value] });
           return (
             <Tooltip content={content}>
-              <ChartIcon symbol="infinity" title={content} />
+              <ChartIcon symbol="infinity" aria-label={content} />
             </Tooltip>
           );
         }

--- a/src/config/product.rhel.js
+++ b/src/config/product.rhel.js
@@ -219,7 +219,7 @@ const config = {
           const content = translate('curiosity-inventory.label', { context: ['hasInfiniteQuantity', uom?.value] });
           return (
             <Tooltip content={content}>
-              <ChartIcon symbol="infinity" title={content} />
+              <ChartIcon symbol="infinity" aria-label={content} />
             </Tooltip>
           );
         }

--- a/src/config/product.rhosak.js
+++ b/src/config/product.rhosak.js
@@ -221,7 +221,7 @@ const config = {
           const content = translate('curiosity-inventory.label', { context: ['hasInfiniteQuantity', uom?.value] });
           return (
             <Tooltip content={content}>
-              <ChartIcon symbol="infinity" title={content} />
+              <ChartIcon symbol="infinity" aria-label={content} />
             </Tooltip>
           );
         }


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(config): ent-3230 unlimited quantity, use aria-label

### Notes
- corrects the dual tooltip display, dependent on browser and os
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm that infinite subscription table cells no longer display a "dual tooltip"

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
### Fixed
![Screen Shot 2022-04-13 at 12 07 01 PM (2)](https://user-images.githubusercontent.com/3761375/163223296-4bfbda15-5321-4b27-b7ea-bc96cc62f6df.png)



### Original
![Screen Shot 2022-04-13 at 12 05 25 PM (2)](https://user-images.githubusercontent.com/3761375/163223118-e196b68a-74c0-4a97-8fdd-3e969f855e2b.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-3230