### PR TITLE
fix(inventoryCard): sw-703 reset columns, rows

### DIFF
--- a/src/components/inventoryCard/__tests__/__snapshots__/inventoryCardContext.test.js.snap
+++ b/src/components/inventoryCard/__tests__/__snapshots__/inventoryCardContext.test.js.snap
@@ -32,7 +32,29 @@ exports[`InventoryCardContext should handle a store response with useGetHostsInv
   ],
   "error": false,
   "fulfilled": true,
+  "message": null,
   "pending": false,
+  "responses": {
+    "id": {},
+    "list": [
+      {
+        "data": [
+          {
+            "data": [
+              {
+                "lorem": "ipsum",
+              },
+              {
+                "dolor": "sit",
+              },
+            ],
+            "meta": {},
+          },
+        ],
+        "fulfilled": true,
+      },
+    ],
+  },
 }
 `;
 
@@ -53,7 +75,29 @@ exports[`InventoryCardContext should handle a store response with useGetInstance
   ],
   "error": false,
   "fulfilled": true,
+  "message": null,
   "pending": false,
+  "responses": {
+    "id": {},
+    "list": [
+      {
+        "data": [
+          {
+            "data": [
+              {
+                "lorem": "ipsum",
+              },
+              {
+                "dolor": "sit",
+              },
+            ],
+            "meta": {},
+          },
+        ],
+        "fulfilled": true,
+      },
+    ],
+  },
 }
 `;
 
@@ -145,8 +189,6 @@ exports[`InventoryCardContext should handle an onPage event: onPage event, dispa
 exports[`InventoryCardContext should handle variations in hosts inventory API responses: inventory, cancelled 1`] = `
 {
   "data": {},
-  "error": undefined,
-  "fulfilled": undefined,
   "pending": true,
 }
 `;
@@ -154,8 +196,6 @@ exports[`InventoryCardContext should handle variations in hosts inventory API re
 exports[`InventoryCardContext should handle variations in hosts inventory API responses: inventory, disabled 1`] = `
 {
   "data": {},
-  "error": undefined,
-  "fulfilled": undefined,
   "pending": false,
 }
 `;
@@ -164,7 +204,6 @@ exports[`InventoryCardContext should handle variations in hosts inventory API re
 {
   "data": {},
   "error": true,
-  "fulfilled": undefined,
   "pending": false,
 }
 `;
@@ -172,7 +211,6 @@ exports[`InventoryCardContext should handle variations in hosts inventory API re
 exports[`InventoryCardContext should handle variations in hosts inventory API responses: inventory, fulfilled 1`] = `
 {
   "data": {},
-  "error": undefined,
   "fulfilled": true,
   "pending": false,
 }
@@ -181,8 +219,6 @@ exports[`InventoryCardContext should handle variations in hosts inventory API re
 exports[`InventoryCardContext should handle variations in hosts inventory API responses: inventory, pending 1`] = `
 {
   "data": {},
-  "error": undefined,
-  "fulfilled": undefined,
   "pending": true,
 }
 `;
@@ -190,8 +226,6 @@ exports[`InventoryCardContext should handle variations in hosts inventory API re
 exports[`InventoryCardContext should handle variations in instances inventory API responses: inventory, cancelled 1`] = `
 {
   "data": {},
-  "error": undefined,
-  "fulfilled": undefined,
   "pending": true,
 }
 `;
@@ -199,8 +233,6 @@ exports[`InventoryCardContext should handle variations in instances inventory AP
 exports[`InventoryCardContext should handle variations in instances inventory API responses: inventory, disabled 1`] = `
 {
   "data": {},
-  "error": undefined,
-  "fulfilled": undefined,
   "pending": false,
 }
 `;
@@ -209,7 +241,6 @@ exports[`InventoryCardContext should handle variations in instances inventory AP
 {
   "data": {},
   "error": true,
-  "fulfilled": undefined,
   "pending": false,
 }
 `;
@@ -217,7 +248,6 @@ exports[`InventoryCardContext should handle variations in instances inventory AP
 exports[`InventoryCardContext should handle variations in instances inventory API responses: inventory, fulfilled 1`] = `
 {
   "data": {},
-  "error": undefined,
   "fulfilled": true,
   "pending": false,
 }
@@ -226,8 +256,6 @@ exports[`InventoryCardContext should handle variations in instances inventory AP
 exports[`InventoryCardContext should handle variations in instances inventory API responses: inventory, pending 1`] = `
 {
   "data": {},
-  "error": undefined,
-  "fulfilled": undefined,
   "pending": true,
 }
 `;

--- a/src/components/inventoryCard/inventoryCard.js
+++ b/src/components/inventoryCard/inventoryCard.js
@@ -72,9 +72,11 @@ const InventoryCard = ({
   const { data: listData = [], meta = {} } = data;
 
   useDeepCompareEffect(() => {
+    let updatedColumnHeaders = [];
+    let updatedRows = [];
+
     if (fulfilled && listData.length) {
-      let updatedColumnHeaders = [];
-      const updatedRows = listData.map(({ ...cellData }) => {
+      updatedRows = listData.map(({ ...cellData }) => {
         const { columnHeaders, cells } = inventoryCardHelpers.parseRowCellsListData({
           filters: inventoryCardHelpers.parseInventoryFilters({
             filters: filterInventoryData,
@@ -112,12 +114,12 @@ const InventoryCard = ({
             undefined
         };
       });
-
-      setUpdatedColumnsRows(() => ({
-        columnHeaders: updatedColumnHeaders,
-        rows: updatedRows
-      }));
     }
+
+    setUpdatedColumnsRows(() => ({
+      columnHeaders: updatedColumnHeaders,
+      rows: updatedRows
+    }));
   }, [filterInventoryData, fulfilled, listData]);
 
   if (isDisabled) {

--- a/src/components/inventoryCard/inventoryCardContext.js
+++ b/src/components/inventoryCard/inventoryCardContext.js
@@ -34,7 +34,7 @@ const useGetHostsInventory = ({
   const { productId } = useAliasProduct();
   const query = useAliasProductInventoryQuery();
   const dispatch = useAliasDispatch();
-  const { error, cancelled, fulfilled, pending, data } = useAliasSelectorsResponse(
+  const { cancelled, pending, data, ...response } = useAliasSelectorsResponse(
     ({ inventory }) => inventory?.hostsInventory?.[productId]
   );
 
@@ -45,8 +45,7 @@ const useGetHostsInventory = ({
   }, [dispatch, isDisabled, productId, query]);
 
   return {
-    error,
-    fulfilled,
+    ...response,
     pending: pending || cancelled || false,
     data: (data?.length === 1 && data[0]) || data || {}
   };
@@ -75,7 +74,7 @@ const useGetInstancesInventory = ({
   const { productId } = useAliasProduct();
   const query = useAliasProductInventoryQuery();
   const dispatch = useAliasDispatch();
-  const { error, cancelled, fulfilled, pending, data } = useAliasSelectorsResponse(
+  const { cancelled, pending, data, ...response } = useAliasSelectorsResponse(
     ({ inventory }) => inventory?.instancesInventory?.[productId]
   );
 
@@ -86,8 +85,7 @@ const useGetInstancesInventory = ({
   }, [dispatch, isDisabled, productId, query]);
 
   return {
-    error,
-    fulfilled,
+    ...response,
     pending: pending || cancelled || false,
     data: (data?.length === 1 && data[0]) || data || {}
   };

--- a/src/components/inventoryCardSubscriptions/__tests__/__snapshots__/inventoryCardSubscriptionsContext.test.js.snap
+++ b/src/components/inventoryCardSubscriptions/__tests__/__snapshots__/inventoryCardSubscriptionsContext.test.js.snap
@@ -30,7 +30,29 @@ exports[`InventoryCardSubscriptionsContext should handle a store response with u
   ],
   "error": false,
   "fulfilled": true,
+  "message": null,
   "pending": false,
+  "responses": {
+    "id": {},
+    "list": [
+      {
+        "data": [
+          {
+            "data": [
+              {
+                "lorem": "ipsum",
+              },
+              {
+                "dolor": "sit",
+              },
+            ],
+            "meta": {},
+          },
+        ],
+        "fulfilled": true,
+      },
+    ],
+  },
 }
 `;
 
@@ -89,8 +111,6 @@ exports[`InventoryCardSubscriptionsContext should handle an onPage event: onPage
 exports[`InventoryCardSubscriptionsContext should handle variations in instances inventory API responses: inventory, cancelled 1`] = `
 {
   "data": {},
-  "error": undefined,
-  "fulfilled": undefined,
   "pending": true,
 }
 `;
@@ -98,8 +118,6 @@ exports[`InventoryCardSubscriptionsContext should handle variations in instances
 exports[`InventoryCardSubscriptionsContext should handle variations in instances inventory API responses: inventory, disabled 1`] = `
 {
   "data": {},
-  "error": undefined,
-  "fulfilled": undefined,
   "pending": false,
 }
 `;
@@ -108,7 +126,6 @@ exports[`InventoryCardSubscriptionsContext should handle variations in instances
 {
   "data": {},
   "error": true,
-  "fulfilled": undefined,
   "pending": false,
 }
 `;
@@ -116,7 +133,6 @@ exports[`InventoryCardSubscriptionsContext should handle variations in instances
 exports[`InventoryCardSubscriptionsContext should handle variations in instances inventory API responses: inventory, fulfilled 1`] = `
 {
   "data": {},
-  "error": undefined,
   "fulfilled": true,
   "pending": false,
 }
@@ -125,8 +141,6 @@ exports[`InventoryCardSubscriptionsContext should handle variations in instances
 exports[`InventoryCardSubscriptionsContext should handle variations in instances inventory API responses: inventory, pending 1`] = `
 {
   "data": {},
-  "error": undefined,
-  "fulfilled": undefined,
   "pending": true,
 }
 `;

--- a/src/components/inventoryCardSubscriptions/inventoryCardSubscriptionsContext.js
+++ b/src/components/inventoryCardSubscriptions/inventoryCardSubscriptionsContext.js
@@ -33,7 +33,7 @@ const useGetSubscriptionsInventory = ({
   const { productId } = useAliasProduct();
   const query = useAliasProductInventoryQuery();
   const dispatch = useAliasDispatch();
-  const { error, cancelled, fulfilled, pending, data } = useAliasSelectorsResponse(
+  const { cancelled, pending, data, ...response } = useAliasSelectorsResponse(
     ({ inventory }) => inventory?.subscriptionsInventory?.[productId]
   );
 
@@ -44,8 +44,7 @@ const useGetSubscriptionsInventory = ({
   }, [dispatch, isDisabled, productId, query]);
 
   return {
-    error,
-    fulfilled,
+    ...response,
     pending: pending || cancelled || false,
     data: (data?.length === 1 && data[0]) || data || {}
   };

--- a/tests/__snapshots__/code.test.js.snap
+++ b/tests/__snapshots__/code.test.js.snap
@@ -2,11 +2,11 @@
 
 exports[`General code checks should only have specific console.[warn|log|info|error] methods: console methods 1`] = `
 [
-  "components/inventoryCard/inventoryCardContext.js:169:        console.warn(\`Sorting can only be performed on select fields, confirm field \${id} is allowed.\`);",
-  "components/inventoryCard/inventoryCardContext.js:231:        console.warn(\`Sorting can only be performed on select fields, confirm field \${id} is allowed.\`);",
+  "components/inventoryCard/inventoryCardContext.js:167:        console.warn(\`Sorting can only be performed on select fields, confirm field \${id} is allowed.\`);",
+  "components/inventoryCard/inventoryCardContext.js:229:        console.warn(\`Sorting can only be performed on select fields, confirm field \${id} is allowed.\`);",
   "components/inventoryCard/inventoryCardHelpers.js:87:          console.warn(\`Warning: Filter "\${id}" not found in "table row" response data.\`, cellData);",
   "components/inventoryCard/inventoryList.deprecated.js:62:        console.warn(\`Sorting can only be performed on select fields, confirm field \${id} is allowed.\`);",
-  "components/inventoryCardSubscriptions/inventoryCardSubscriptionsContext.js:127:        console.warn(\`Sorting can only be performed on select fields, confirm field \${id} is allowed.\`);",
+  "components/inventoryCardSubscriptions/inventoryCardSubscriptionsContext.js:126:        console.warn(\`Sorting can only be performed on select fields, confirm field \${id} is allowed.\`);",
   "index.js:12:      console.log(\`Emulated appNavClick: \${JSON.stringify({ id, ...rest })}\`);",
   "redux/common/reduxHelpers.js:282:    console.error(\`Error: Property \${prop} does not exist within the passed state.\`, state);",
   "redux/common/reduxHelpers.js:286:    console.warn(\`Warning: Property \${prop} does not exist within the passed initialState.\`, initialState);",


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(inventoryCard): sw-703 reset columns, rows

### Notes
- quick fix to align inventory components
   - Need to review using the deep comparison on these against a lighter alternative, something like data response identifiers. We use a form of ID hash caching that could be leveraged here

<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm that inventory displays reset and display the correct data when selecting granularity, granularity-like, and uom filters

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-703
relates sw-702 sw-235 sw-690