### PR TITLE
feat(routerContext): sw-1089 enhance page titles

### DIFF
--- a/config/jest.setupTests.js
+++ b/config/jest.setupTests.js
@@ -99,6 +99,7 @@ global.window.insights = {
           })
         )
     },
+    getBundleData: Function.prototype,
     getUserPermissions: () => [],
     hideGlobalFilter: Function.prototype,
     identifyApp: Function.prototype,

--- a/src/components/router/__tests__/__snapshots__/routerContext.test.js.snap
+++ b/src/components/router/__tests__/__snapshots__/routerContext.test.js.snap
@@ -44,6 +44,7 @@ exports[`RouterContext should apply a hook for useRouteDetail: document title 1`
 [
   [
     "t(curiosity-view.title, {"appName":"Subscriptions","context":"RHEL"}) - Subscriptions",
+    true,
   ],
 ]
 `;

--- a/src/components/router/routerContext.js
+++ b/src/components/router/routerContext.js
@@ -102,7 +102,8 @@ const useRouteDetail = ({
   useChrome: useAliasChrome = useChrome,
   useSelector: useAliasSelector = storeHooks.reactRedux.useSelectors
 } = {}) => {
-  const { updateDocumentTitle = helpers.noop } = useAliasChrome();
+  const { getBundleData = helpers.noop, updateDocumentTitle = helpers.noop } = useAliasChrome();
+  const bundleData = getBundleData();
   const [productPath] = useAliasSelector([({ view }) => view?.product?.config]);
   const [detail, setDetail] = useState({});
 
@@ -112,12 +113,13 @@ const useRouteDetail = ({
         pathName: productPath
       });
 
-      // Set document title
+      // Set document title, remove pre-baked suffix
       updateDocumentTitle(
         `${t(`curiosity-view.title`, {
           appName: helpers.UI_DISPLAY_NAME,
           context: firstMatch?.productGroup
-        })} - ${helpers.UI_DISPLAY_NAME}`
+        })} - ${helpers.UI_DISPLAY_NAME}${(bundleData?.bundleTitle && ` | ${bundleData?.bundleTitle}`) || ''}`,
+        true
       );
 
       // Set route detail
@@ -132,7 +134,7 @@ const useRouteDetail = ({
         productPath
       });
     }
-  }, [detail?._passed, productPath, t, updateDocumentTitle]);
+  }, [bundleData?.bundleTitle, detail?._passed, productPath, t, updateDocumentTitle]);
 
   return detail;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ window.insights = {
           });
         })
     },
+    getBundleData: () => ({ bundleId: 'insights', bundleTitle: 'Red Hat Insights' }),
     getUserPermissions: () => [],
     hideGlobalFilter: Function.prototype,
     identifyApp: Function.prototype,


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- feat(routerContext): sw-1089 enhance page titles

### Notes
- exposes the new getBundleData func and related copy for doc title
- fails quietly if unavailable 
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm product display view document titles in Subs display as per requirements

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-1089
#1089 
https://github.com/RedHatInsights/insights-chrome/pull/2406