### PR TITLE
fix(routerContext): sw-625 useNavigate state update

### DIFF
--- a/src/components/README.md
+++ b/src/components/README.md
@@ -5183,7 +5183,8 @@ Focused on exposing replace and href.
 <a name="Router.module_RouterContext..useNavigate"></a>
 
 ### RouterContext~useNavigate(options) ⇒ <code>function</code>
-useNavigate wrapper, apply application config context routing
+useNavigate wrapper. Leverage useNavigate for a modified router with parallel "state"
+update. Dispatches the same type leveraged by the initialize hook, useSetRouteDetail.
 
 **Kind**: inner method of [<code>RouterContext</code>](#Router.module_RouterContext)  
 <table>
@@ -5196,6 +5197,8 @@ useNavigate wrapper, apply application config context routing
 <tr>
     <td>options</td><td><code>object</code></td>
     </tr><tr>
+    <td>options.useDispatch</td><td><code>function</code></td>
+    </tr><tr>
     <td>options.useLocation</td><td><code>function</code></td>
     </tr><tr>
     <td>options.useNavigate</td><td><code>function</code></td>
@@ -5205,7 +5208,8 @@ useNavigate wrapper, apply application config context routing
 <a name="Router.module_RouterContext..useRouteDetail"></a>
 
 ### RouterContext~useRouteDetail(options) ⇒ <code>Object</code>
-Get a route detail configuration from state.
+Get a route detail from "state". Consume useSetRouteDetail and set basis for product
+configuration context.
 
 **Kind**: inner method of [<code>RouterContext</code>](#Router.module_RouterContext)  
 <table>
@@ -5278,8 +5282,9 @@ This hook defaults to merging search objects instead of overwriting them.
 <a name="Router.module_RouterContext..useSetRouteDetail"></a>
 
 ### RouterContext~useSetRouteDetail(options) ⇒ <code>\*</code> \| <code>string</code>
-Store product path, parameter, in state. We're opting to use "window.location.pathname"
-directly since it appears to be quicker, and returns a similar structured value as useParam.
+Initialize and store product path, parameter, in a "state" update parallel to routing.
+We're opting to use "window.location.pathname" directly since it appears to be quicker,
+and returns a similar structured value as useParam.
 
 **Kind**: inner method of [<code>RouterContext</code>](#Router.module_RouterContext)  
 <table>

--- a/src/components/router/__tests__/__snapshots__/routerContext.test.js.snap
+++ b/src/components/router/__tests__/__snapshots__/routerContext.test.js.snap
@@ -9,6 +9,29 @@ exports[`RouterContext should apply a hook for useLocation: location 1`] = `
 }
 `;
 
+exports[`RouterContext should apply a hook for useNavigate: navigation dispatch 1`] = `
+[
+  [
+    {
+      "config": "rhods",
+      "type": "SET_PRODUCT",
+    },
+  ],
+  [
+    {
+      "config": "rhel",
+      "type": "SET_PRODUCT",
+    },
+  ],
+  [
+    {
+      "config": "rhel",
+      "type": "SET_PRODUCT",
+    },
+  ],
+]
+`;
+
 exports[`RouterContext should apply a hook for useNavigate: navigation push 1`] = `
 [
   "./rhods?lorem=ipsum",

--- a/src/components/router/__tests__/routerContext.test.js
+++ b/src/components/router/__tests__/routerContext.test.js
@@ -24,22 +24,26 @@ describe('RouterContext', () => {
   });
 
   it('should apply a hook for useNavigate', () => {
-    const mockLocation = {
-      search: '?lorem=ipsum'
-    };
-
+    const mockDispatch = jest.fn();
     const updatedCalls = [];
     const { result: mockNavigationSet } = shallowHook(() =>
       useNavigate({
-        useLocation: () => mockLocation,
+        useDispatch: () => mockDispatch,
+        useLocation: () => ({
+          search: '?lorem=ipsum'
+        }),
         useNavigate: () => value => updatedCalls.push(value)
       })
     );
 
+    /**
+     * Note: Snapshots for first "mockNavigationSet" are aimed at being what Levenshtein denotes as a "closest match"
+     */
     mockNavigationSet('/dolor/sit');
     mockNavigationSet('rhel');
     mockNavigationSet('insights');
 
+    expect(mockDispatch.mock.calls).toMatchSnapshot('navigation dispatch');
     expect(updatedCalls).toMatchSnapshot('navigation push');
   });
 


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(routerContext): sw-625 useNavigate state update

### Notes
- another non-blocking routing update. #1071 exposed a `useNavigate` issue, this corrects it. `useNavigate` is used on the missing product view ONLY (currently). If we at some point decide to `useNavigate` outside of the missing view this issue would be exposed
- there should be no noticeable end-user behavioral changes with this update
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. confirm that navigating from the "developer" view (product missing) does not require a "browser refresh" to view the corresponding product context

<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-625
#1071 