### PR TITLE
fix(routerContext): sw-1089 page display titles

### DIFF
--- a/src/components/router/__tests__/__snapshots__/routerContext.test.js.snap
+++ b/src/components/router/__tests__/__snapshots__/routerContext.test.js.snap
@@ -40,6 +40,14 @@ exports[`RouterContext should apply a hook for useNavigate: navigation push 1`] 
 ]
 `;
 
+exports[`RouterContext should apply a hook for useRouteDetail: document title 1`] = `
+[
+  [
+    "t(curiosity-view.title, {"appName":"Subscriptions","context":"RHEL"}) - Subscriptions",
+  ],
+]
+`;
+
 exports[`RouterContext should apply a hook for useRouteDetail: route details, closest 1`] = `
 {
   "detailProps": [

--- a/src/components/router/__tests__/routerContext.test.js
+++ b/src/components/router/__tests__/routerContext.test.js
@@ -48,7 +48,14 @@ describe('RouterContext', () => {
   });
 
   it('should apply a hook for useRouteDetail', async () => {
-    const { result: exactMatch } = await mountHook(() => useRouteDetail({ useSelector: () => ['rhel'] }));
+    const mockUpdateDocumentTitle = jest.fn();
+    const { result: exactMatch } = await mountHook(() =>
+      useRouteDetail({
+        useChrome: () => ({ updateDocumentTitle: mockUpdateDocumentTitle }),
+        useSelector: () => ['rhel']
+      })
+    );
+    expect(mockUpdateDocumentTitle.mock.calls).toMatchSnapshot('document title');
     expect({
       detailProps: Object.keys(exactMatch),
       isClosest: exactMatch.isClosest,

--- a/src/components/router/routerContext.js
+++ b/src/components/router/routerContext.js
@@ -114,10 +114,10 @@ const useRouteDetail = ({
 
       // Set document title
       updateDocumentTitle(
-        `${helpers.UI_DISPLAY_NAME}: ${t(`curiosity-view.title`, {
+        `${t(`curiosity-view.title`, {
           appName: helpers.UI_DISPLAY_NAME,
           context: firstMatch?.productGroup
-        })}`
+        })} - ${helpers.UI_DISPLAY_NAME}`
       );
 
       // Set route detail


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(routerContext): sw-1089 page display titles

### Notes
- when we updated routing we shifted the title format, this moves it back
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm that page titles follow one of the recommend formats
   - _*note we had been leveraging "the bundle" (of sorts it currently registers out as `console.redhat.com`) applied through the chrome `updateDocumentTitle` hook... we left that in place for now with the understanding we may have to apply it "manually" in a subsequent update_ **_Subs is in a unique position compared to other apps... it spans multiple bundles and has the ability to be loaded anywhere. Putting the onus on any app to determine where it's being loaded when/while the architecture seems to be under a regular cadence for shifting appears futile_**

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-1089