### PR TITLE
fix(build): Change container image name

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: rhsm-frontend
+  name: curiosity-frontend
 objects:
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: Frontend
@@ -79,4 +79,4 @@ parameters:
   - name: IMAGE_TAG
     required: true
   - name: IMAGE
-    value: quay.io/cloudservices/rhsm-frontend
+    value: quay.io/cloudservices/curiosity-frontend


### PR DESCRIPTION
We changed container image name in app-interfaces repository, but we forgot to change it here.
Without this change, you need to pass few more CLI options to `bonfire` to deploy frontend to ephemeral environment.