### PR TITLE
fix(graphCard): sw-223 generated key from settings

### DIFF
--- a/src/components/graphCard/__tests__/__snapshots__/graphCard.test.js.snap
+++ b/src/components/graphCard/__tests__/__snapshots__/graphCard.test.js.snap
@@ -68,7 +68,7 @@ exports[`GraphCard Component should setup basic settings: settings 1`] = `
     />
   </ContextProvider>
   <ContextProvider
-    key="graphCard_undefined"
+    key="graphCard_Sockets"
     value={
       {
         "settings": {

--- a/src/components/graphCard/graphCard.js
+++ b/src/components/graphCard/graphCard.js
@@ -35,7 +35,7 @@ const GraphCard = ({ isDisabled, useProductGraphConfig: useAliasProductGraphConf
       )) ||
         null}
       {standaloneFiltersSettings?.map(filtersSettings => (
-        <GraphCardContext.Provider key={`graphCard_${filtersSettings?.metric?.id}`} value={filtersSettings}>
+        <GraphCardContext.Provider key={`graphCard_${filtersSettings?.settings?.metric?.id}`} value={filtersSettings}>
           <GraphCardMetricTotals>
             <GraphCardChart />
           </GraphCardMetricTotals>


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(graphCard): sw-223 generated key from settings

<!-- ### Notes -->
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. open the dev console, then
   - navigate to an "on demand" product view within Subs
   - hitting refresh you should NO longer see the "duplicate key" console error

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-223
ent-4899
pr #927 