### PR TITLE
fix(rhosak): ent-4982 activate sort, storage GiB months

### DIFF
--- a/src/config/product.rhosak.js
+++ b/src/config/product.rhosak.js
@@ -178,7 +178,7 @@ const config = {
           context: RHSM_API_PATH_METRIC_TYPES.STORAGE_GIBIBYTE_MONTHS,
           total: helpers.numberDisplay(total?.value)?.format({ mantissa: 5, trimMantissa: true }) || 0
         }),
-      isSortable: false,
+      isSortable: true,
       isWrappable: true,
       cellWidth: 15
     },


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(rhosak): ent-4982 activate sort, storage GiB months

### Notes
- activates the sort for storage GiB months inventory column
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests pass
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm the "streams"/RHOSAK column for storage can now be sorted with the column header button

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
![Screen Shot 2022-06-13 at 12 08 05 PM](https://user-images.githubusercontent.com/3761375/173397087-67e6321a-b8fd-4a54-9471-8b0d11900269.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-4982
