### PR TITLE
fix(routerContext): sw-625 doc name, deprecated init

### DIFF
--- a/src/components/authentication/authenticationContext.js
+++ b/src/components/authentication/authenticationContext.js
@@ -27,7 +27,6 @@ const useAuthContext = () => useContext(AuthenticationContext);
  * @param {string} options.appName
  * @param {Function} options.authorizeUser
  * @param {Function} options.hideGlobalFilter
- * @param {Function} options.initializeChrome
  * @param {Function} options.setAppName
  * @param {Function} options.useDispatch
  * @param {Function} options.useSelectorsResponse
@@ -37,7 +36,6 @@ const useGetAuthorization = ({
   appName = routerHelpers.appName,
   authorizeUser = reduxActions.platform.authorizeUser,
   hideGlobalFilter = reduxActions.platform.hideGlobalFilter,
-  initializeChrome = reduxActions.platform.initializeChrome,
   setAppName = reduxActions.platform.setAppName,
   useDispatch: useAliasDispatch = storeHooks.reactRedux.useDispatch,
   useSelectorsResponse: useAliasSelectorsResponse = storeHooks.reactRedux.useSelectorsResponse
@@ -54,7 +52,7 @@ const useGetAuthorization = ({
 
   useMount(async () => {
     await dispatch(authorizeUser());
-    dispatch([initializeChrome(), setAppName(appName), hideGlobalFilter()]);
+    dispatch([setAppName(appName), hideGlobalFilter()]);
   });
 
   const [user = {}, app = {}] = (Array.isArray(data.auth) && data.auth) || [];

--- a/src/components/router/routerContext.js
+++ b/src/components/router/routerContext.js
@@ -8,9 +8,11 @@ import {
   // useParams as useRRDParams,
   useSearchParams as useRRDSearchParams
 } from 'react-router-dom';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import { routerHelpers } from './routerHelpers';
 import { helpers } from '../../common/helpers';
 import { storeHooks, reduxTypes } from '../../redux';
+import { translate } from '../i18n/i18n';
 
 /**
  * ToDo: Review react-router-dom useParams once v6 updates are in env
@@ -247,10 +249,17 @@ const useSetRouteDetail = ({
  * Get a route detail from router context.
  *
  * @param {object} options
+ * @param {Function} options.t
+ * @param {Function} options.useChrome
  * @param {Function} options.useSelector
  * @returns {{baseName: string, errorRoute: object}}
  */
-const useRouteDetail = ({ useSelector: useAliasSelector = storeHooks.reactRedux.useSelectors } = {}) => {
+const useRouteDetail = ({
+  t = translate,
+  useChrome: useAliasChrome = useChrome,
+  useSelector: useAliasSelector = storeHooks.reactRedux.useSelectors
+} = {}) => {
+  const { updateDocumentTitle } = useAliasChrome();
   const [productPath] = useAliasSelector([({ view }) => view?.product?.config]);
   const [detail, setDetail] = useState({});
   console.log('>>> use route detail', productPath);
@@ -268,9 +277,15 @@ const useRouteDetail = ({ useSelector: useAliasSelector = storeHooks.reactRedux.
         productConfig: (configs?.length && configs) || [],
         productPath
       };
+      updateDocumentTitle(
+        `${helpers.UI_DISPLAY_NAME}: ${t(`curiosity-view.title`, {
+          appName: helpers.UI_DISPLAY_NAME,
+          context: firstMatch?.productGroup
+        })}`
+      );
       setDetail(updateDetail);
     }
-  }, [detail?._passed, productPath]);
+  }, [detail?._passed, productPath, t, updateDocumentTitle]);
 
   return detail;
 


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(routerContext): sw-625 doc name, deprecated init

<!-- ### Notes -->
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-625
#1052 