### PR TITLE
fix(config): sw-106 disable category, metric sort

### DIFF
--- a/src/config/__tests__/__snapshots__/product.rhel.test.js.snap
+++ b/src/config/__tests__/__snapshots__/product.rhel.test.js.snap
@@ -247,7 +247,7 @@ exports[`Product RHEL config should apply hosts inventory configuration: filtere
       </React.Fragment>,
     },
     {
-      "title": "",
+      "title": "--",
     },
     {
       "title": <DateFormat
@@ -343,7 +343,7 @@ exports[`Product RHEL config should apply hosts inventory configuration: filtere
       </React.Fragment>,
     },
     {
-      "title": "",
+      "title": "--",
     },
     {
       "title": "",

--- a/src/config/product.rhel.js
+++ b/src/config/product.rhel.js
@@ -217,12 +217,13 @@ const config = {
             ''}
         </React.Fragment>
       ),
-      isSortable: true,
+      isSortable: false,
       cellWidth: 20
     },
     {
       id: RHSM_API_PATH_METRIC_TYPES.SOCKETS,
-      isSortable: true,
+      cell: ({ [RHSM_API_PATH_METRIC_TYPES.SOCKETS]: sockets } = {}) => sockets?.value || '--',
+      isSortable: false,
       isWrappable: true,
       cellWidth: 15
     },

--- a/src/services/rhsm/rhsmSchemas.js
+++ b/src/services/rhsm/rhsmSchemas.js
@@ -168,9 +168,9 @@ const instancesMetaSchema = metaResponseSchema
  */
 const instancesItem = Joi.object({
   inventory_id: Joi.string().optional().allow(null),
-  category: Joi.string().optional().allow(null),
+  category: Joi.string().lowercase().optional().allow(null),
   display_name: Joi.string().optional().allow(null),
-  billing_provider: Joi.string().optional().allow(null),
+  billing_provider: Joi.string().lowercase().optional().allow(null, ''),
   billing_account_id: Joi.string().optional().allow(null),
   measurements: Joi.array().default([]),
   number_of_guests: Joi.number().integer().default(0),


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(config): sw-106 disable category, metric sort

### Notes
* config, rhel disable sort, metric dash display
* rhsmSchemas, lowercase response, allow empty
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. navigate to RHEL and confirm
   - that the Category and metric/Sockets sorts are off
   - that the metric/Sockets column displays `--` when the value doesn't exist or is zero from the API

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screen Shot 2023-01-23 at 2 37 43 PM](https://user-images.githubusercontent.com/3761375/214133480-b529f815-5f4a-44e6-9602-a6ea90ed4f48.png)



## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-106
sw-235
sw-806
pr #1018 