### PR TITLE
fix(productViewMissing): sw-625 local dev view, run

### DIFF
--- a/src/components/productView/productViewMissing.js
+++ b/src/components/productView/productViewMissing.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useLayoutEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Button, Card, CardBody, CardFooter, CardTitle, Gallery, Title, PageSection } from '@patternfly/react-core';
 import { ArrowRightIcon } from '@patternfly/react-icons';
@@ -31,10 +31,16 @@ const ProductViewMissing = ({
 }) => {
   const navigate = useAliasNavigate();
   const { firstMatch, allConfigs } = useAliasRouteDetail();
-  const availableProducts = (firstMatch && [firstMatch]) || allConfigs;
+  const availableProducts = (!helpers.DEV_MODE && firstMatch && [firstMatch]) || allConfigs;
+  const isRedirect = availableProducts?.length <= availableProductsRedirect;
 
-  if (availableProducts?.length <= availableProductsRedirect) {
-    navigate(availableProducts[0].productPath);
+  useLayoutEffect(() => {
+    if (isRedirect) {
+      navigate(availableProducts[0].productPath);
+    }
+  });
+
+  if (isRedirect) {
     return null;
   }
 
@@ -55,7 +61,8 @@ const ProductViewMissing = ({
           {availableProducts?.map(({ productGroup, productId, productPath }) => (
             <Card
               key={`missingViewCard-${productId}-${helpers.generateId()}`}
-              isHoverable
+              isSelectable
+              isSelected={firstMatch.productPath === productPath}
               onClick={() => onNavigate(productPath)}
             >
               <CardTitle>


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(productViewMissing): sw-625 local dev view, run

### Notes
- non blocking local developer workflow view and run
- we ignored/disabled the local developer workflow to get the router updates out. this pr reactivates it 
- this may, or may not, throw an error in console in environment since routing is now tiered/nested with consoledot
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. confirm that the default card display appears and can be used to navigate between all available products, see example
   - _note: the selected card attempts a url path closest match for product_


### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm routing/navigating between products remains unchanged
   - confirm manually navigating towards a url/path under subscriptions like `[consoledot path]/subscriptions/lorem-ipusm/rhacs` redirects to the closest product match without throwing a console error.
   - _note: an end-user should never be able to directly receive the developer multi-card-product view_


<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screen Shot 2023-03-02 at 4 18 16 PM](https://user-images.githubusercontent.com/3761375/222556388-4d05a4eb-8590-4c28-9e96-b68424bad946.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
