### PR TITLE
fix(rhosak,rhacs): ent-5129 (sw-47) billing provider for subscriptions inventory

### DIFF
--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -623,6 +623,10 @@ Array [
       },
       Object {
         "key": "",
+        "match": "translate(\`curiosity-inventory.measurement_\${SUBSCRIPTIONS_INVENTORY_TYPES.BILLING_PROVIDER}\`, { context: provider?.value || 'none' })",
+      },
+      Object {
+        "key": "",
         "match": "translate(\`curiosity-inventory.label_\${SUBSCRIPTIONS_INVENTORY_META_TYPES.SUBSCRIPTION_TYPE}\`, { context: subscriptionType || EMPTY_CONTEXT })",
       },
     ],
@@ -698,6 +702,10 @@ Array [
       Object {
         "key": "curiosity-inventory.measurement",
         "match": "translate('curiosity-inventory.measurement', { context: RHSM_API_PATH_METRIC_TYPES.INSTANCE_HOURS, total: helpers.numberDisplay(total?.value)",
+      },
+      Object {
+        "key": "",
+        "match": "translate(\`curiosity-inventory.measurement_\${SUBSCRIPTIONS_INVENTORY_TYPES.BILLING_PROVIDER}\`, { context: provider?.value || 'none' })",
       },
       Object {
         "key": "",

--- a/src/config/__tests__/__snapshots__/product.rhacs.test.js.snap
+++ b/src/config/__tests__/__snapshots__/product.rhacs.test.js.snap
@@ -164,6 +164,9 @@ Object {
       "title": "lorem",
     },
     Object {
+      "title": "t(curiosity-inventory.measurement_billing_provider, {\\"context\\":\\"none\\"})",
+    },
+    Object {
       "title": "hello world",
     },
     Object {
@@ -180,6 +183,12 @@ Object {
     Object {
       "title": "t(curiosity-inventory.header, {\\"context\\":\\"product_name\\"})",
       "transforms": Array [],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"billing_provider\\"})",
+      "transforms": Array [
+        [Function],
+      ],
     },
     Object {
       "title": "t(curiosity-inventory.header, {\\"context\\":\\"service_level\\"})",
@@ -238,6 +247,9 @@ Object {
       "title": "lorem",
     },
     Object {
+      "title": "t(curiosity-inventory.measurement_billing_provider, {\\"context\\":\\"none\\"})",
+    },
+    Object {
       "title": "",
     },
     Object {
@@ -254,6 +266,12 @@ Object {
     Object {
       "title": "t(curiosity-inventory.header, {\\"context\\":\\"product_name\\"})",
       "transforms": Array [],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"billing_provider\\"})",
+      "transforms": Array [
+        [Function],
+      ],
     },
     Object {
       "title": "t(curiosity-inventory.header, {\\"context\\":\\"service_level\\"})",

--- a/src/config/__tests__/__snapshots__/product.rhosak.test.js.snap
+++ b/src/config/__tests__/__snapshots__/product.rhosak.test.js.snap
@@ -280,6 +280,9 @@ Object {
       "title": "lorem",
     },
     Object {
+      "title": "t(curiosity-inventory.measurement_billing_provider, {\\"context\\":\\"none\\"})",
+    },
+    Object {
       "title": "hello world",
     },
     Object {
@@ -296,6 +299,12 @@ Object {
     Object {
       "title": "t(curiosity-inventory.header, {\\"context\\":\\"product_name\\"})",
       "transforms": Array [],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"billing_provider\\"})",
+      "transforms": Array [
+        [Function],
+      ],
     },
     Object {
       "title": "t(curiosity-inventory.header, {\\"context\\":\\"service_level\\"})",
@@ -354,6 +363,9 @@ Object {
       "title": "lorem",
     },
     Object {
+      "title": "t(curiosity-inventory.measurement_billing_provider, {\\"context\\":\\"none\\"})",
+    },
+    Object {
       "title": "",
     },
     Object {
@@ -370,6 +382,12 @@ Object {
     Object {
       "title": "t(curiosity-inventory.header, {\\"context\\":\\"product_name\\"})",
       "transforms": Array [],
+    },
+    Object {
+      "title": "t(curiosity-inventory.header, {\\"context\\":\\"billing_provider\\"})",
+      "transforms": Array [
+        [Function],
+      ],
     },
     Object {
       "title": "t(curiosity-inventory.header, {\\"context\\":\\"service_level\\"})",

--- a/src/config/product.rhacs.js
+++ b/src/config/product.rhacs.js
@@ -155,6 +155,16 @@ const config = {
       isWrappable: true
     },
     {
+      id: SUBSCRIPTIONS_INVENTORY_TYPES.BILLING_PROVIDER,
+      cell: ({ [SUBSCRIPTIONS_INVENTORY_TYPES.BILLING_PROVIDER]: provider }) =>
+        translate(`curiosity-inventory.measurement_${SUBSCRIPTIONS_INVENTORY_TYPES.BILLING_PROVIDER}`, {
+          context: provider?.value || 'none'
+        }),
+      isSortable: true,
+      isWrappable: false,
+      cellWidth: 15
+    },
+    {
       id: SUBSCRIPTIONS_INVENTORY_TYPES.SERVICE_LEVEL,
       isSortable: true,
       isWrappable: true,

--- a/src/config/product.rhosak.js
+++ b/src/config/product.rhosak.js
@@ -213,6 +213,16 @@ const config = {
       isWrappable: true
     },
     {
+      id: SUBSCRIPTIONS_INVENTORY_TYPES.BILLING_PROVIDER,
+      cell: ({ [SUBSCRIPTIONS_INVENTORY_TYPES.BILLING_PROVIDER]: provider }) =>
+        translate(`curiosity-inventory.measurement_${SUBSCRIPTIONS_INVENTORY_TYPES.BILLING_PROVIDER}`, {
+          context: provider?.value || 'none'
+        }),
+      isSortable: true,
+      isWrappable: false,
+      cellWidth: 15
+    },
+    {
       id: SUBSCRIPTIONS_INVENTORY_TYPES.SERVICE_LEVEL,
       isSortable: true,
       isWrappable: true,

--- a/src/services/rhsm/rhsmServices.js
+++ b/src/services/rhsm/rhsmServices.js
@@ -2297,6 +2297,7 @@ const getInstancesInventory = (id, params = {}, options = {}) => {
  *         {
  *           "sku": "RH00011",
  *           "product_name": "Red Hat Enterprise Linux Server, Premium (Physical and 4 Virtual Nodes)(L3 Only)",
+ *           "billing_provider": "red hat",
  *           "service_level": "Premium",
  *           "usage": "Production",
  *           "subscriptions": [
@@ -2316,6 +2317,7 @@ const getInstancesInventory = (id, params = {}, options = {}) => {
  *         {
  *           "sku": "RH00010",
  *           "product_name": "Red Hat Enterprise Linux Server",
+ *           "billing_provider": "azure",
  *           "service_level": "Self-Support",
  *           "usage": "Production",
  *           "subscriptions": [],
@@ -2331,6 +2333,7 @@ const getInstancesInventory = (id, params = {}, options = {}) => {
  *         {
  *           "sku": "RH00009",
  *           "product_name": "Red Hat Enterprise Linux Server, Premium",
+ *           "billing_provider": "Unknown",
  *           "service_level": "Premium",
  *           "usage": "Production",
  *           "subscriptions": [


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- ~refactor(inventoryCardSubscriptions): ent-5129 camel to snake~
   * ~config, products updated to use snake case~
   * ~services, constants updated with subscriptions types~
- fix(rhosak,rhacs): ent-5129 billing provider for subscriptions inventory
   * config, rhosak, rhacs billing provider column
   * services, subscriptions mock

### Notes
- ~includes refactor work to flip the subs table config to using snake case instead of camel case~ see #949 instead
- ACTIVATES the billing provider column display for RHOSAK
- notes regarding what copy displays when for billing providers, #936 
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. login and 
1. confirm all subscriptions table inventory column headers for RHEL, OpenShift console, and RHOSAK are display correctly, and
1. confirm the billing provider column is available for subscriptions inventory in RHOSAK
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
#### Activated billing provider column
Notes regarding what copy displays when, #936 
![Screen Shot 2022-06-21 at 4 36 12 PM](https://user-images.githubusercontent.com/3761375/174894476-2e15e8fa-ba10-4392-ad07-11086a668d48.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-5129 aka SWATCH-47