### PR TITLE
fix(rhosak): ent-4689 (sw-93) billing provider, remove none option

### DIFF
--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldBillingProvider.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldBillingProvider.test.js.snap
@@ -12,11 +12,6 @@ Array [
     "title": "t(curiosity-toolbar.billing_provider, {\\"context\\":\\"aws\\"})",
     "value": "aws",
   },
-  Object {
-    "selected": false,
-    "title": "t(curiosity-toolbar.billing_provider, {\\"context\\":\\"none\\"})",
-    "value": "",
-  },
 ]
 `;
 
@@ -80,11 +75,6 @@ exports[`ToolbarFieldBillingProvider Component should render a basic component: 
         "selected": true,
         "title": "t(curiosity-toolbar.billing_provider, {\\"context\\":\\"aws\\"})",
         "value": "aws",
-      },
-      Object {
-        "selected": false,
-        "title": "t(curiosity-toolbar.billing_provider, {\\"context\\":\\"none\\"})",
-        "value": "",
       },
     ]
   }

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldSelectCategory.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldSelectCategory.test.js.snap
@@ -182,11 +182,6 @@ Array [
         "title": "t(curiosity-toolbar.billing_provider, {\\"context\\":\\"aws\\"})",
         "value": "aws",
       },
-      Object {
-        "selected": false,
-        "title": "t(curiosity-toolbar.billing_provider, {\\"context\\":\\"none\\"})",
-        "value": "",
-      },
     ],
     "selected": false,
     "title": "t(curiosity-toolbar.category, {\\"context\\":\\"billing_provider\\"})",

--- a/src/services/rhsm/__tests__/__snapshots__/rhsmConstants.test.js.snap
+++ b/src/services/rhsm/__tests__/__snapshots__/rhsmConstants.test.js.snap
@@ -31,7 +31,6 @@ Object {
   },
   "RHSM_API_QUERY_BILLING_PROVIDER_TYPES": Object {
     "AWS": "aws",
-    "NONE": "",
     "RED_HAT": "red hat",
   },
   "RHSM_API_QUERY_GRANULARITY_TYPES": Object {
@@ -121,7 +120,6 @@ Object {
   },
   "RHSM_API_RESPONSE_BILLING_PROVIDER_TYPES": Object {
     "AWS": "aws",
-    "NONE": "",
     "RED_HAT": "red hat",
   },
   "RHSM_API_RESPONSE_DATA": "data",
@@ -247,7 +245,6 @@ Object {
     },
     "RHSM_API_QUERY_BILLING_PROVIDER_TYPES": Object {
       "AWS": "aws",
-      "NONE": "",
       "RED_HAT": "red hat",
     },
     "RHSM_API_QUERY_GRANULARITY_TYPES": Object {
@@ -337,7 +334,6 @@ Object {
     },
     "RHSM_API_RESPONSE_BILLING_PROVIDER_TYPES": Object {
       "AWS": "aws",
-      "NONE": "",
       "RED_HAT": "red hat",
     },
     "RHSM_API_RESPONSE_DATA": "data",
@@ -464,7 +460,6 @@ Object {
     },
     "RHSM_API_QUERY_BILLING_PROVIDER_TYPES": Object {
       "AWS": "aws",
-      "NONE": "",
       "RED_HAT": "red hat",
     },
     "RHSM_API_QUERY_GRANULARITY_TYPES": Object {
@@ -554,7 +549,6 @@ Object {
     },
     "RHSM_API_RESPONSE_BILLING_PROVIDER_TYPES": Object {
       "AWS": "aws",
-      "NONE": "",
       "RED_HAT": "red hat",
     },
     "RHSM_API_RESPONSE_DATA": "data",
@@ -685,7 +679,6 @@ Object {
   },
   "RHSM_API_QUERY_BILLING_PROVIDER_TYPES": Object {
     "AWS": "aws",
-    "NONE": "",
     "RED_HAT": "red hat",
   },
   "RHSM_API_QUERY_GRANULARITY_TYPES": Object {
@@ -775,7 +768,6 @@ Object {
   },
   "RHSM_API_RESPONSE_BILLING_PROVIDER_TYPES": Object {
     "AWS": "aws",
-    "NONE": "",
     "RED_HAT": "red hat",
   },
   "RHSM_API_RESPONSE_DATA": "data",

--- a/src/services/rhsm/rhsmConstants.js
+++ b/src/services/rhsm/rhsmConstants.js
@@ -208,11 +208,11 @@ const RHSM_API_RESPONSE_GRANULARITY_TYPES = {
  */
 const RHSM_API_RESPONSE_BILLING_PROVIDER_TYPES = {
   RED_HAT: 'red hat',
-  AWS: 'aws',
+  AWS: 'aws'
   // GCP: 'gcp',
   // AZURE: 'azure',
   // ORACLE: 'oracle',
-  NONE: ''
+  // NONE: ''
 };
 
 /**


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- ~fix(rhosak): ent-4689 remove none option~ fix(rhosak): sw-93 billing provider, remove none option

### Notes
- removes the `none` option, behavior for #936  should be updated to reflect this
- introduces "unique" additional options for our dropdown listing components when compared with existing lists
   - as silly as this seems, this update will affect generating future lists, and force unique qualities to be configured either in the API or GUI
      - consistency of dropdown options vs what the API provides is the underlying issue... why is the option being provided in the first place
- ~marking this as blocked since "removing none" was posed as a solution without accounting for configuration~

<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. navigate to RHOSAK, confirm the select/dropdown only has the options displayed in the below example

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![NONE-REMOVED-Screen Shot 2022-06-24 at 12 22 27 AM](https://user-images.githubusercontent.com/3761375/175462579-3f67f0da-b02a-417f-ba0e-c38005ac4d4d.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-4689 aka SWATCH-93