### PR TITLE
fix(config): sw-707 openshift-metrics graph x-axis

### DIFF
--- a/src/components/router/__tests__/__snapshots__/redirect.test.js.snap
+++ b/src/components/router/__tests__/__snapshots__/redirect.test.js.snap
@@ -192,6 +192,7 @@ exports[`Redirect Component should handle existing routes: existing route 1`] = 
         {
           "color": "#06c",
           "fill": "#8bc1f7",
+          "isStacked": false,
           "metric": "Cores",
           "stroke": "#06c",
         },

--- a/src/config/__tests__/__snapshots__/product.openshiftMetrics.test.js.snap
+++ b/src/config/__tests__/__snapshots__/product.openshiftMetrics.test.js.snap
@@ -13,7 +13,7 @@ exports[`Product OpenShift Metrics config should apply graph configuration: filt
           "fill": "#8bc1f7",
           "id": "Cores",
           "isCapacity": false,
-          "isStacked": true,
+          "isStacked": false,
           "isStandalone": false,
           "isThreshold": false,
           "metric": "Cores",

--- a/src/config/product.openshiftMetrics.js
+++ b/src/config/product.openshiftMetrics.js
@@ -50,7 +50,8 @@ const config = {
       metric: RHSM_API_PATH_METRIC_TYPES.CORES,
       fill: chartColorBlueLight.value,
       stroke: chartColorBlueDark.value,
-      color: chartColorBlueDark.value
+      color: chartColorBlueDark.value,
+      isStacked: false
     }
   ],
   initialGraphSettings: {


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(config): sw-707 openshift-metrics graph x-axis

<!-- ### Notes -->
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. navigate towards OpenShift-metrics/OpenShift on-demand and confirm the date range displays correctly, on graph.

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screen Shot 2022-11-28 at 12 41 18 PM (2)](https://user-images.githubusercontent.com/3761375/204345997-b0fe15b8-65e1-49d8-bf93-d15269456ce4.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-707