### PR TITLE
fix(i18nHelpers): sw-922 i18n element wrapping

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -232,6 +232,7 @@ This project makes use of reserved DOM attributes and string identifiers used by
    - To use add the `testId` to your locale string function call use
       - `t('locale.string.id', { testId: true })`. In this example, this would populate `locale.string.id` as the testId.
       - or `t('locale.string.id', { testId: 'custom-id-coordinated-with-QE' })`
+      - or `t('locale.string.id', { testId: <div data-test="custom-element-wrapper-and-id" /> })`
 
 ### Reserved Files
 #### Spandx Config

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -2701,6 +2701,7 @@ Default props.
     * [~splitContext(value, settings)](#i18n.module_i18nHelpers..splitContext) ⇒ <code>string</code> \| <code>Array.&lt;string&gt;</code>
     * [~parseContext(translateKey, context, settings)](#i18n.module_i18nHelpers..parseContext) ⇒ <code>Object</code>
     * [~parseTranslateKey(translateKey)](#i18n.module_i18nHelpers..parseTranslateKey) ⇒ <code>\*</code>
+    * [~setI18nTestElement(params)](#i18n.module_i18nHelpers..setI18nTestElement) ⇒ <code>null</code> \| <code>React.ReactNode</code>
     * [~translate(translateKey, values, components, settings)](#i18n.module_i18nHelpers..translate) ⇒ <code>string</code> \| <code>React.ReactNode</code>
     * [~translateComponent(Component, settings)](#i18n.module_i18nHelpers..translateComponent) ⇒ <code>React.ReactNode</code>
 
@@ -2799,6 +2800,28 @@ Parse a translation key. If an array, filter for defined strings.
     </tr>  </tbody>
 </table>
 
+<a name="i18n.module_i18nHelpers..setI18nTestElement"></a>
+
+### i18nHelpers~setI18nTestElement(params) ⇒ <code>null</code> \| <code>React.ReactNode</code>
+Return a test element wrapper;
+
+**Kind**: inner method of [<code>i18nHelpers</code>](#i18n.module_i18nHelpers)  
+<table>
+  <thead>
+    <tr>
+      <th>Param</th><th>Type</th>
+    </tr>
+  </thead>
+  <tbody>
+<tr>
+    <td>params</td><td><code>object</code></td>
+    </tr><tr>
+    <td>params.defaultTestId</td><td><code>string</code> | <code>Array</code></td>
+    </tr><tr>
+    <td>params.testId</td><td><code>string</code></td>
+    </tr>  </tbody>
+</table>
+
 <a name="i18n.module_i18nHelpers..translate"></a>
 
 ### i18nHelpers~translate(translateKey, values, components, settings) ⇒ <code>string</code> \| <code>React.ReactNode</code>
@@ -2819,7 +2842,7 @@ See, https://react.i18next.com/
     </tr><tr>
     <td>values</td><td><code>string</code> | <code>object</code> | <code>Array</code></td><td><code>null</code></td><td><ul>
 <li>A default string if the key can&#39;t be found.<ul>
-<li>An object with i18next settings. i.e. &quot;{ context: Array|string, testId: boolean|string }&quot;</li>
+<li>An object with i18next settings. i.e. &quot;{ context: Array|string, testId: boolean|string|React.ReactNode }&quot;</li>
 <li>An array of objects (key/value) pairs used to replace string tokens. i.e. &quot;[{ hello: &#39;world&#39; }]&quot;</li>
 </ul>
 </li>

--- a/src/components/i18n/__tests__/__snapshots__/i18nHelpers.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18nHelpers.test.js.snap
@@ -22,35 +22,55 @@ exports[`I18nHelpers should attempt to perform translate with a node: translated
 exports[`I18nHelpers should attempt to place a test identifier around copy: test id 1`] = `
 {
   "basic": <span
-    className="curiosity-translate__test-id"
+    class="curiosity-translate__test-id"
     data-test="lorem.ipsum"
   />,
+  "basicNode": <TestElementNode>
+    <dolor-sit
+      data-test="dolor-sit"
+    />
+  </TestElementNode>,
   "basicString": <span
-    className="curiosity-translate__test-id"
+    class="curiosity-translate__test-id"
     data-test="dolor-sit"
   />,
   "emptyContext": <span
-    className="curiosity-translate__test-id"
+    class="curiosity-translate__test-id"
     data-test="lorem.ipsum"
   />,
+  "emptyContextNode": <TestElementNode>
+    <dolor-sit
+      data-test="dolor-sit"
+    />
+  </TestElementNode>,
   "emptyContextString": <span
-    className="curiosity-translate__test-id"
+    class="curiosity-translate__test-id"
     data-test="dolor-sit"
   />,
   "emptyPartialContext": <span
-    className="curiosity-translate__test-id"
+    class="curiosity-translate__test-id"
     data-test="lorem.ipsum"
   />,
+  "emptyPartialContextNode": <TestElementNode>
+    <dolor-sit
+      data-test="dolor-sit"
+    />
+  </TestElementNode>,
   "emptyPartialContextString": <span
-    className="curiosity-translate__test-id"
+    class="curiosity-translate__test-id"
     data-test="dolor-sit"
   />,
   "stringContextNested": <span
-    className="curiosity-translate__test-id"
+    class="curiosity-translate__test-id"
     data-test="lorem.ipsum"
   />,
+  "stringContextNestedNode": <TestElementNode>
+    <dolor-sit
+      data-test="dolor-sit"
+    />
+  </TestElementNode>,
   "stringContextNestedString": <span
-    className="curiosity-translate__test-id"
+    class="curiosity-translate__test-id"
     data-test="dolor-sit"
   />,
 }

--- a/src/components/i18n/__tests__/i18nHelpers.test.js
+++ b/src/components/i18n/__tests__/i18nHelpers.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { mount } from 'enzyme';
 import PropTypes from 'prop-types';
 import { i18nHelpers, EMPTY_CONTEXT, translate, translateComponent } from '../i18nHelpers';
 
@@ -60,61 +61,112 @@ describe('I18nHelpers', () => {
   it('should attempt to place a test identifier around copy', () => {
     const mockI18next = { store: jest.fn(), t: jest.fn() };
 
-    const basic = translate('lorem.ipsum', { testId: true }, undefined, { i18next: mockI18next, isDebug: false });
-    const basicString = translate('lorem.ipsum', { testId: 'dolor-sit' }, undefined, {
-      i18next: mockI18next,
-      isDebug: false
-    });
-    const emptyContext = translate('lorem.ipsum', { context: EMPTY_CONTEXT, testId: true }, undefined, {
-      i18next: mockI18next,
-      isDebug: false
-    });
-    const emptyContextString = translate('lorem.ipsum', { context: EMPTY_CONTEXT, testId: 'dolor-sit' }, undefined, {
-      i18next: mockI18next,
-      isDebug: false
-    });
-    const emptyPartialContext = translate(
-      'lorem.ipsum',
-      { context: ['hello', EMPTY_CONTEXT], testId: true },
-      undefined,
-      { i18next: mockI18next, isDebug: false }
+    const basic = mount(
+      translate('lorem.ipsum', { testId: true }, undefined, { i18next: mockI18next, isDebug: false })
     );
-    const emptyPartialContextString = translate(
-      'lorem.ipsum',
-      { context: ['hello', EMPTY_CONTEXT], testId: 'dolor-sit' },
-      undefined,
-      { i18next: mockI18next, isDebug: false }
-    );
-    const stringContextNested = translate(
-      'lorem.ipsum',
-      {
-        context: 'hello_world_lorem_ipsum_dolor_sit',
+    const basicString = mount(
+      translate('lorem.ipsum', { testId: 'dolor-sit' }, undefined, {
         i18next: mockI18next,
-        testId: true
-      },
-      undefined,
-      { i18next: mockI18next, isDebug: false }
+        isDebug: false
+      })
     );
-    const stringContextNestedString = translate(
-      'lorem.ipsum',
-      {
-        context: 'hello_world_lorem_ipsum_dolor_sit',
+    const basicNode = mount(
+      translate('lorem.ipsum', { testId: <dolor-sit data-test="dolor-sit" /> }, undefined, {
         i18next: mockI18next,
-        testId: 'dolor-sit'
-      },
-      undefined,
-      { i18next: mockI18next, isDebug: false }
+        isDebug: false
+      })
+    );
+    const emptyContext = mount(
+      translate('lorem.ipsum', { context: EMPTY_CONTEXT, testId: true }, undefined, {
+        i18next: mockI18next,
+        isDebug: false
+      })
+    );
+    const emptyContextString = mount(
+      translate('lorem.ipsum', { context: EMPTY_CONTEXT, testId: 'dolor-sit' }, undefined, {
+        i18next: mockI18next,
+        isDebug: false
+      })
+    );
+    const emptyContextNode = mount(
+      translate('lorem.ipsum', { context: EMPTY_CONTEXT, testId: <dolor-sit data-test="dolor-sit" /> }, undefined, {
+        i18next: mockI18next,
+        isDebug: false
+      })
+    );
+    const emptyPartialContext = mount(
+      translate('lorem.ipsum', { context: ['hello', EMPTY_CONTEXT], testId: true }, undefined, {
+        i18next: mockI18next,
+        isDebug: false
+      })
+    );
+    const emptyPartialContextString = mount(
+      translate('lorem.ipsum', { context: ['hello', EMPTY_CONTEXT], testId: 'dolor-sit' }, undefined, {
+        i18next: mockI18next,
+        isDebug: false
+      })
+    );
+    const emptyPartialContextNode = mount(
+      translate(
+        'lorem.ipsum',
+        { context: ['hello', EMPTY_CONTEXT], testId: <dolor-sit data-test="dolor-sit" /> },
+        undefined,
+        {
+          i18next: mockI18next,
+          isDebug: false
+        }
+      )
+    );
+    const stringContextNested = mount(
+      translate(
+        'lorem.ipsum',
+        {
+          context: 'hello_world_lorem_ipsum_dolor_sit',
+          i18next: mockI18next,
+          testId: true
+        },
+        undefined,
+        { i18next: mockI18next, isDebug: false }
+      )
+    );
+    const stringContextNestedString = mount(
+      translate(
+        'lorem.ipsum',
+        {
+          context: 'hello_world_lorem_ipsum_dolor_sit',
+          i18next: mockI18next,
+          testId: 'dolor-sit'
+        },
+        undefined,
+        { i18next: mockI18next, isDebug: false }
+      )
+    );
+    const stringContextNestedNode = mount(
+      translate(
+        'lorem.ipsum',
+        {
+          context: 'hello_world_lorem_ipsum_dolor_sit',
+          i18next: mockI18next,
+          testId: <dolor-sit data-test="dolor-sit" />
+        },
+        undefined,
+        { i18next: mockI18next, isDebug: false }
+      )
     );
 
     expect({
-      basic,
-      basicString,
-      emptyContext,
-      emptyContextString,
-      emptyPartialContext,
-      emptyPartialContextString,
-      stringContextNested,
-      stringContextNestedString
+      basic: basic.render(),
+      basicString: basicString.render(),
+      basicNode,
+      emptyContext: emptyContext.render(),
+      emptyContextString: emptyContextString.render(),
+      emptyContextNode,
+      emptyPartialContext: emptyPartialContext.render(),
+      emptyPartialContextString: emptyPartialContextString.render(),
+      emptyPartialContextNode,
+      stringContextNested: stringContextNested.render(),
+      stringContextNestedString: stringContextNestedString.render(),
+      stringContextNestedNode
     }).toMatchSnapshot('test id');
   });
 });


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(i18nHelpers): sw-922 i18n element wrapping

### Notes
- adjust to wrap component elements, not just strings
- adds the ability to use a custom element ie. `testId: <div className="custom-class" data-test="custom-id" />`
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->

### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`

1. confirm tests come back clean

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-922 #1079 