### PR TITLE
fix(rhsmTransformers,services): sw-726 restore capacity logic

### DIFF
--- a/src/services/rhsm/__tests__/__snapshots__/rhsmTransformers.test.js.snap
+++ b/src/services/rhsm/__tests__/__snapshots__/rhsmTransformers.test.js.snap
@@ -44,7 +44,7 @@ exports[`RHSM Transformers should attempt to parse a capacity response: capacity
       "isCurrentDate": false,
       "isFutureDate": true,
       "x": 2,
-      "y": 0,
+      "y": null,
     },
     {
       "date": "2019-07-22T00:00:00Z",
@@ -53,7 +53,7 @@ exports[`RHSM Transformers should attempt to parse a capacity response: capacity
       "isCurrentDate": false,
       "isFutureDate": true,
       "x": 3,
-      "y": 0,
+      "y": null,
     },
     {
       "date": "2019-07-23T00:00:00Z",
@@ -62,7 +62,7 @@ exports[`RHSM Transformers should attempt to parse a capacity response: capacity
       "isCurrentDate": false,
       "isFutureDate": true,
       "x": 4,
-      "y": 0,
+      "y": null,
     },
     {
       "date": "2019-07-24T00:00:00Z",
@@ -71,7 +71,7 @@ exports[`RHSM Transformers should attempt to parse a capacity response: capacity
       "isCurrentDate": false,
       "isFutureDate": true,
       "x": 5,
-      "y": 0,
+      "y": null,
     },
     {
       "date": "2019-07-25T00:00:00Z",
@@ -80,7 +80,7 @@ exports[`RHSM Transformers should attempt to parse a capacity response: capacity
       "isCurrentDate": false,
       "isFutureDate": true,
       "x": 6,
-      "y": 0,
+      "y": null,
     },
     {
       "date": "2019-07-26T00:00:00Z",
@@ -89,7 +89,7 @@ exports[`RHSM Transformers should attempt to parse a capacity response: capacity
       "isCurrentDate": false,
       "isFutureDate": true,
       "x": 7,
-      "y": 0,
+      "y": null,
     },
     {
       "date": "2019-07-27T00:00:00Z",
@@ -98,7 +98,7 @@ exports[`RHSM Transformers should attempt to parse a capacity response: capacity
       "isCurrentDate": false,
       "isFutureDate": true,
       "x": 8,
-      "y": 0,
+      "y": null,
     },
     {
       "date": "2019-07-28T00:00:00Z",
@@ -107,7 +107,7 @@ exports[`RHSM Transformers should attempt to parse a capacity response: capacity
       "isCurrentDate": false,
       "isFutureDate": true,
       "x": 9,
-      "y": 0,
+      "y": null,
     },
     {
       "date": "2019-07-29T00:00:00Z",
@@ -116,7 +116,7 @@ exports[`RHSM Transformers should attempt to parse a capacity response: capacity
       "isCurrentDate": false,
       "isFutureDate": true,
       "x": 10,
-      "y": 0,
+      "y": null,
     },
     {
       "date": "2019-07-30T00:00:00Z",
@@ -125,7 +125,7 @@ exports[`RHSM Transformers should attempt to parse a capacity response: capacity
       "isCurrentDate": false,
       "isFutureDate": true,
       "x": 11,
-      "y": 0,
+      "y": null,
     },
     {
       "date": "2019-07-31T00:00:00Z",
@@ -134,7 +134,7 @@ exports[`RHSM Transformers should attempt to parse a capacity response: capacity
       "isCurrentDate": false,
       "isFutureDate": true,
       "x": 12,
-      "y": 0,
+      "y": null,
     },
   ],
   "meta": {
@@ -223,7 +223,7 @@ exports[`RHSM Transformers should attempt to parse a capacity response: capacity
       "isCurrentDate": false,
       "isFutureDate": true,
       "x": 7,
-      "y": 0,
+      "y": null,
     },
     {
       "date": "2019-07-22T00:00:00Z",
@@ -232,7 +232,7 @@ exports[`RHSM Transformers should attempt to parse a capacity response: capacity
       "isCurrentDate": false,
       "isFutureDate": true,
       "x": 8,
-      "y": 0,
+      "y": null,
     },
     {
       "date": "2019-07-23T00:00:00Z",
@@ -241,7 +241,7 @@ exports[`RHSM Transformers should attempt to parse a capacity response: capacity
       "isCurrentDate": false,
       "isFutureDate": true,
       "x": 9,
-      "y": 0,
+      "y": null,
     },
     {
       "date": "2019-07-24T00:00:00Z",
@@ -250,7 +250,7 @@ exports[`RHSM Transformers should attempt to parse a capacity response: capacity
       "isCurrentDate": false,
       "isFutureDate": true,
       "x": 10,
-      "y": 0,
+      "y": null,
     },
     {
       "date": "2019-07-25T00:00:00Z",
@@ -259,7 +259,7 @@ exports[`RHSM Transformers should attempt to parse a capacity response: capacity
       "isCurrentDate": false,
       "isFutureDate": true,
       "x": 11,
-      "y": 0,
+      "y": null,
     },
   ],
   "meta": {
@@ -348,7 +348,7 @@ exports[`RHSM Transformers should attempt to parse a capacity response: capacity
       "isCurrentDate": false,
       "isFutureDate": true,
       "x": 7,
-      "y": 0,
+      "y": null,
     },
   ],
   "meta": {

--- a/src/services/rhsm/__tests__/rhsmTransformers.test.js
+++ b/src/services/rhsm/__tests__/rhsmTransformers.test.js
@@ -15,7 +15,7 @@ describe('RHSM Transformers', () => {
       [rhsmConstants.RHSM_API_RESPONSE_META]: {}
     };
 
-    expect(rhsmTransformers.tallyCapacity(baseCapacity)).toMatchSnapshot('capacity');
+    expect(rhsmTransformers.tallyCapacity(baseCapacity, { _isCapacity: true })).toMatchSnapshot('capacity');
 
     const dailyCapacityResponse = {
       [rhsmConstants.RHSM_API_RESPONSE_DATA]: [
@@ -83,7 +83,9 @@ describe('RHSM Transformers', () => {
       [rhsmConstants.RHSM_API_RESPONSE_META]: {}
     };
 
-    expect(rhsmTransformers.tallyCapacity(dailyCapacityResponse)).toMatchSnapshot('capacity, daily like granularity');
+    expect(rhsmTransformers.tallyCapacity(dailyCapacityResponse, { _isCapacity: true })).toMatchSnapshot(
+      'capacity, daily like granularity'
+    );
 
     const dailyCapacityFirstMonthResponse = {
       [rhsmConstants.RHSM_API_RESPONSE_DATA]: [
@@ -151,7 +153,9 @@ describe('RHSM Transformers', () => {
       [rhsmConstants.RHSM_API_RESPONSE_META]: {}
     };
 
-    const transformedDailyCapacityFirstMonthResponse = rhsmTransformers.tallyCapacity(dailyCapacityFirstMonthResponse);
+    const transformedDailyCapacityFirstMonthResponse = rhsmTransformers.tallyCapacity(dailyCapacityFirstMonthResponse, {
+      _isCapacity: true
+    });
 
     expect(dailyCapacityFirstMonthResponse[rhsmConstants.RHSM_API_RESPONSE_DATA].length).toBe(12);
     expect(transformedDailyCapacityFirstMonthResponse.data.length).toBe(13);
@@ -205,7 +209,7 @@ describe('RHSM Transformers', () => {
       [rhsmConstants.RHSM_API_RESPONSE_META]: {}
     };
 
-    expect(rhsmTransformers.tallyCapacity(monthlyCapacityResponse)).toMatchSnapshot(
+    expect(rhsmTransformers.tallyCapacity(monthlyCapacityResponse, { _isCapacity: true })).toMatchSnapshot(
       'capacity, monthly like granularity'
     );
   });

--- a/src/services/rhsm/rhsmServices.js
+++ b/src/services/rhsm/rhsmServices.js
@@ -2185,7 +2185,8 @@ const getGraphCapacity = (id, params = {}, options = {}) => {
     cancel,
     cancelId,
     schema,
-    transform
+    transform,
+    _isCapacity: true
   });
 };
 

--- a/src/services/rhsm/rhsmTransformers.js
+++ b/src/services/rhsm/rhsmTransformers.js
@@ -98,10 +98,11 @@ const rhsmInstances = response => {
  *
  * @param {object} response
  * @param {object} config
+ * @param {boolean} config._isCapacity
  * @param {string} config.params
  * @returns {object}
  */
-const rhsmTallyCapacity = (response, { params } = {}) => {
+const rhsmTallyCapacity = (response, { _isCapacity, params } = {}) => {
   const updatedResponse = {};
   const { [rhsmConstants.RHSM_API_RESPONSE_DATA]: data = [], [rhsmConstants.RHSM_API_RESPONSE_META]: meta = {} } =
     response || {};
@@ -130,7 +131,10 @@ const rhsmTallyCapacity = (response, { params } = {}) => {
       return {
         x: index,
         y:
-          (hasData === false && isFutureDate) || (hasData === false && isCurrentDate) || hasInfiniteQuantity === true
+          (_isCapacity === true && isFutureDate) ||
+          (_isCapacity === true && hasInfiniteQuantity === true) ||
+          (!_isCapacity && hasData === false && isFutureDate) ||
+          (!_isCapacity && hasData === false && isCurrentDate)
             ? null
             : value,
         date,


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(rhsmTransformers,services): sw-726 restore capacity logic

### Notes
- the capacity metric response includes a `has_data` property. we reverted using this property and restored the original y axis capacity display logic
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm threshold/capacity display returns expected display results


### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. confirm checks come back clean


## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-726
relates sw-690 sw-235