### PR TITLE
chore(prod): routing, onNavigate

### DIFF
--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -36,8 +36,12 @@ releaseProd()
 {
   local UPDATED_UI_VERSION="$(node -p 'require(`./package.json`).version')";
 
-  if [[ "${TRAVIS_COMMIT_MESSAGE}" = *"chore(release):"* ]]; then
-    if [[ "${TRAVIS_BRANCH}" = "v${UPDATED_UI_VERSION}" || "${TRAVIS_BRANCH}" = "prod" || "${TRAVIS_BRANCH}" = "prod-stable" ]] && [[ $TRAVIS_BUILD_STAGE_NAME != *"Beta"* ]]; then
+  if [[ "${TRAVIS_COMMIT_MESSAGE}" = *"chore(prod):"* ]]; then
+    if [[ "${TRAVIS_BRANCH}" = "main" ]] && [[ $TRAVIS_BUILD_STAGE_NAME != *"Beta"* ]]; then
+      release "prod-stable"
+    fi
+  elif [[ "${TRAVIS_COMMIT_MESSAGE}" = *"chore(release):"* ]]; then
+    if [[ "${TRAVIS_BRANCH}" = "v${UPDATED_UI_VERSION}" || "${TRAVIS_BRANCH}" = "main" ]] && [[ $TRAVIS_BUILD_STAGE_NAME != *"Beta"* ]]; then
       release "ci-stable"
       release "qa-stable"
       release "prod-beta"


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- chore(prod): routing, onNavigate

### Notes
- rollback of GUI patch v2.10.1 with release bypass
   - If env testing comes back negative
      - this commit along with the `fix(platformServices): sw-625 remove onNavigate ([#1092](https://github.com/RedHatInsights/curiosity-frontend/issues/1092))` will be removed
   - if env testing comes back positive
      - this commit will be removed and a subsequent release commit be pushed and synced to the lower envs 
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-625
rollback GUI v2.10.1 patch