### PR TITLE
Ephemeral Environments onboarding step 2

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -5,6 +5,8 @@
 # --------------------------------------------
 # name of app-sre "application" folder this component lives in; needs to match for quay
 export COMPONENT="rhsm"
+# IMAGE should match the quay repo set by app.yaml in app-interface
+export IMAGE="quay.io/cloudservices/curiosity-frontend"
 export APP_NAME=`node -e 'console.log(require("./package.json").insights.appname)'`
 export APP_ROOT=$(pwd)
 export NODE_BUILD_VERSION=`node -e 'console.log(require("./package.json").engines.node.match(/(\d+)\.\d+\.\d+/)[1])'`

--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -1,0 +1,82 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: rhsm-frontend
+objects:
+  - apiVersion: cloud.redhat.com/v1alpha1
+    kind: Frontend
+    metadata:
+      # this must match appList value in frontend-configs/deploy/deploy.yaml
+      name: subscriptions
+    spec:
+      envName: ${ENV_NAME}
+      title: rhsm
+      deploymentRepo: https://github.com/RedHatInsights/curiosity-frontend
+      API:
+        versions:
+          - v1
+      frontend:
+        paths:
+          - /apps/subscriptions
+      image: ${IMAGE}:${IMAGE_TAG}
+      navItems:
+        # use *-navigation.json in cloud-services-config for reference
+        - title: "Subscriptions"
+          expandable: true
+          routes:
+            - appId: "subscriptions"
+              title: "All RHEL"
+              href: "/insights/subscriptions/rhel"
+              product: "Subscription Watch"
+            - appId: "subscriptions"
+              title: "ARM"
+              href: "/insights/subscriptions/rhel-arm"
+              product: "Subscription Watch"
+            - appId: "subscriptions"
+              title: "IBM Power"
+              href: "/insights/subscriptions/rhel-ibmpower"
+              product: "Subscription Watch"
+            - appId: "subscriptions"
+              title: "IBM Z systems"
+              href: "/insights/subscriptions/rhel-ibmz"
+              product: "Subscription Watch"
+            - appId: "subscriptions"
+              title: "X86"
+              href: "/insights/subscriptions/rhel-x86"
+              product: "Subscription Watch"
+            - appId: "subscriptions"
+              title: "OpenShift Subscriptions"
+              href: "/openshift/subscriptions/openshift-container"
+              product: "Subscription Watch"
+            - appId: "subscriptions"
+              title: "Dedicated (On-Demand)"
+              href: "/openshift/subscriptions/openshift-dedicated"
+              product: "Subscription Watch"
+            - appId: "subscriptions"
+              title: "Streams for Apache Kafka"
+              href: "/application-services/subscriptions/streams"
+              product: "Subscription Watch"
+      module:
+        # this should match chrome/fed-modules.json in cloud-services-config
+        manifestLocation: "/apps/subscriptions/fed-mods.json"
+        modules:
+          - id: "application-services-subscriptions"
+            module: "./RootApp"
+            routes:
+              - pathname: "/application-services/subscriptions"
+          - id: "insights-subscriptions"
+            module: "./RootApp"
+            routes:
+              - pathname: "/insights/subscriptions"
+          - id: "openshift-subscriptions"
+            module: "./RootApp"
+            routes:
+              - pathname: "/openshift/subscriptions"
+
+parameters:
+  - name: ENV_NAME
+    required: true
+  - name: IMAGE_TAG
+    required: true
+  - name: IMAGE
+    value: quay.io/cloudservices/rhsm-frontend

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -5,6 +5,8 @@
 # --------------------------------------------
 # name of app-sre "application" folder this component lives in; needs to match for quay
 export COMPONENT="rhsm"
+# IMAGE should match the quay repo set by app.yaml in app-interface
+export IMAGE="quay.io/cloudservices/curiosity-frontend"
 export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
 export APP_ROOT=$(pwd)
 export NODE_BUILD_VERSION=`node -e 'console.log(require("./package.json").engines.node.match(/(\d+)\.\d+\.\d+/)[1])'`


### PR DESCRIPTION
## What's included

* Set `IMAGE` in `build_deploy.sh` and `pr_check.sh` scripts, see RHCLOUD-18589
* Provide `deploy/frontend.yaml` file, required by frontend-operator to deploy curiosity on ephemeral env

`IMAGE` is URL of container image. If we want to change it from rhsm-frontend to whatever we want, now would be a good time. This name must match name in app-interface, but I'll handle the PR.

`frontend.yaml` is resource template. The idea is something like that:

* bonfire will consult app-interfaces to get the list of applications and their components
* component needs resource template to be deployable
* depending on other flags, bonfire will deploy component or not

In other words: we need this file to create PR in app-interfaces adding frontend component to rhsm. And once app-interfaces PR is merged, we will be able to do:

```
bonfire deploy rhsm --frontends=true
```

This will reserve ephemeral namespace, deploy rhsm with all dependencies (rbac, cloudigrade, what have you) and deploy curiosity with all dependencies (chrome, landing page, dashboard). So you will get fully-functional SWatch in ephemeral environment.

*Right now* rhsm seems to be undeployable (times out while waiting for cloudigrade), but I am confident this reasoning is correct.

`navItems` is kind of a stub, it does not reflect menu structure currently used in prod / stage. In fact, it's not yet possible to re-create prod menu structure in ephemeral env (RHCLOUD-19211). But we can iterate over it later.