### PR TITLE
feat(i18nHelpers): sw-922 apply testId to copy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,12 +216,22 @@ This project makes use of reserved CSS class prefixes used by external resources
    CSS classes with the prefix `uxui-` are used by external resources to identify elements for use in 3rd party tooling. Changes to the class name or element should be broadcast towards our UI/UX team members. 
 
 ### Reserved QE testing attributes
-This project makes use of reserved DOM attributes used by the QE team.
-> Updating elements with these attributes should be done with the knowledge "you are affecting" QE's ability to test.
+This project makes use of reserved DOM attributes and string identifiers used by the QE team.
+> Updating elements with these attributes, or settings, should be done with the knowledge "you are affecting" QE's ability to test.
+> And it is recommended you coordinate with QE before altering these attributes, settings.
 
 1. Attribute `data-test`
 
-   DOM attributes with `data-test=""` are used by QE as a means to identify specific DOM elements.
+   - DOM attributes with `data-test=""` are used by QE as a means to identify specific DOM elements.
+   - To use simply place `data-test="[your-id-coordinated-with-QE]`" onto a DOM element.
+
+2. `testId` used with i18next `translate` or `t`
+
+   - The i18next `translate` or `t` function supports the use of a `testId` setting. This `testId` wraps a
+   `<span data-test=[testId|locale string id]>[locale string]</span>` around copy content.
+   - To use add the `testId` to your locale string function call use
+      - `t('locale.string.id', { testId: true })`. In this example, this would populate `locale.string.id` as the testId.
+      - or `t('locale.string.id', { testId: 'custom-id-coordinated-with-QE' })`
 
 ### Reserved Files
 #### Spandx Config

