### PR TITLE
fix(rhsmTransformers): ent-5213 allow first dates to draw line

### DIFF
--- a/src/services/rhsm/__tests__/__snapshots__/rhsmTransformers.test.js.snap
+++ b/src/services/rhsm/__tests__/__snapshots__/rhsmTransformers.test.js.snap
@@ -15,6 +15,126 @@ Object {
 }
 `;
 
+exports[`RHSM Transformers should attempt to parse a tally response: tally, daily like first of month granularity 1`] = `
+Object {
+  "data": Array [
+    Object {
+      "date": "2019-07-20T00:00:00Z",
+      "hasData": true,
+      "isCurrentDate": false,
+      "isFutureDate": false,
+      "x": 0,
+      "y": 0.1,
+    },
+    Object {
+      "date": "2019-07-20T00:00:00Z",
+      "hasData": true,
+      "isCurrentDate": true,
+      "isFutureDate": false,
+      "x": 1,
+      "y": 0.1,
+    },
+    Object {
+      "date": "2019-07-21T00:00:00Z",
+      "hasData": false,
+      "isCurrentDate": false,
+      "isFutureDate": true,
+      "x": 2,
+      "y": null,
+    },
+    Object {
+      "date": "2019-07-22T00:00:00Z",
+      "hasData": false,
+      "isCurrentDate": false,
+      "isFutureDate": true,
+      "x": 3,
+      "y": null,
+    },
+    Object {
+      "date": "2019-07-23T00:00:00Z",
+      "hasData": false,
+      "isCurrentDate": false,
+      "isFutureDate": true,
+      "x": 4,
+      "y": null,
+    },
+    Object {
+      "date": "2019-07-24T00:00:00Z",
+      "hasData": false,
+      "isCurrentDate": false,
+      "isFutureDate": true,
+      "x": 5,
+      "y": null,
+    },
+    Object {
+      "date": "2019-07-25T00:00:00Z",
+      "hasData": false,
+      "isCurrentDate": false,
+      "isFutureDate": true,
+      "x": 6,
+      "y": null,
+    },
+    Object {
+      "date": "2019-07-26T00:00:00Z",
+      "hasData": false,
+      "isCurrentDate": false,
+      "isFutureDate": true,
+      "x": 7,
+      "y": null,
+    },
+    Object {
+      "date": "2019-07-27T00:00:00Z",
+      "hasData": false,
+      "isCurrentDate": false,
+      "isFutureDate": true,
+      "x": 8,
+      "y": null,
+    },
+    Object {
+      "date": "2019-07-28T00:00:00Z",
+      "hasData": false,
+      "isCurrentDate": false,
+      "isFutureDate": true,
+      "x": 9,
+      "y": null,
+    },
+    Object {
+      "date": "2019-07-29T00:00:00Z",
+      "hasData": false,
+      "isCurrentDate": false,
+      "isFutureDate": true,
+      "x": 10,
+      "y": null,
+    },
+    Object {
+      "date": "2019-07-30T00:00:00Z",
+      "hasData": false,
+      "isCurrentDate": false,
+      "isFutureDate": true,
+      "x": 11,
+      "y": null,
+    },
+    Object {
+      "date": "2019-07-31T00:00:00Z",
+      "hasData": false,
+      "isCurrentDate": false,
+      "isFutureDate": true,
+      "x": 12,
+      "y": null,
+    },
+  ],
+  "meta": Object {
+    "cloudigradeHasMismatch": undefined,
+    "count": undefined,
+    "metricId": undefined,
+    "productId": undefined,
+    "totalMonthlyDate": undefined,
+    "totalMonthlyHasData": undefined,
+    "totalMonthlyValue": undefined,
+  },
+}
+`;
+
 exports[`RHSM Transformers should attempt to parse a tally response: tally, daily like granularity 1`] = `
 Object {
   "data": Array [

--- a/src/services/rhsm/__tests__/rhsmTransformers.test.js
+++ b/src/services/rhsm/__tests__/rhsmTransformers.test.js
@@ -97,6 +97,78 @@ describe('RHSM Transformers', () => {
 
     expect(rhsmTransformers.tally(dailyTallyResponse)).toMatchSnapshot('tally, daily like granularity');
 
+    const dailyTallyFirstMonthResponse = {
+      [rhsmConstants.RHSM_API_RESPONSE_DATA]: [
+        {
+          [TALLY_DATA_TYPES.DATE]: '2019-07-20T00:00:00Z',
+          [TALLY_DATA_TYPES.VALUE]: 0.1,
+          [TALLY_DATA_TYPES.HAS_DATA]: true
+        },
+        {
+          [TALLY_DATA_TYPES.DATE]: '2019-07-21T00:00:00Z',
+          [TALLY_DATA_TYPES.VALUE]: 0.0,
+          [TALLY_DATA_TYPES.HAS_DATA]: false
+        },
+        {
+          [TALLY_DATA_TYPES.DATE]: '2019-07-22T00:00:00Z',
+          [TALLY_DATA_TYPES.VALUE]: 0.0,
+          [TALLY_DATA_TYPES.HAS_DATA]: false
+        },
+        {
+          [TALLY_DATA_TYPES.DATE]: '2019-07-23T00:00:00Z',
+          [TALLY_DATA_TYPES.VALUE]: 0.0,
+          [TALLY_DATA_TYPES.HAS_DATA]: false
+        },
+        {
+          [TALLY_DATA_TYPES.DATE]: '2019-07-24T00:00:00Z',
+          [TALLY_DATA_TYPES.VALUE]: 0.0,
+          [TALLY_DATA_TYPES.HAS_DATA]: false
+        },
+        {
+          [TALLY_DATA_TYPES.DATE]: '2019-07-25T00:00:00Z',
+          [TALLY_DATA_TYPES.VALUE]: 0.0,
+          [TALLY_DATA_TYPES.HAS_DATA]: false
+        },
+        {
+          [TALLY_DATA_TYPES.DATE]: '2019-07-26T00:00:00Z',
+          [TALLY_DATA_TYPES.VALUE]: 0.0,
+          [TALLY_DATA_TYPES.HAS_DATA]: false
+        },
+        {
+          [TALLY_DATA_TYPES.DATE]: '2019-07-27T00:00:00Z',
+          [TALLY_DATA_TYPES.VALUE]: 0.0,
+          [TALLY_DATA_TYPES.HAS_DATA]: false
+        },
+        {
+          [TALLY_DATA_TYPES.DATE]: '2019-07-28T00:00:00Z',
+          [TALLY_DATA_TYPES.VALUE]: 0.0,
+          [TALLY_DATA_TYPES.HAS_DATA]: false
+        },
+        {
+          [TALLY_DATA_TYPES.DATE]: '2019-07-29T00:00:00Z',
+          [TALLY_DATA_TYPES.VALUE]: 0.0,
+          [TALLY_DATA_TYPES.HAS_DATA]: false
+        },
+        {
+          [TALLY_DATA_TYPES.DATE]: '2019-07-30T00:00:00Z',
+          [TALLY_DATA_TYPES.VALUE]: 0.0,
+          [TALLY_DATA_TYPES.HAS_DATA]: false
+        },
+        {
+          [TALLY_DATA_TYPES.DATE]: '2019-07-31T00:00:00Z',
+          [TALLY_DATA_TYPES.VALUE]: 0.0,
+          [TALLY_DATA_TYPES.HAS_DATA]: false
+        }
+      ],
+      [rhsmConstants.RHSM_API_RESPONSE_META]: {}
+    };
+
+    const transformedDailyTallyFirstMonthResponse = rhsmTransformers.tally(dailyTallyFirstMonthResponse);
+
+    expect(dailyTallyFirstMonthResponse[rhsmConstants.RHSM_API_RESPONSE_DATA].length).toBe(12);
+    expect(transformedDailyTallyFirstMonthResponse.data.length).toBe(13);
+    expect(transformedDailyTallyFirstMonthResponse).toMatchSnapshot('tally, daily like first of month granularity');
+
     const monthlyTallyResponse = {
       [rhsmConstants.RHSM_API_RESPONSE_DATA]: [
         {

--- a/src/services/rhsm/rhsmTransformers.js
+++ b/src/services/rhsm/rhsmTransformers.js
@@ -53,6 +53,11 @@ const rhsmInstances = response => {
 };
 
 /**
+ * ToDo: Evaluate granularity alterations, transform logic is targeted at daily granularity
+ * Specifically, the "isCurrentDate" condition is targeted at daily. Weekly, monthly, and
+ * quarterly have not been tested, and may need logic adjustments for "isCurrentLikeDate".
+ */
+/**
  * Parse RHSM tally response for caching.
  *
  * @param {object} response
@@ -63,6 +68,7 @@ const rhsmTally = response => {
   const { [rhsmConstants.RHSM_API_RESPONSE_DATA]: data = [], [rhsmConstants.RHSM_API_RESPONSE_META]: meta = {} } =
     response || {};
   const currentDate = moment.utc(dateHelpers.getCurrentDate()).format('MM-D-YYYY');
+  let futureDateCount = 0;
 
   updatedResponse.data = data.map(
     (
@@ -72,6 +78,10 @@ const rhsmTally = response => {
       const updatedDate = moment.utc(date);
       const isCurrentDate = updatedDate.format('MM-D-YYYY') === currentDate;
       const isFutureDate = updatedDate.diff(currentDate) > 0;
+
+      if (isFutureDate) {
+        futureDateCount += 1;
+      }
 
       return {
         x: index,
@@ -83,6 +93,20 @@ const rhsmTally = response => {
       };
     }
   );
+
+  /**
+   * Add an extra date to the first entry of the range to help Victory charts display.
+   */
+  if (futureDateCount === updatedResponse.data.length - 1) {
+    updatedResponse.data = [
+      {
+        ...updatedResponse.data[0],
+        x: 0,
+        isCurrentDate: false
+      },
+      ...updatedResponse.data
+    ].map((props, index) => ({ ...props, x: index }));
+  }
 
   updatedResponse.meta = {
     count: meta[TALLY_META_TYPES.COUNT],


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(rhsmTransformers): ent-5213 allow first dates to draw line
   * rhsmTransformers, shift x axis index for first dates

### Notes
- adds an additional x axis entry and tick in the event the first date with a value exists, and all subsequent dates are future dates. this allows Victory to display a line
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. In order to emulate this you have to add a GUI debugger date to the dotenv files. Add the following entry to a `.env.local` file in the root of the project
   ```
      REACT_APP_DEBUG_DEFAULT_DATETIME=20220701
   ```
1. You'll also need to update the fixture associated with `Instance Hours` by updating the `./src/services/rhsm/rhsmServices.js` file, [you can find an example here](https://github.com/cdcabrera/curiosity-frontend/blob/20220705b-ent-5213/src/services/rhsm/rhsmServices.js#L1305-L1486)
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1.  navigate to the RHOSAK display and confirm the graph for Instance hours matches the AFTER screenshot below

<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
### BEFORE
![image](https://user-images.githubusercontent.com/3761375/177449474-05eac030-0eb9-4e67-a52c-533fa8939dd5.png)

### AFTER
![Screen Shot 2022-07-05 at 9 12 42 PM](https://user-images.githubusercontent.com/3761375/177449513-ce28efa5-1122-4a4e-8bd8-515726075017.png)



## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-5213