### PR TITLE
chore(testing): sw-722 dist route checks for ephemeral

### DIFF
--- a/tests/__snapshots__/dist.test.js.snap
+++ b/tests/__snapshots__/dist.test.js.snap
@@ -1,5 +1,70 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Build distribution should have a predictable ephemeral navigation based on route configuration: expected covered, missing routes 1`] = `
+[
+  {
+    "coverage": "TRUE",
+    "path": "/rhel",
+    "productParameter": [
+      "RHEL",
+    ],
+  },
+  {
+    "coverage": "TRUE",
+    "path": "/openshift-container",
+    "productParameter": [
+      "OpenShift Container Platform",
+      "OpenShift-metrics",
+    ],
+  },
+  {
+    "coverage": "TRUE",
+    "path": "/openshift-dedicated",
+    "productParameter": [
+      "OpenShift-dedicated-metrics",
+    ],
+  },
+  {
+    "coverage": "FALSE",
+    "path": "/rhacs",
+    "productParameter": [
+      "rhacs",
+    ],
+  },
+  {
+    "coverage": "TRUE",
+    "path": "/rhods",
+    "productParameter": [
+      "rhods",
+    ],
+  },
+  {
+    "coverage": "TRUE",
+    "path": "/streams",
+    "productParameter": [
+      "rhosak",
+    ],
+  },
+  {
+    "coverage": "TRUE",
+    "path": "/satellite",
+    "productParameter": [
+      "Satellite",
+    ],
+  },
+  {
+    "coverage": "FALSE",
+    "path": "/optin",
+    "productParameter": null,
+  },
+  {
+    "coverage": "FALSE",
+    "path": "/",
+    "productParameter": null,
+  },
+]
+`;
+
 exports[`Build distribution should match a specific file output 1`] = `
 [
   "",


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- chore(testing): sw-722 dist route checks for ephemeral

### Notes
- simple output checks to confirm ephemeral routing config aligns with app routing expectations @mirekdlugosz 
- we missed an update that could cause future problems in #1014 this check will help prevent that in the future

<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->

### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. confirm build checks pass


## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-722
ongoing