### PR TITLE
build(prod,stage): sw-917 dotenv config for surface urls

### DIFF
--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -11,7 +11,7 @@ const {
 
 const { config: webpackConfig, plugins } = config({
   rootFolder: _BUILD_RELATIVE_DIRNAME,
-  deployment: (/beta/.test(BETA_PREFIX) && 'beta/apps') || 'apps',
+  deployment: (/beta|preview/.test(BETA_PREFIX) && 'beta/apps') || 'apps',
   replacePlugin: setReplacePlugin()
 });
 

--- a/scripts/pre.sh
+++ b/scripts/pre.sh
@@ -11,7 +11,7 @@ deployPaths()
   DEPLOY_PATH_PREFIX=""
 
   if [[ $DEPLOY_BUILD_STAGE == *"Beta"* ]]; then
-    DEPLOY_PATH_PREFIX=/beta
+    DEPLOY_PATH_PREFIX=/preview
   fi
 
   echo UI_DEPLOY_PATH_PREFIX="$DEPLOY_PATH_PREFIX" >> ./.env.production.local


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- build(prod,stage): sw-917 dotenv config for surface urls

### Notes
- The update on prod from `beta` to `preview` on 20230426 highlighted a missing "hardcoded-like" path for multiple urls. Curiosity "shares" the `beta` prefix through dotenv files making `beta`, and now `preview` available during compile for both the build and GUI
   - Curiosity uses a "path prefix" to load remote locale strings. This update moves and applies "preview" to that path instead of beta while still deploying to "beta/apps"
   - Curiosity uses a link back to inventory displays, this is also affected

<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->

### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. confirm tests come back clean

### Check the preview redirect, and beta env
1. navigate towards preview staging `subscriptions`
   - open the dev console and confirm `en-US.json` reflects the correct path
   - confirm the inventory links point at "preview"
1. navigate towards beta staging `subscriptions`
   - open the dev console and confirm `en-US.json` reflects the correct path
   - confirm the inventory links point at "preview" (we're doing this now to avoid updates later since the intention is to make `preview` the primary path)



## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-917