### PR TITLE
3 of 3, chore(build): nodejs 16 to 18

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node.js ${{ matrix.node-version }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ notifications:
     - rooms:
       - secure: cB1tOG48V5iia0O2dJ9+1gusBSCaohu5TR8PeWbqug/Yho+ZCQ3rp7Tfd7fRyYsf9ztWdu6G+VrHwOboR08Aef7cttZ743j/aXwo5m50Q9Ne3fkNzEUjL8IGeM4MtlRtwruD54RQmPzjmHjEapfx0dX2AHkB/8Zrnjs36YzPST1kT/YYrub9Kv5wUXB0TlzWmrRGj+pPGqBmJVksxQFxvbvafRcKI3kj91maJQhBHQe+19GboJbFOnwzPTPAL7Lf7j70ZmbPlQVG3G3VjN/QUALqaiwjlgH0owLHjBbDrMt8cpPoTq8Uw6ANBWYzENBMzHeiBwz0jqTY/BBP06WCxJSJCgOgd90L93/LAbJYiTyvpfAt8dOdWk7RhKy0L3kIalj5Mff8/3zDyLDOvd9Xtn7topHJv/5SBV6ZZVUvEJTxgEQq9337YEOka2omPvwt7UfHNcT/PH4flV70cy/OdR6J4x1UIKIUgX0iWYMZUj7QZqUhLybXv5BRS0vQTg4V8C7uvQ4aE8hzkv+pjXZ5aL5POtJhrgNPiO9iIHXtV/EUoGrT9iibijyQbWPusloJBwmPWkZ2j3UbaCY5bPTgnHnaPllnE3WKuTwxQA4bIL1Ma2C3yv2RSgfVvwM+pekeNsaVmpOD5xlcNYPPuW5bLE/jqhLmeKJaKQWujoC0glU=
 node_js:
-  - 16
+  - 18
 cache: yarn
 jobs:
   include:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A web user interface for subscription reporting, based on [Patternfly](https://w
 
 ## Requirements
 Before developing for Curiosity Frontend, the basic requirements:
- * Your system needs to be running [NodeJS version 16+ and NPM](https://nodejs.org/)
+ * Your system needs to be running [NodeJS version 18+ and NPM](https://nodejs.org/)
  * [Docker](https://docs.docker.com/engine/install/)
    * Alternatively, you can try [Podman](https://github.com/containers/podman).
  * And [Yarn 1.22+](https://yarnpkg.com) for dependency and script management.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/RedHatInsights/curiosity-frontend/issues"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "insights": {
     "appname": "subscriptions"


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- chore(build): nodejs 16 to 18

### Notes
- current lts
- potential check for next lts release, nodejs 20
   - this aspect is blocked by #1103 due to an eslint jsdoc NPM dep update 
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->

### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
1. confirm tests come back clean

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing
blocked by #1103 