### PR TITLE
fix(config): sw-1136 missing rhosak path alias

### DIFF
--- a/src/config/product.rhosak.js
+++ b/src/config/product.rhosak.js
@@ -40,11 +40,11 @@ const productId = RHSM_API_PATH_PRODUCT_TYPES.RHOSAK;
 const productLabel = RHSM_API_PATH_PRODUCT_TYPES.RHOSAK;
 
 const config = {
-  aliases: ['streams', 'apache', 'kafka'],
+  aliases: ['application-services', productGroup.toLowerCase(), 'apache', 'kafka'],
   productGroup,
   productId,
   productLabel,
-  productPath: productGroup.toLowerCase(),
+  productPath: 'streams',
   productDisplay: DISPLAY_TYPES.HOURLY,
   viewId: `view${productGroup}`,
   query: {

--- a/tests/__snapshots__/dist.test.js.snap
+++ b/tests/__snapshots__/dist.test.js.snap
@@ -207,15 +207,22 @@ exports[`Build distribution should have a predictable ephemeral navigation based
     ],
   },
   {
-    "coverage": "FALSE",
-    "path": "/rhosak",
+    "coverage": "TRUE",
+    "path": "/streams",
     "productId": [
       "rhosak",
     ],
   },
   {
-    "coverage": "TRUE",
-    "path": "/streams",
+    "coverage": "FALSE",
+    "path": "/application-services",
+    "productId": [
+      "rhosak",
+    ],
+  },
+  {
+    "coverage": "FALSE",
+    "path": "/rhosak",
     "productId": [
       "rhosak",
     ],


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(config): sw-1136 missing rhosak path alias

### Notes
- missing application-services path alias
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->

### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. confirm tests come back clean


## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-1136