### PR TITLE
fix(dateHelpers):  ent-5213 (sw-43) expose for testing

### DIFF
--- a/src/common/dateHelpers.js
+++ b/src/common/dateHelpers.js
@@ -195,7 +195,7 @@ const dateHelpers = {
   timestampUTCTimeFormats
 };
 
-helpers.browserExpose({ ...dateHelpers }, { limit: false });
+helpers.browserExpose({ dateHelpers }, { limit: false });
 
 export {
   dateHelpers as default,

--- a/src/common/dateHelpers.js
+++ b/src/common/dateHelpers.js
@@ -195,6 +195,8 @@ const dateHelpers = {
   timestampUTCTimeFormats
 };
 
+helpers.browserExpose({ ...dateHelpers }, { limit: false });
+
 export {
   dateHelpers as default,
   getCurrentDate,

--- a/src/services/rhsm/rhsmTransformers.js
+++ b/src/services/rhsm/rhsmTransformers.js
@@ -6,7 +6,7 @@ import {
   RHSM_API_RESPONSE_TALLY_META_TYPES as TALLY_META_TYPES,
   rhsmConstants
 } from './rhsmConstants';
-import { dateHelpers } from '../../common';
+import { dateHelpers, helpers } from '../../common';
 
 /**
  * FixMe: If RHSM Instances is deprecating Hosts we're missing a property, number_of_guests
@@ -125,5 +125,15 @@ const rhsmTransformers = {
   instances: rhsmInstances,
   tally: rhsmTally
 };
+
+helpers.browserExpose(
+  {
+    rhsmTransformers: {
+      ...rhsmTransformers,
+      currentData: moment.utc(dateHelpers.getCurrentDate()).format('MM-D-YYYY')
+    }
+  },
+  { limit: false }
+);
 
 export { rhsmTransformers as default, rhsmTransformers, rhsmInstances, rhsmTally };


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(dateHelpers):  ent-5213 expose for testing

### Notes
- exposes `dateHelpers` to the browser console for both `dateHelpers` and `rhsmTransformers`
- type `$ curiosity.dateHelpers.[method]()` or `$ curiosity.rhsmTransformers.[method]()`
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ent-5213
SWATCH-43