### PR TITLE
fix(i18nHelpers): update multi-context keys

### DIFF
--- a/public/locales/en-US.json
+++ b/public/locales/en-US.json
@@ -120,7 +120,7 @@
     "cardHeading": "Current systems",
     "tabSubHeading": "Tab {{count}}",
     "tabHosts": "Current systems",
-    "tabHosts_noInstances_OpenShift-dedicated-metrics": "Current instances",
+    "tabHosts_OpenShift-dedicated-metrics": "Current instances",
     "tabHosts_OpenShift-dedicated-metrics_one": "{{count}} instance",
     "tabHosts_OpenShift-dedicated-metrics_other": "{{count}} instances",
     "tabInstances": "Current monthly instances",

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -1,21 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`I18n Component should attempt to perform a component translate: translated component 1`] = `"<div>t(lorem.ipsum, hello world)</div>"`;
-
-exports[`I18n Component should attempt to perform a string replace: translate 1`] = `
-{
-  "emptyContext": "t(lorem.ipsum, {"context":" "})",
-  "emptyPartialContext": "t(lorem.ipsum, {"context":"hello_ "})",
-  "localeKey": "t(lorem.ipsum)",
-  "multiContext": "t(lorem.ipsum, {"context":"hello_world"})",
-  "multiContextWithEmptyValue": "t(lorem.ipsum, {"context":"hello_world"})",
-  "multiKey": "t([lorem.ipsum,lorem.fallback])",
-  "placeholder": "t(lorem.ipsum, hello world)",
-}
-`;
-
-exports[`I18n Component should attempt to perform translate with a node: translated node 1`] = `"<div>t(lorem.ipsum, {&quot;hello&quot;:&quot;world&quot;}, [object Object])</div>"`;
-
 exports[`I18n Component should generate a predictable locale key output snapshot: key output 1`] = `
 [
   {

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -286,15 +286,15 @@ exports[`I18n Component should generate a predictable locale key output snapshot
       },
       {
         "key": "curiosity-inventory.tabHosts",
-        "match": "t('curiosity-inventory.tabHosts', { context: ['noInstances', productId] })",
+        "match": "t('curiosity-inventory.tabHosts', { context: [productId] })",
       },
       {
         "key": "curiosity-inventory.tabInstances",
-        "match": "t('curiosity-inventory.tabInstances', { context: ['noInstances', productId] })",
+        "match": "t('curiosity-inventory.tabInstances', { context: [productId] })",
       },
       {
         "key": "curiosity-inventory.tabSubscriptions",
-        "match": "t('curiosity-inventory.tabSubscriptions', { context: productId })",
+        "match": "t('curiosity-inventory.tabSubscriptions', { context: [productId] })",
       },
       {
         "key": "curiosity-view.title",
@@ -332,7 +332,7 @@ exports[`I18n Component should generate a predictable locale key output snapshot
       },
       {
         "key": "curiosity-inventory.tabHosts",
-        "match": "t('curiosity-inventory.tabHosts', { context: ['noInstances', productId] })",
+        "match": "t('curiosity-inventory.tabHosts', { context: [productId] })",
       },
       {
         "key": "curiosity-inventory.tabSubscriptions",

--- a/src/components/i18n/__tests__/__snapshots__/i18nHelpers.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18nHelpers.test.js.snap
@@ -5,10 +5,10 @@ exports[`I18nHelpers should attempt to perform a component translate: translated
 exports[`I18nHelpers should attempt to perform a string replace: translate 1`] = `
 {
   "emptyContext": "t(lorem.ipsum, {"context":" "})",
-  "emptyPartialContext": "t(lorem.ipsum, {"context":"hello_ "})",
+  "emptyPartialContext": "t(lorem.ipsum_hello, {"context":" "})",
   "localeKey": "t(lorem.ipsum)",
-  "multiContext": "t(lorem.ipsum, {"context":"hello_world"})",
-  "multiContextWithEmptyValue": "t(lorem.ipsum, {"context":"hello_world"})",
+  "multiContext": "t(lorem.ipsum_hello, {"context":"world"})",
+  "multiContextWithEmptyValue": "t(lorem.ipsum_hello, {"context":"world"})",
   "multiKey": "t([lorem.ipsum,lorem.fallback])",
   "placeholder": "t(lorem.ipsum, hello world)",
 }

--- a/src/components/i18n/__tests__/__snapshots__/i18nHelpers.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18nHelpers.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`I18nHelpers should attempt to perform a component translate: translated component 1`] = `"<div>t(lorem.ipsum, hello world)</div>"`;
+
+exports[`I18nHelpers should attempt to perform a string replace: translate 1`] = `
+{
+  "emptyContext": "t(lorem.ipsum, {"context":" "})",
+  "emptyPartialContext": "t(lorem.ipsum, {"context":"hello_ "})",
+  "localeKey": "t(lorem.ipsum)",
+  "multiContext": "t(lorem.ipsum, {"context":"hello_world"})",
+  "multiContextWithEmptyValue": "t(lorem.ipsum, {"context":"hello_world"})",
+  "multiKey": "t([lorem.ipsum,lorem.fallback])",
+  "placeholder": "t(lorem.ipsum, hello world)",
+}
+`;
+
+exports[`I18nHelpers should attempt to perform translate with a node: translated node 1`] = `"<div>t(lorem.ipsum, {&quot;hello&quot;:&quot;world&quot;}, [object Object])</div>"`;
+
+exports[`I18nHelpers should have specific functions: i18nHelpers 1`] = `
+{
+  "EMPTY_CONTEXT": "LOCALE_EMPTY_CONTEXT",
+  "translate": [Function],
+  "translateComponent": [Function],
+}
+`;

--- a/src/components/i18n/__tests__/i18n.test.js
+++ b/src/components/i18n/__tests__/i18n.test.js
@@ -1,11 +1,9 @@
 import { readFileSync } from 'fs';
 import glob from 'glob';
 import React from 'react';
-import PropTypes from 'prop-types';
-import { shallow } from 'enzyme';
 import _get from 'lodash/get';
 import enLocales from '../../../../public/locales/en-US.json';
-import { EMPTY_CONTEXT, I18n, translate, translateComponent } from '../i18n';
+import { I18n } from '../i18n';
 
 /**
  * Get translation keys.
@@ -66,54 +64,6 @@ describe('I18n Component', () => {
     const component = await mountHookComponent(<I18n>lorem ipsum</I18n>);
 
     expect(component.html()).toMatchSnapshot('children');
-  });
-
-  it('should attempt to perform translate with a node', () => {
-    const ExampleComponent = () => <div>{translate('lorem.ipsum', { hello: 'world' }, [<span id="test" />])}</div>;
-
-    ExampleComponent.propTypes = {};
-    ExampleComponent.defaultProps = {};
-
-    const component = shallow(<ExampleComponent />);
-
-    expect(component.html()).toMatchSnapshot('translated node');
-  });
-
-  it('should attempt to perform a component translate', () => {
-    const ExampleComponent = ({ t }) => <div>{t('lorem.ipsum', 'hello world')}</div>;
-
-    ExampleComponent.propTypes = {
-      t: PropTypes.func
-    };
-
-    ExampleComponent.defaultProps = {
-      t: translate
-    };
-
-    const TranslatedComponent = translateComponent(ExampleComponent);
-    const component = shallow(<TranslatedComponent />);
-
-    expect(component.html()).toMatchSnapshot('translated component');
-  });
-
-  it('should attempt to perform a string replace', () => {
-    const emptyContext = translate('lorem.ipsum', { context: EMPTY_CONTEXT });
-    const emptyPartialContext = translate('lorem.ipsum', { context: ['hello', EMPTY_CONTEXT] });
-    const localeKey = translate('lorem.ipsum');
-    const placeholder = translate('lorem.ipsum', 'hello world');
-    const multiContext = translate('lorem.ipsum', { context: ['hello', 'world'] });
-    const multiContextWithEmptyValue = translate('lorem.ipsum', { context: ['hello', undefined, null, '', 'world'] });
-    const multiKey = translate(['lorem.ipsum', undefined, null, '', 'lorem.fallback']);
-
-    expect({
-      emptyContext,
-      emptyPartialContext,
-      localeKey,
-      placeholder,
-      multiContext,
-      multiContextWithEmptyValue,
-      multiKey
-    }).toMatchSnapshot('translate');
   });
 
   it('should generate a predictable locale key output snapshot', () => {

--- a/src/components/i18n/__tests__/i18nHelpers.test.js
+++ b/src/components/i18n/__tests__/i18nHelpers.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 import PropTypes from 'prop-types';
 import { i18nHelpers, EMPTY_CONTEXT, translate, translateComponent } from '../i18nHelpers';
 
@@ -8,20 +7,17 @@ describe('I18nHelpers', () => {
     expect(i18nHelpers).toMatchSnapshot('i18nHelpers');
   });
 
-  it('should attempt to perform translate with a node', () => {
+  it('should attempt to perform translate with a node', async () => {
     const ExampleComponent = () => <div>{translate('lorem.ipsum', { hello: 'world' }, [<span id="test" />])}</div>;
-
     ExampleComponent.propTypes = {};
     ExampleComponent.defaultProps = {};
 
-    const component = shallow(<ExampleComponent />);
-
+    const component = await shallowHookComponent(<ExampleComponent />);
     expect(component.html()).toMatchSnapshot('translated node');
   });
 
-  it('should attempt to perform a component translate', () => {
+  it('should attempt to perform a component translate', async () => {
     const ExampleComponent = ({ t }) => <div>{t('lorem.ipsum', 'hello world')}</div>;
-
     ExampleComponent.propTypes = {
       t: PropTypes.func
     };
@@ -31,8 +27,7 @@ describe('I18nHelpers', () => {
     };
 
     const TranslatedComponent = translateComponent(ExampleComponent);
-    const component = shallow(<TranslatedComponent />);
-
+    const component = await shallowHookComponent(<TranslatedComponent />);
     expect(component.html()).toMatchSnapshot('translated component');
   });
 

--- a/src/components/i18n/__tests__/i18nHelpers.test.js
+++ b/src/components/i18n/__tests__/i18nHelpers.test.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import PropTypes from 'prop-types';
+import { i18nHelpers, EMPTY_CONTEXT, translate, translateComponent } from '../i18nHelpers';
+
+describe('I18nHelpers', () => {
+  it('should have specific functions', () => {
+    expect(i18nHelpers).toMatchSnapshot('i18nHelpers');
+  });
+
+  it('should attempt to perform translate with a node', () => {
+    const ExampleComponent = () => <div>{translate('lorem.ipsum', { hello: 'world' }, [<span id="test" />])}</div>;
+
+    ExampleComponent.propTypes = {};
+    ExampleComponent.defaultProps = {};
+
+    const component = shallow(<ExampleComponent />);
+
+    expect(component.html()).toMatchSnapshot('translated node');
+  });
+
+  it('should attempt to perform a component translate', () => {
+    const ExampleComponent = ({ t }) => <div>{t('lorem.ipsum', 'hello world')}</div>;
+
+    ExampleComponent.propTypes = {
+      t: PropTypes.func
+    };
+
+    ExampleComponent.defaultProps = {
+      t: translate
+    };
+
+    const TranslatedComponent = translateComponent(ExampleComponent);
+    const component = shallow(<TranslatedComponent />);
+
+    expect(component.html()).toMatchSnapshot('translated component');
+  });
+
+  it('should attempt to perform a string replace', () => {
+    const emptyContext = translate('lorem.ipsum', { context: EMPTY_CONTEXT });
+    const emptyPartialContext = translate('lorem.ipsum', { context: ['hello', EMPTY_CONTEXT] });
+    const localeKey = translate('lorem.ipsum');
+    const placeholder = translate('lorem.ipsum', 'hello world');
+    const multiContext = translate('lorem.ipsum', { context: ['hello', 'world'] });
+    const multiContextWithEmptyValue = translate('lorem.ipsum', { context: ['hello', undefined, null, '', 'world'] });
+    const multiKey = translate(['lorem.ipsum', undefined, null, '', 'lorem.fallback']);
+
+    expect({
+      emptyContext,
+      emptyPartialContext,
+      localeKey,
+      placeholder,
+      multiContext,
+      multiContextWithEmptyValue,
+      multiKey
+    }).toMatchSnapshot('translate');
+  });
+});

--- a/src/components/i18n/i18n.js
+++ b/src/components/i18n/i18n.js
@@ -2,78 +2,10 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import i18next from 'i18next';
 import XHR from 'i18next-http-backend';
-import { initReactI18next, Trans } from 'react-i18next';
+import { initReactI18next } from 'react-i18next';
 import { useMount } from 'react-use';
 import { helpers } from '../../common/helpers';
-
-/**
- * Check to help provide an empty context.
- *
- * @type {string}
- */
-const EMPTY_CONTEXT = 'LOCALE_EMPTY_CONTEXT';
-
-/**
- * Apply a string towards a key. Optional replacement values and component/nodes.
- * See, https://react.i18next.com/
- *
- * @param {string|Array} translateKey A key reference, or an array of a primary key with fallback keys.
- * @param {string|object|Array} values A default string if the key can't be found. An object with i18next settings. Or an array of objects (key/value) pairs used to replace string tokes. i.e. "[{ hello: 'world' }]"
- * @param {Array} components An array of HTML/React nodes used to replace string tokens. i.e. "[<span />, <React.Fragment />]"
- * @param {object} options
- * @param {string} options.emptyContextValue Check to allow an empty context value.
- * @returns {string|React.ReactNode}
- */
-const translate = (translateKey, values = null, components, { emptyContextValue = EMPTY_CONTEXT } = {}) => {
-  const updatedValues = values;
-  let updatedTranslateKey = translateKey;
-
-  if (Array.isArray(updatedTranslateKey)) {
-    updatedTranslateKey = updatedTranslateKey.filter(value => typeof value === 'string' && value.length > 0);
-  }
-
-  if (Array.isArray(updatedValues?.context)) {
-    updatedValues.context = updatedValues.context
-      .map(value => (value === emptyContextValue && ' ') || value)
-      .filter(value => typeof value === 'string' && value.length > 0)
-      .join('_');
-  } else if (updatedValues?.context === emptyContextValue) {
-    updatedValues.context = ' ';
-  }
-
-  if (helpers.TEST_MODE) {
-    return helpers.noopTranslate(updatedTranslateKey, updatedValues, components);
-  }
-
-  if (components) {
-    return (
-      (i18next.store && <Trans i18nKey={updatedTranslateKey} values={updatedValues} components={components} />) || (
-        <React.Fragment>t({updatedTranslateKey})</React.Fragment>
-      )
-    );
-  }
-
-  return (i18next.store && i18next.t(updatedTranslateKey, updatedValues)) || `t([${updatedTranslateKey}])`;
-};
-
-/**
- * Apply string replacements against a component, HOC.
- *
- * @param {React.ReactNode} Component
- * @returns {React.ReactNode}
- */
-const translateComponent = Component => {
-  const withTranslation = ({ ...props }) => (
-    <Component
-      {...props}
-      t={(i18next.store && translate) || helpers.noopTranslate}
-      i18n={(i18next.store && i18next) || helpers.noop}
-    />
-  );
-
-  withTranslation.displayName = 'withTranslation';
-  return withTranslation;
-};
+import { EMPTY_CONTEXT, translate, translateComponent } from './i18nHelpers';
 
 /**
  * Load I18n.

--- a/src/components/i18n/i18nHelpers.js
+++ b/src/components/i18n/i18nHelpers.js
@@ -22,7 +22,7 @@ const EMPTY_CONTEXT = 'LOCALE_EMPTY_CONTEXT';
  * @returns {string|React.ReactNode}
  */
 const translate = (translateKey, values = null, components, { emptyContextValue = EMPTY_CONTEXT } = {}) => {
-  const updatedValues = values;
+  const updatedValues = values || {};
   let updatedTranslateKey = translateKey;
 
   if (Array.isArray(updatedTranslateKey)) {
@@ -30,10 +30,23 @@ const translate = (translateKey, values = null, components, { emptyContextValue 
   }
 
   if (Array.isArray(updatedValues?.context)) {
-    updatedValues.context = updatedValues.context
+    const updatedContext = updatedValues.context
       .map(value => (value === emptyContextValue && ' ') || value)
-      .filter(value => typeof value === 'string' && value.length > 0)
-      .join('_');
+      .filter(value => typeof value === 'string' && value.length > 0);
+
+    if (updatedContext?.length > 1) {
+      const lastContext = updatedContext.pop();
+
+      if (Array.isArray(updatedTranslateKey)) {
+        updatedTranslateKey[0] = `${updatedTranslateKey[0]}_${updatedContext.join('_')}`;
+      } else {
+        updatedTranslateKey = `${updatedTranslateKey}_${updatedContext.join('_')}`;
+      }
+
+      updatedValues.context = lastContext;
+    } else {
+      updatedValues.context = updatedContext.join('_');
+    }
   } else if (updatedValues?.context === emptyContextValue) {
     updatedValues.context = ' ';
   }

--- a/src/components/i18n/i18nHelpers.js
+++ b/src/components/i18n/i18nHelpers.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import i18next from 'i18next';
+import { Trans } from 'react-i18next';
+import { helpers } from '../../common/helpers';
+
+/**
+ * Check to help provide an empty context.
+ *
+ * @type {string}
+ */
+const EMPTY_CONTEXT = 'LOCALE_EMPTY_CONTEXT';
+
+/**
+ * Apply a string towards a key. Optional replacement values and component/nodes.
+ * See, https://react.i18next.com/
+ *
+ * @param {string|Array} translateKey A key reference, or an array of a primary key with fallback keys.
+ * @param {string|object|Array} values A default string if the key can't be found. An object with i18next settings. Or an array of objects (key/value) pairs used to replace string tokes. i.e. "[{ hello: 'world' }]"
+ * @param {Array} components An array of HTML/React nodes used to replace string tokens. i.e. "[<span />, <React.Fragment />]"
+ * @param {object} options
+ * @param {string} options.emptyContextValue Check to allow an empty context value.
+ * @returns {string|React.ReactNode}
+ */
+const translate = (translateKey, values = null, components, { emptyContextValue = EMPTY_CONTEXT } = {}) => {
+  const updatedValues = values;
+  let updatedTranslateKey = translateKey;
+
+  if (Array.isArray(updatedTranslateKey)) {
+    updatedTranslateKey = updatedTranslateKey.filter(value => typeof value === 'string' && value.length > 0);
+  }
+
+  if (Array.isArray(updatedValues?.context)) {
+    updatedValues.context = updatedValues.context
+      .map(value => (value === emptyContextValue && ' ') || value)
+      .filter(value => typeof value === 'string' && value.length > 0)
+      .join('_');
+  } else if (updatedValues?.context === emptyContextValue) {
+    updatedValues.context = ' ';
+  }
+
+  if (helpers.TEST_MODE) {
+    return helpers.noopTranslate(updatedTranslateKey, updatedValues, components);
+  }
+
+  if (components) {
+    return (
+      (i18next.store && <Trans i18nKey={updatedTranslateKey} values={updatedValues} components={components} />) || (
+        <React.Fragment>t({updatedTranslateKey})</React.Fragment>
+      )
+    );
+  }
+
+  return (i18next.store && i18next.t(updatedTranslateKey, updatedValues)) || `t([${updatedTranslateKey}])`;
+};
+
+/**
+ * Apply string replacements against a component, HOC.
+ *
+ * @param {React.ReactNode} Component
+ * @returns {React.ReactNode}
+ */
+const translateComponent = Component => {
+  const withTranslation = ({ ...props }) => (
+    <Component
+      {...props}
+      t={(i18next.store && translate) || helpers.noopTranslate}
+      i18n={(i18next.store && i18next) || helpers.noop}
+    />
+  );
+
+  withTranslation.displayName = 'withTranslation';
+  return withTranslation;
+};
+
+const i18nHelpers = {
+  EMPTY_CONTEXT,
+  translate,
+  translateComponent
+};
+
+export { i18nHelpers as default, i18nHelpers, EMPTY_CONTEXT, translate, translateComponent };

--- a/src/components/productView/__tests__/__snapshots__/productView.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productView.test.js.snap
@@ -506,7 +506,7 @@ exports[`ProductView Component should use an instances inventory for rhosak: cus
 <InventoryTab
   active={false}
   key="inventory_instances_rhosak"
-  title="t(curiosity-inventory.tabInstances, {"context":"noInstances_rhosak"})"
+  title="t(curiosity-inventory.tabInstances, {"context":"rhosak"})"
 >
   <InventoryCard
     cardActions={

--- a/src/components/productView/__tests__/__snapshots__/productViewOpenShiftContainer.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productViewOpenShiftContainer.test.js.snap
@@ -280,7 +280,7 @@ exports[`ProductViewOpenShiftContainer Component should render a basic component
           <InventoryTab
             active={false}
             key="inventory_hosts_OpenShift Container Platform"
-            title="t(curiosity-inventory.tabHosts, {"context":"noInstances_OpenShift Container Platform"})"
+            title="t(curiosity-inventory.tabHosts, {"context":"OpenShift Container Platform"})"
           >
             <Connect(InventoryList)
               filterGuestsData={
@@ -605,7 +605,7 @@ exports[`ProductViewOpenShiftContainer Component should render a basic component
           <InventoryTab
             active={false}
             key="inventory_hosts_OpenShift-metrics"
-            title="t(curiosity-inventory.tabHosts, {"context":"noInstances_OpenShift-metrics"})"
+            title="t(curiosity-inventory.tabHosts, {"context":"OpenShift-metrics"})"
           >
             <Connect(InventoryList)
               filterGuestsData={[]}

--- a/src/components/productView/productView.js
+++ b/src/components/productView/productView.js
@@ -124,7 +124,7 @@ const ProductView = ({ t, toolbarGraph, toolbarGraphDescription, useRouteDetail:
             {!helpers.UI_DISABLED_TABLE_HOSTS && productDisplay !== DISPLAY_TYPES.HOURLY && initialInventoryFilters && (
               <InventoryTab
                 key={`inventory_hosts_${productId}`}
-                title={t('curiosity-inventory.tabHosts', { context: ['noInstances', productId] })}
+                title={t('curiosity-inventory.tabHosts', { context: [productId] })}
               >
                 <ConnectedInventoryListDeprecated
                   key={`inv_${productId}`}
@@ -142,7 +142,7 @@ const ProductView = ({ t, toolbarGraph, toolbarGraphDescription, useRouteDetail:
               initialInventoryFilters && (
                 <InventoryTab
                   key={`inventory_instances_${productId}`}
-                  title={t('curiosity-inventory.tabInstances', { context: ['noInstances', productId] })}
+                  title={t('curiosity-inventory.tabInstances', { context: [productId] })}
                 >
                   <InventoryCard />
                 </InventoryTab>
@@ -150,7 +150,7 @@ const ProductView = ({ t, toolbarGraph, toolbarGraphDescription, useRouteDetail:
             {!helpers.UI_DISABLED_TABLE_SUBSCRIPTIONS && initialSubscriptionsInventoryFilters && (
               <InventoryTab
                 key={`inventory_subs_${productId}`}
-                title={t('curiosity-inventory.tabSubscriptions', { context: productId })}
+                title={t('curiosity-inventory.tabSubscriptions', { context: [productId] })}
               >
                 <InventoryCardSubscriptions />
               </InventoryTab>

--- a/src/components/productView/productViewOpenShiftContainer.js
+++ b/src/components/productView/productViewOpenShiftContainer.js
@@ -118,7 +118,7 @@ const ProductViewOpenShiftContainer = ({ t, useRouteDetail: useAliasRouteDetail 
           <InventoryTabs key={`inventory_${productId}`} productId={productId}>
             <InventoryTab
               key={`inventory_hosts_${productId}`}
-              title={t('curiosity-inventory.tabHosts', { context: ['noInstances', productId] })}
+              title={t('curiosity-inventory.tabHosts', { context: [productId] })}
             >
               <InventoryList
                 key={`inv_${productId}`}

--- a/src/config/__tests__/__snapshots__/product.openshiftContainer.test.js.snap
+++ b/src/config/__tests__/__snapshots__/product.openshiftContainer.test.js.snap
@@ -151,13 +151,13 @@ exports[`Product OpenShift Container config should apply hosts inventory configu
       "transforms": [],
     },
     {
-      "title": "t(curiosity-inventory.header, {"context":"sockets_OpenShift Container Platform"})",
+      "title": "t(curiosity-inventory.header_sockets, {"context":"OpenShift Container Platform"})",
       "transforms": [
         [Function],
       ],
     },
     {
-      "title": "t(curiosity-inventory.header, {"context":"cores_OpenShift Container Platform"})",
+      "title": "t(curiosity-inventory.header_cores, {"context":"OpenShift Container Platform"})",
       "transforms": [
         [Function],
       ],
@@ -224,13 +224,13 @@ exports[`Product OpenShift Container config should apply hosts inventory configu
       "transforms": [],
     },
     {
-      "title": "t(curiosity-inventory.header, {"context":"sockets_OpenShift Container Platform"})",
+      "title": "t(curiosity-inventory.header_sockets, {"context":"OpenShift Container Platform"})",
       "transforms": [
         [Function],
       ],
     },
     {
-      "title": "t(curiosity-inventory.header, {"context":"cores_OpenShift Container Platform"})",
+      "title": "t(curiosity-inventory.header_cores, {"context":"OpenShift Container Platform"})",
       "transforms": [
         [Function],
       ],

--- a/src/config/__tests__/__snapshots__/product.rhosak.test.js.snap
+++ b/src/config/__tests__/__snapshots__/product.rhosak.test.js.snap
@@ -37,7 +37,7 @@ exports[`Product RHOSAK config should apply an instances inventory configuration
     },
     {
       "title": <Tooltip
-        content="t(curiosity-inventory.header, {"context":"tooltip_Transfer-gibibytes"})"
+        content="t(curiosity-inventory.header_tooltip, {"context":"Transfer-gibibytes"})"
         distance={5}
         enableFlip={false}
         entryDelay={100}
@@ -53,7 +53,7 @@ exports[`Product RHOSAK config should apply an instances inventory configuration
     },
     {
       "title": <Tooltip
-        content="t(curiosity-inventory.header, {"context":"tooltip_Storage-gibibyte-months"})"
+        content="t(curiosity-inventory.header_tooltip, {"context":"Storage-gibibyte-months"})"
         distance={5}
         enableFlip={false}
         entryDelay={100}
@@ -149,7 +149,7 @@ exports[`Product RHOSAK config should apply an instances inventory configuration
     },
     {
       "title": <Tooltip
-        content="t(curiosity-inventory.header, {"context":"tooltip_Transfer-gibibytes"})"
+        content="t(curiosity-inventory.header_tooltip, {"context":"Transfer-gibibytes"})"
         distance={5}
         enableFlip={false}
         entryDelay={100}
@@ -165,7 +165,7 @@ exports[`Product RHOSAK config should apply an instances inventory configuration
     },
     {
       "title": <Tooltip
-        content="t(curiosity-inventory.header, {"context":"tooltip_Storage-gibibyte-months"})"
+        content="t(curiosity-inventory.header_tooltip, {"context":"Storage-gibibyte-months"})"
         distance={5}
         enableFlip={false}
         entryDelay={100}


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(i18nHelpers): update multi-context keys
- perf(i18n): breakout i18n into helpers

### Notes
- this update makes it easier to apply mult-context keys
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm that all strings are displaying correctly, including dropdown/select lists

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing