### PR TITLE
chore(build): sw-538 rhacs ephemeral routing

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -48,6 +48,10 @@ objects:
               title: "OpenShift Data Science"
               href: "/application-services/subscriptions/rhods"
               product: "Subscription Watch"
+            - appId: "subscriptions"
+              title: "Advanced Cluster Security"
+              href: "/application-services/subscriptions/rhacs"
+              product: "Subscription Watch"
       module:
         # this should match chrome/fed-modules.json in cloud-services-config
         manifestLocation: "/apps/subscriptions/fed-mods.json"

--- a/tests/__snapshots__/dist.test.js.snap
+++ b/tests/__snapshots__/dist.test.js.snap
@@ -88,7 +88,7 @@ exports[`Build distribution should have a predictable ephemeral navigation based
     ],
   },
   {
-    "coverage": "FALSE",
+    "coverage": "TRUE",
     "path": "/rhacs",
     "productId": [
       "rhacs",


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- chore(build): sw-538 rhacs ephemeral routing

### Notes
- clean up for RHACS activation, reflect in ephemeral routing config
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->

### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. confirm tests come back clean


## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-538
dup sw-777