--- a/src/common/README.md
+++ b/src/common/README.md
@@ -204,7 +204,6 @@ Download the debug log file.
     * [~isPromise(obj)](#Helpers.module_General..isPromise) ⇒ <code>boolean</code>
     * [~generateHash(anyValue, options)](#Helpers.module_General..generateHash) ⇒ <code>\*</code> \| <code>string</code>
     * [~memo(func, options)](#Helpers.module_General..memo) ⇒ <code>function</code>
-    * [~noopTranslate(key, value, components)](#Helpers.module_General..noopTranslate) ⇒ <code>string</code>
     * [~numberDisplay(value)](#Helpers.module_General..numberDisplay) ⇒ <code>numbro.Numbro</code> \| <code>\*</code>
     * [~objFreeze(obj)](#Helpers.module_General..objFreeze) ⇒ <code>\*</code>
     * [~browserExpose(obj, options)](#Helpers.module_General..browserExpose)
@@ -526,29 +525,6 @@ Simple memoize, cache based arguments with adjustable limit.
     <td>options</td><td><code>object</code></td>
     </tr><tr>
     <td>options.cacheLimit</td><td><code>number</code></td>
-    </tr>  </tbody>
-</table>
-
-<a name="Helpers.module_General..noopTranslate"></a>
-
-### General~noopTranslate(key, value, components) ⇒ <code>string</code>
-A placeholder for "t", translation method.
-Associated with the i18n package, and typically used as a default prop.
-
-**Kind**: inner method of [<code>General</code>](#Helpers.module_General)  
-<table>
-  <thead>
-    <tr>
-      <th>Param</th><th>Type</th>
-    </tr>
-  </thead>
-  <tbody>
-<tr>
-    <td>key</td><td><code>string</code> | <code>Array</code></td>
-    </tr><tr>
-    <td>value</td><td><code>string</code> | <code>object</code> | <code>Array</code></td>
-    </tr><tr>
-    <td>components</td><td><code>Array</code></td>
     </tr>  </tbody>
 </table>
 

--- a/src/common/__tests__/__snapshots__/helpers.test.js.snap
+++ b/src/common/__tests__/__snapshots__/helpers.test.js.snap
@@ -45,7 +45,6 @@ exports[`Helpers should expose a window object: limited window object 1`] = `
   "memo": [Function],
   "noop": [Function],
   "noopPromise": Promise {},
-  "noopTranslate": [Function],
   "numberDisplay": [Function],
   "objFreeze": [Function],
 }
@@ -90,7 +89,6 @@ exports[`Helpers should expose a window object: window object 1`] = `
   "memo": [Function],
   "noop": [Function],
   "noopPromise": Promise {},
-  "noopTranslate": [Function],
   "numberDisplay": [Function],
   "objFreeze": [Function],
 }
@@ -146,7 +144,6 @@ exports[`Helpers should have specific functions: helpers 1`] = `
   "memo": [Function],
   "noop": [Function],
   "noopPromise": Promise {},
-  "noopTranslate": [Function],
   "numberDisplay": [Function],
   "objFreeze": [Function],
 }

--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -131,29 +131,6 @@ const noop = Function.prototype;
 const noopPromise = Promise.resolve({});
 
 /**
- * A placeholder for "t", translation method.
- * Associated with the i18n package, and typically used as a default prop.
- *
- * @param {string|Array} key
- * @param {string|object|Array} value
- * @param {Array} components
- * @returns {string}
- */
-const noopTranslate = (key, value, components) => {
-  const updatedKey = (Array.isArray(key) && `[${key}]`) || key;
-  const updatedValue =
-    (typeof value === 'string' && value) ||
-    (Array.isArray(value) && `[${value}]`) ||
-    (Object.keys(value || '').length && JSON.stringify(value)) ||
-    '';
-  const updatedComponents = (components && `${components}`) || '';
-
-  return `t(${updatedKey}${(updatedValue && `, ${updatedValue}`) || ''}${
-    (updatedComponents && `, ${updatedComponents}`) || ''
-  })`;
-};
-
-/**
  * ToDo: review adding "locale" for numbro
  */
 /**
@@ -434,7 +411,6 @@ const helpers = {
   memo,
   noop,
   noopPromise,
-  noopTranslate,
   numberDisplay,
   objFreeze,
   DEV_MODE,

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -2817,13 +2817,21 @@ See, https://react.i18next.com/
     <td>translateKey</td><td><code>string</code> | <code>Array</code></td><td></td><td><p>A key reference, or an array of a primary key with fallback keys.</p>
 </td>
     </tr><tr>
-    <td>values</td><td><code>string</code> | <code>object</code> | <code>Array</code></td><td><code>null</code></td><td><p>A default string if the key can&#39;t be found. An object with i18next settings. Or an array of objects (key/value) pairs used to replace string tokes. i.e. &quot;[{ hello: &#39;world&#39; }]&quot;</p>
+    <td>values</td><td><code>string</code> | <code>object</code> | <code>Array</code></td><td><code>null</code></td><td><ul>
+<li>A default string if the key can&#39;t be found.<ul>
+<li>An object with i18next settings. i.e. &quot;{ context: Array|string, testId: boolean|string }&quot;</li>
+<li>An array of objects (key/value) pairs used to replace string tokens. i.e. &quot;[{ hello: &#39;world&#39; }]&quot;</li>
+</ul>
+</li>
+</ul>
 </td>
     </tr><tr>
     <td>components</td><td><code>Array</code></td><td></td><td><p>An array of HTML/React nodes used to replace string tokens. i.e. &quot;[<span />, &lt;React.Fragment /&gt;]&quot;</p>
 </td>
     </tr><tr>
     <td>settings</td><td><code>object</code></td><td></td><td></td>
+    </tr><tr>
+    <td>settings.i18next</td><td><code>*</code></td><td></td><td></td>
     </tr><tr>
     <td>settings.isDebug</td><td><code>function</code></td><td></td><td></td>
     </tr><tr>
@@ -2852,6 +2860,8 @@ Apply string replacements against a component, HOC.
     <td>Component</td><td><code>React.ReactNode</code></td>
     </tr><tr>
     <td>settings</td><td><code>object</code></td>
+    </tr><tr>
+    <td>settings.i18next</td><td><code>*</code></td>
     </tr><tr>
     <td>settings.noopTranslate</td><td><code>function</code></td>
     </tr>  </tbody>

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -2697,8 +2697,12 @@ Default props.
 
 * [i18nHelpers](#i18n.module_i18nHelpers)
     * [~EMPTY_CONTEXT](#i18n.module_i18nHelpers..EMPTY_CONTEXT) : <code>string</code>
-    * [~translate(translateKey, values, components, options)](#i18n.module_i18nHelpers..translate) ⇒ <code>string</code> \| <code>React.ReactNode</code>
-    * [~translateComponent(Component)](#i18n.module_i18nHelpers..translateComponent) ⇒ <code>React.ReactNode</code>
+    * [~noopTranslate(key, value, components)](#i18n.module_i18nHelpers..noopTranslate) ⇒ <code>string</code>
+    * [~splitContext(value, settings)](#i18n.module_i18nHelpers..splitContext) ⇒ <code>string</code> \| <code>Array.&lt;string&gt;</code>
+    * [~parseContext(translateKey, context, settings)](#i18n.module_i18nHelpers..parseContext) ⇒ <code>Object</code>
+    * [~parseTranslateKey(translateKey)](#i18n.module_i18nHelpers..parseTranslateKey) ⇒ <code>\*</code>
+    * [~translate(translateKey, values, components, settings)](#i18n.module_i18nHelpers..translate) ⇒ <code>string</code> \| <code>React.ReactNode</code>
+    * [~translateComponent(Component, settings)](#i18n.module_i18nHelpers..translateComponent) ⇒ <code>React.ReactNode</code>
 
 <a name="i18n.module_i18nHelpers..EMPTY_CONTEXT"></a>
 
@@ -2706,9 +2710,98 @@ Default props.
 Check to help provide an empty context.
 
 **Kind**: inner constant of [<code>i18nHelpers</code>](#i18n.module_i18nHelpers)  
+<a name="i18n.module_i18nHelpers..noopTranslate"></a>
+
+### i18nHelpers~noopTranslate(key, value, components) ⇒ <code>string</code>
+A placeholder for "t", translation method.
+Associated with the i18n package, and typically used as a default prop.
+
+**Kind**: inner method of [<code>i18nHelpers</code>](#i18n.module_i18nHelpers)  
+<table>
+  <thead>
+    <tr>
+      <th>Param</th><th>Type</th>
+    </tr>
+  </thead>
+  <tbody>
+<tr>
+    <td>key</td><td><code>string</code> | <code>Array</code></td>
+    </tr><tr>
+    <td>value</td><td><code>string</code> | <code>object</code> | <code>Array</code></td>
+    </tr><tr>
+    <td>components</td><td><code>Array</code></td>
+    </tr>  </tbody>
+</table>
+
+<a name="i18n.module_i18nHelpers..splitContext"></a>
+
+### i18nHelpers~splitContext(value, settings) ⇒ <code>string</code> \| <code>Array.&lt;string&gt;</code>
+Split a string on underscore.
+
+**Kind**: inner method of [<code>i18nHelpers</code>](#i18n.module_i18nHelpers)  
+<table>
+  <thead>
+    <tr>
+      <th>Param</th><th>Type</th>
+    </tr>
+  </thead>
+  <tbody>
+<tr>
+    <td>value</td><td><code>string</code></td>
+    </tr><tr>
+    <td>settings</td><td><code>object</code></td>
+    </tr><tr>
+    <td>settings.emptyContextValue</td><td><code>string</code></td>
+    </tr>  </tbody>
+</table>
+
+<a name="i18n.module_i18nHelpers..parseContext"></a>
+
+### i18nHelpers~parseContext(translateKey, context, settings) ⇒ <code>Object</code>
+Parse extend context arrays/lists, and apply values to a concatenated translate key.
+
+**Kind**: inner method of [<code>i18nHelpers</code>](#i18n.module_i18nHelpers)  
+<table>
+  <thead>
+    <tr>
+      <th>Param</th><th>Type</th>
+    </tr>
+  </thead>
+  <tbody>
+<tr>
+    <td>translateKey</td><td><code>string</code> | <code>Array</code></td>
+    </tr><tr>
+    <td>context</td><td><code>*</code> | <code>string</code> | <code>Array</code></td>
+    </tr><tr>
+    <td>settings</td><td><code>object</code></td>
+    </tr><tr>
+    <td>settings.emptyContextValue</td><td><code>string</code></td>
+    </tr><tr>
+    <td>settings.splitContext</td><td><code>function</code></td>
+    </tr>  </tbody>
+</table>
+
+<a name="i18n.module_i18nHelpers..parseTranslateKey"></a>
+
+### i18nHelpers~parseTranslateKey(translateKey) ⇒ <code>\*</code>
+Parse a translation key. If an array, filter for defined strings.
+
+**Kind**: inner method of [<code>i18nHelpers</code>](#i18n.module_i18nHelpers)  
+<table>
+  <thead>
+    <tr>
+      <th>Param</th><th>Type</th>
+    </tr>
+  </thead>
+  <tbody>
+<tr>
+    <td>translateKey</td><td><code>*</code> | <code>string</code> | <code>Array</code></td>
+    </tr>  </tbody>
+</table>
+
 <a name="i18n.module_i18nHelpers..translate"></a>
 
-### i18nHelpers~translate(translateKey, values, components, options) ⇒ <code>string</code> \| <code>React.ReactNode</code>
+### i18nHelpers~translate(translateKey, values, components, settings) ⇒ <code>string</code> \| <code>React.ReactNode</code>
 Apply a string towards a key. Optional replacement values and component/nodes.
 See, https://react.i18next.com/
 
@@ -2730,16 +2823,21 @@ See, https://react.i18next.com/
     <td>components</td><td><code>Array</code></td><td></td><td><p>An array of HTML/React nodes used to replace string tokens. i.e. &quot;[<span />, &lt;React.Fragment /&gt;]&quot;</p>
 </td>
     </tr><tr>
-    <td>options</td><td><code>object</code></td><td></td><td></td>
+    <td>settings</td><td><code>object</code></td><td></td><td></td>
     </tr><tr>
-    <td>options.emptyContextValue</td><td><code>string</code></td><td></td><td><p>Check to allow an empty context value.</p>
-</td>
+    <td>settings.isDebug</td><td><code>function</code></td><td></td><td></td>
+    </tr><tr>
+    <td>settings.noopTranslate</td><td><code>function</code></td><td></td><td></td>
+    </tr><tr>
+    <td>settings.parseContext</td><td><code>function</code></td><td></td><td></td>
+    </tr><tr>
+    <td>settings.parseTranslateKey</td><td><code>function</code></td><td></td><td></td>
     </tr>  </tbody>
 </table>
 
 <a name="i18n.module_i18nHelpers..translateComponent"></a>
 
-### i18nHelpers~translateComponent(Component) ⇒ <code>React.ReactNode</code>
+### i18nHelpers~translateComponent(Component, settings) ⇒ <code>React.ReactNode</code>
 Apply string replacements against a component, HOC.
 
 **Kind**: inner method of [<code>i18nHelpers</code>](#i18n.module_i18nHelpers)  
@@ -2752,6 +2850,10 @@ Apply string replacements against a component, HOC.
   <tbody>
 <tr>
     <td>Component</td><td><code>React.ReactNode</code></td>
+    </tr><tr>
+    <td>settings</td><td><code>object</code></td>
+    </tr><tr>
+    <td>settings.noopTranslate</td><td><code>function</code></td>
     </tr>  </tbody>
 </table>
 

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -16,15 +16,6 @@ exports[`I18n Component should generate a predictable locale key output snapshot
     ],
   },
   {
-    "file": "./src/common/helpers.js",
-    "keys": [
-      {
-        "key": "",
-        "match": "t(\${updatedKey}\${(updatedValue && \`, \${updatedValue}\`)",
-      },
-    ],
-  },
-  {
     "file": "./src/components/authentication/authentication.js",
     "keys": [
       {
@@ -140,6 +131,15 @@ exports[`I18n Component should generate a predictable locale key output snapshot
       {
         "key": "curiosity-graph.cardFooterMetric",
         "match": "t('curiosity-graph.cardFooterMetric', { date: moment.utc(monthlyDate)",
+      },
+    ],
+  },
+  {
+    "file": "./src/components/i18n/i18nHelpers.js",
+    "keys": [
+      {
+        "key": "",
+        "match": "t(\${updatedKey}\${(updatedValue && \`, \${updatedValue}\`)",
       },
     ],
   },

--- a/src/components/i18n/__tests__/__snapshots__/i18nHelpers.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18nHelpers.test.js.snap
@@ -22,6 +22,10 @@ exports[`I18nHelpers should attempt to perform translate with a node: translated
 exports[`I18nHelpers should have specific functions: i18nHelpers 1`] = `
 {
   "EMPTY_CONTEXT": "LOCALE_EMPTY_CONTEXT",
+  "noopTranslate": [Function],
+  "parseContext": [Function],
+  "parseTranslateKey": [Function],
+  "splitContext": [Function],
   "translate": [Function],
   "translateComponent": [Function],
 }

--- a/src/components/i18n/__tests__/__snapshots__/i18nHelpers.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18nHelpers.test.js.snap
@@ -19,6 +19,43 @@ exports[`I18nHelpers should attempt to perform a string replace: translate 1`] =
 
 exports[`I18nHelpers should attempt to perform translate with a node: translated node 1`] = `"<div>t(lorem.ipsum, {&quot;hello&quot;:&quot;world&quot;}, [object Object])</div>"`;
 
+exports[`I18nHelpers should attempt to place a test identifier around copy: test id 1`] = `
+{
+  "basic": <span
+    className="curiosity-translate__test-id"
+    data-test="lorem.ipsum"
+  />,
+  "basicString": <span
+    className="curiosity-translate__test-id"
+    data-test="dolor-sit"
+  />,
+  "emptyContext": <span
+    className="curiosity-translate__test-id"
+    data-test="lorem.ipsum"
+  />,
+  "emptyContextString": <span
+    className="curiosity-translate__test-id"
+    data-test="dolor-sit"
+  />,
+  "emptyPartialContext": <span
+    className="curiosity-translate__test-id"
+    data-test="lorem.ipsum"
+  />,
+  "emptyPartialContextString": <span
+    className="curiosity-translate__test-id"
+    data-test="dolor-sit"
+  />,
+  "stringContextNested": <span
+    className="curiosity-translate__test-id"
+    data-test="lorem.ipsum"
+  />,
+  "stringContextNestedString": <span
+    className="curiosity-translate__test-id"
+    data-test="dolor-sit"
+  />,
+}
+`;
+
 exports[`I18nHelpers should have specific functions: i18nHelpers 1`] = `
 {
   "EMPTY_CONTEXT": "LOCALE_EMPTY_CONTEXT",

--- a/src/components/i18n/__tests__/i18nHelpers.test.js
+++ b/src/components/i18n/__tests__/i18nHelpers.test.js
@@ -56,4 +56,65 @@ describe('I18nHelpers', () => {
       multiKey
     }).toMatchSnapshot('translate');
   });
+
+  it('should attempt to place a test identifier around copy', () => {
+    const mockI18next = { store: jest.fn(), t: jest.fn() };
+
+    const basic = translate('lorem.ipsum', { testId: true }, undefined, { i18next: mockI18next, isDebug: false });
+    const basicString = translate('lorem.ipsum', { testId: 'dolor-sit' }, undefined, {
+      i18next: mockI18next,
+      isDebug: false
+    });
+    const emptyContext = translate('lorem.ipsum', { context: EMPTY_CONTEXT, testId: true }, undefined, {
+      i18next: mockI18next,
+      isDebug: false
+    });
+    const emptyContextString = translate('lorem.ipsum', { context: EMPTY_CONTEXT, testId: 'dolor-sit' }, undefined, {
+      i18next: mockI18next,
+      isDebug: false
+    });
+    const emptyPartialContext = translate(
+      'lorem.ipsum',
+      { context: ['hello', EMPTY_CONTEXT], testId: true },
+      undefined,
+      { i18next: mockI18next, isDebug: false }
+    );
+    const emptyPartialContextString = translate(
+      'lorem.ipsum',
+      { context: ['hello', EMPTY_CONTEXT], testId: 'dolor-sit' },
+      undefined,
+      { i18next: mockI18next, isDebug: false }
+    );
+    const stringContextNested = translate(
+      'lorem.ipsum',
+      {
+        context: 'hello_world_lorem_ipsum_dolor_sit',
+        i18next: mockI18next,
+        testId: true
+      },
+      undefined,
+      { i18next: mockI18next, isDebug: false }
+    );
+    const stringContextNestedString = translate(
+      'lorem.ipsum',
+      {
+        context: 'hello_world_lorem_ipsum_dolor_sit',
+        i18next: mockI18next,
+        testId: 'dolor-sit'
+      },
+      undefined,
+      { i18next: mockI18next, isDebug: false }
+    );
+
+    expect({
+      basic,
+      basicString,
+      emptyContext,
+      emptyContextString,
+      emptyPartialContext,
+      emptyPartialContextString,
+      stringContextNested,
+      stringContextNestedString
+    }).toMatchSnapshot('test id');
+  });
 });

--- a/src/components/i18n/i18nHelpers.js
+++ b/src/components/i18n/i18nHelpers.js
@@ -125,9 +125,13 @@ const parseTranslateKey = translateKey => {
  * See, https://react.i18next.com/
  *
  * @param {string|Array} translateKey A key reference, or an array of a primary key with fallback keys.
- * @param {string|object|Array} values A default string if the key can't be found. An object with i18next settings. Or an array of objects (key/value) pairs used to replace string tokes. i.e. "[{ hello: 'world' }]"
+ * @param {string|object|Array} values
+ *     - A default string if the key can't be found.
+ *     - An object with i18next settings. i.e. "{ context: Array|string, testId: boolean|string }"
+ *     - An array of objects (key/value) pairs used to replace string tokens. i.e. "[{ hello: 'world' }]"
  * @param {Array} components An array of HTML/React nodes used to replace string tokens. i.e. "[<span />, <React.Fragment />]"
  * @param {object} settings
+ * @param {*} settings.i18next
  * @param {Function} settings.isDebug
  * @param {Function} settings.noopTranslate
  * @param {Function} settings.parseContext
@@ -139,6 +143,7 @@ const translate = (
   values = null,
   components,
   {
+    i18next: aliasI18next = i18next,
     isDebug = helpers.TEST_MODE,
     noopTranslate: aliasNoopTranslate = noopTranslate,
     parseContext: aliasParseContext = parseContext,
@@ -146,7 +151,8 @@ const translate = (
   } = {}
 ) => {
   const updatedValues = values || {};
-  let updatedTranslateKey = aliasParseTranslateKey(translateKey);
+  const baseUpdatedTranslateKey = aliasParseTranslateKey(translateKey);
+  let updatedTranslateKey = baseUpdatedTranslateKey;
 
   if (updatedValues?.context) {
     const { context: parsedContext, translateKey: parsedAgainTranslateKey } = aliasParseContext(
@@ -163,13 +169,28 @@ const translate = (
 
   if (components) {
     return (
-      (i18next.store && <Trans i18nKey={updatedTranslateKey} values={updatedValues} components={components} />) || (
-        <React.Fragment>t({updatedTranslateKey})</React.Fragment>
-      )
+      (aliasI18next.store && (
+        <Trans i18nKey={updatedTranslateKey} values={updatedValues} components={components} />
+      )) || <React.Fragment>t({updatedTranslateKey})</React.Fragment>
     );
   }
 
-  return (i18next.store && i18next.t(updatedTranslateKey, updatedValues)) || `t([${updatedTranslateKey}])`;
+  if (aliasI18next.store) {
+    if (updatedValues?.testId) {
+      const updatedTestId =
+        (typeof updatedValues?.testId === 'string' && updatedValues?.testId.length > 0 && updatedValues?.testId) ||
+        baseUpdatedTranslateKey;
+      return (
+        <span className="curiosity-translate__test-id" data-test={updatedTestId}>
+          {aliasI18next.t(updatedTranslateKey, updatedValues)}
+        </span>
+      );
+    }
+
+    return aliasI18next.t(updatedTranslateKey, updatedValues);
+  }
+
+  return `t([${updatedTranslateKey}])`;
 };
 
 /**
@@ -177,15 +198,19 @@ const translate = (
  *
  * @param {React.ReactNode} Component
  * @param {object} settings
+ * @param {*} settings.i18next
  * @param {Function} settings.noopTranslate
  * @returns {React.ReactNode}
  */
-const translateComponent = (Component, { noopTranslate: aliasNoopTranslate = noopTranslate } = {}) => {
+const translateComponent = (
+  Component,
+  { i18next: aliasI18next = i18next, noopTranslate: aliasNoopTranslate = noopTranslate } = {}
+) => {
   const withTranslation = ({ ...props }) => (
     <Component
       {...props}
-      t={(i18next.store && translate) || aliasNoopTranslate}
-      i18n={(i18next.store && i18next) || helpers.noop}
+      t={(aliasI18next.store && translate) || aliasNoopTranslate}
+      i18n={(aliasI18next.store && aliasI18next) || helpers.noop}
     />
   );
 


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- refactor(i18nHelpers): sw-922 translate break apart
- feat(i18nHelpers): sw-922 apply testId to copy

### Notes
- exposes a `testId` prop for i18next to allow either the use of the locale string key on a span with a `data-test` attribute wrapped around the immediate copy, or a custom identifier
- this does restructure aspects of our i18next implementation
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->

### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. confirm tests come back clean


## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-922