### PR TITLE
fix(satellite): sw-20 remove graph threshold

### DIFF
--- a/src/components/productView/__tests__/__snapshots__/productViewMissing.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productViewMissing.test.js.snap
@@ -212,6 +212,42 @@ exports[`ProductViewMissing Component should render a non-connected component: n
           </Button>
         </CardFooter>
       </Card>
+      <Card
+        isHoverable={true}
+        key="missingViewCard-satellite"
+        onClick={[Function]}
+      >
+        <CardTitle>
+          <Title
+            headingLevel="h2"
+            size="lg"
+          >
+            t(curiosity-view.title, {"appName":"Subscriptions","context":"Satellite"})
+          </Title>
+        </CardTitle>
+        <CardBody
+          className="curiosity-missing-view__card-description"
+        >
+          t(curiosity-view.description, {"appName":"Subscriptions","context":"Satellite"})
+        </CardBody>
+        <CardFooter>
+          <Button
+            icon={
+              <ArrowRightIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+              />
+            }
+            iconPosition="right"
+            isInline={true}
+            onClick={[Function]}
+            variant="link"
+          >
+            Open
+          </Button>
+        </CardFooter>
+      </Card>
     </Gallery>
   </PageSection>
 </PageLayout>

--- a/src/config/product.satellite.js
+++ b/src/config/product.satellite.js
@@ -77,8 +77,7 @@ const config = {
       fill: chartColorPurpleLight.value,
       stroke: chartColorPurpleDark.value,
       color: chartColorPurpleDark.value
-    },
-    { id: 'thresholdSockets', chartType: 'threshold' }
+    }
   ],
   initialGuestsFilters: [
     {

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -142,7 +142,7 @@ const routes = [
     productParameter: [satelliteProductConfig.productGroup],
     productConfig: [{ ...satelliteProductConfig, productId: RHSM_API_PATH_ID_TYPES.SATELLITE }],
     redirect: null,
-    isSearchable: false,
+    isSearchable: true,
     aliases: [],
     activateOnError: false,
     disabled: helpers.UI_DISABLED,


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(satellite): sw-20 remove graph threshold

### Notes
- disables the threshold display for satellite views
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. navigate to the satellite product views, confirm threshold no longer displays for the graphs

<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screen Shot 2022-08-29 at 9 09 27 PM](https://user-images.githubusercontent.com/3761375/187325736-5b504963-f21d-4db4-9fd1-74822463ddf3.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-20