### PR TITLE
fix(config): sw-1294 rhacs, rhods inventory links

### DIFF
--- a/src/config/__tests__/__snapshots__/product.rhacs.test.js.snap
+++ b/src/config/__tests__/__snapshots__/product.rhacs.test.js.snap
@@ -65,7 +65,7 @@ exports[`Product RHACS config should apply an inventory configuration: filtered,
     {
       "title": <Button
         component="a"
-        href="/insights/inventory/XXXX-XXXX-XXXXX-XXXXX/"
+        href="/application-services/acs/instances/instance/XXXX-XXXX-XXXXX-XXXXX"
         isInline={true}
         variant="link"
       >

--- a/src/config/__tests__/__snapshots__/product.rhods.test.js.snap
+++ b/src/config/__tests__/__snapshots__/product.rhods.test.js.snap
@@ -63,14 +63,7 @@ exports[`Product RHODS config should apply an inventory configuration: filtered,
 {
   "cells": [
     {
-      "title": <Button
-        component="a"
-        href="/insights/inventory/XXXX-XXXX-XXXXX-XXXXX/"
-        isInline={true}
-        variant="link"
-      >
-        lorem ipsum
-      </Button>,
+      "title": "lorem ipsum",
     },
     {
       "title": "t(curiosity-inventory.label_billing_provider, {"context":"none"})",

--- a/src/config/product.rhacs.js
+++ b/src/config/product.rhacs.js
@@ -167,7 +167,7 @@ const config = {
               isInline
               component="a"
               variant="link"
-              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${instanceId.value}/`}
+              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/application-services/acs/instances/instance/${instanceId.value}`}
             >
               {displayName.value || instanceId.value}
             </Button>

--- a/src/config/product.rhods.js
+++ b/src/config/product.rhods.js
@@ -144,11 +144,9 @@ const config = {
   initialInventoryFilters: [
     {
       id: INVENTORY_TYPES.DISPLAY_NAME,
-      cell: (
-        { [INVENTORY_TYPES.DISPLAY_NAME]: displayName = {}, [INVENTORY_TYPES.INSTANCE_ID]: instanceId = {} },
-        session
-      ) => {
-        const { inventory: authorized } = session?.authorized || {};
+      cell: ({ [INVENTORY_TYPES.DISPLAY_NAME]: displayName = {}, [INVENTORY_TYPES.INSTANCE_ID]: instanceId = {} }) => {
+        // FixMe: Disabled, see SWATCH-1209 for resolution
+        const { inventory: authorized = false } = {};
 
         if (!instanceId.value) {
           return displayName.value;


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(config): sw-1294 rhacs, rhods inventory links

### Notes
- rhacs inventory links
- rhods disabled inventory links with note
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm the RHACS inventory links navigate towards `/application-services/acs/instances/instance/`
1. confirm the RHODS inventory links are no longer available

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-1294