### PR TITLE
fix(inventory): sw-356 empty state copy

### DIFF
--- a/public/locales/en-US.json
+++ b/public/locales/en-US.json
@@ -129,7 +129,7 @@
     "tableAriaLabel": "{{appName}} systems inventory table.",
     "tableSummary": "A generated table with one level of column headers.",
     "tableEmptyInventoryTitle": "No results found",
-    "tableEmptyInventoryMessage": "No results match the filter criteria. Remove filters or clear all filters to show results.",
+    "tableEmptyInventoryMessage": "To show more results, clear some or all filters.",
     "tableSkeletonAriaLabel": "Loading",
     "label_has_infinite_quantity_cores": "Unlimited cores",
     "label_has_infinite_quantity_sockets": "Unlimited sockets",


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(inventory): sw-356 empty state copy

<!-- ### Notes -->
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. navigate to a product and...
   - confirm that the inventory messaging displays per the screenshot

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screen Shot 2022-10-12 at 11 22 34 AM](https://user-images.githubusercontent.com/3761375/195384942-411d5309-9b5c-4485-b310-3b1ec82a7c03.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-356