### PR TITLE
fix(locale): sw-728 rhel, satellite variant filters

### DIFF
--- a/public/locales/en-US.json
+++ b/public/locales/en-US.json
@@ -286,7 +286,7 @@
     "label_category_physical": "Physical",
     "label_category_virtual": "Virtualized",
     "label_filter": "Filter by",
-    "label_filter_architecture": "Architecture",
+    "label_filter_architecture": "Variant",
     "label_filter_billing_provider": "Purchased through",
     "label_filter_category": "Type",
     "label_filter_granularity": "Granularity",
@@ -294,7 +294,7 @@
     "label_filter_sla": "SLA",
     "label_filter_uom": "Unit of measure",
     "label_filter_usage": "Usage",
-    "label_filter_variant": "Product",
+    "label_filter_variant": "Variant",
     "label_granularity": "",
     "label_granularity_Daily": "Daily",
     "label_granularity_Weekly": "Weekly",
@@ -328,7 +328,7 @@
     "placeholder_uom": "Select unit",
     "placeholder_usage": "Select usage",
     "placeholder_filter": "Filter by",
-    "placeholder_filter_architecture": "Filter by architecture",
+    "placeholder_filter_architecture": "Filter by variant",
     "placeholder_filter_billing_provider": "Filter by purchased through",
     "placeholder_filter_category": "Filter by type",
     "placeholder_filter_displayName": "Filter by name",
@@ -337,7 +337,7 @@
     "placeholder_filter_sla": "Filter by SLA",
     "placeholder_filter_uom": "Filter by unit",
     "placeholder_filter_usage": "Filter by usage",
-    "placeholder_filter_variant": "Filter by product"
+    "placeholder_filter_variant": "Filter by variant"
   },
   "curiosity-optin": {
     "buttonActivate": "Activate {{appName}}",


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(locale): sw-728 rhel, satellite variant filters

### Notes
- quick fix, string update Satellite products and RHEL architectures filter shifts towards `Variant`
- a more long term solution of combining the RHEL and Satellite views will have its own story
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. confirm the filters for both RHEL and Satellite toolbar display as `Variant` and `Filter by variant`, see examples below

<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screen Shot 2023-02-14 at 1 48 35 PM](https://user-images.githubusercontent.com/3761375/218831133-10b3c59f-535c-4c4d-a57d-90cc53861e18.png)
![Screen Shot 2023-02-14 at 1 48 54 PM](https://user-images.githubusercontent.com/3761375/218831135-a9af8605-f814-452c-95fe-734e32e21277.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-728