### PR TITLE
fix(config): sw-1335 openshift on-demand inventory links

### DIFF
--- a/src/config/__tests__/__snapshots__/product.openshiftDedicated.test.js.snap
+++ b/src/config/__tests__/__snapshots__/product.openshiftDedicated.test.js.snap
@@ -139,14 +139,7 @@ exports[`Product OpenShift Dedicated config should apply an inventory configurat
   "cells": [
     {
       "title": <React.Fragment>
-        <Button
-          component="a"
-          href="/insights/inventory/XXXX-XXXX-XXXXX-XXXXX/"
-          isInline={true}
-          variant="link"
-        >
-          lorem ipsum
-        </Button>
+        lorem ipsum
          
         
       </React.Fragment>,

--- a/src/config/__tests__/__snapshots__/product.openshiftMetrics.test.js.snap
+++ b/src/config/__tests__/__snapshots__/product.openshiftMetrics.test.js.snap
@@ -113,14 +113,7 @@ exports[`Product OpenShift Metrics config should apply an inventory configuratio
   "cells": [
     {
       "title": <React.Fragment>
-        <Button
-          component="a"
-          href="/insights/inventory/XXXX-XXXX-XXXXX-XXXXX/"
-          isInline={true}
-          variant="link"
-        >
-          lorem ipsum
-        </Button>
+        lorem ipsum
          
         
       </React.Fragment>,

--- a/src/config/product.openshiftDedicated.js
+++ b/src/config/product.openshiftDedicated.js
@@ -154,15 +154,13 @@ const config = {
   initialInventoryFilters: [
     {
       id: INVENTORY_TYPES.DISPLAY_NAME,
-      cell: (
-        {
-          [INVENTORY_TYPES.DISPLAY_NAME]: displayName = {},
-          [INVENTORY_TYPES.INSTANCE_ID]: instanceId = {},
-          [INVENTORY_TYPES.NUMBER_OF_GUESTS]: numberOfGuests = {}
-        } = {},
-        session
-      ) => {
-        const { inventory: authorized } = session?.authorized || {};
+      cell: ({
+        [INVENTORY_TYPES.DISPLAY_NAME]: displayName = {},
+        [INVENTORY_TYPES.INSTANCE_ID]: instanceId = {},
+        [INVENTORY_TYPES.NUMBER_OF_GUESTS]: numberOfGuests = {}
+      } = {}) => {
+        // FixMe: Disabled, see SWATCH-1209 for resolution
+        const { inventory: authorized = false } = {};
 
         if (!instanceId.value) {
           return displayName.value;

--- a/src/config/product.openshiftMetrics.js
+++ b/src/config/product.openshiftMetrics.js
@@ -145,15 +145,13 @@ const config = {
   initialInventoryFilters: [
     {
       id: INVENTORY_TYPES.DISPLAY_NAME,
-      cell: (
-        {
-          [INVENTORY_TYPES.DISPLAY_NAME]: displayName = {},
-          [INVENTORY_TYPES.INSTANCE_ID]: instanceId = {},
-          [INVENTORY_TYPES.NUMBER_OF_GUESTS]: numberOfGuests = {}
-        } = {},
-        session
-      ) => {
-        const { inventory: authorized } = session?.authorized || {};
+      cell: ({
+        [INVENTORY_TYPES.DISPLAY_NAME]: displayName = {},
+        [INVENTORY_TYPES.INSTANCE_ID]: instanceId = {},
+        [INVENTORY_TYPES.NUMBER_OF_GUESTS]: numberOfGuests = {}
+      } = {}) => {
+        // FixMe: Disabled, see SWATCH-1209 for resolution
+        const { inventory: authorized = false } = {};
 
         if (!instanceId.value) {
           return displayName.value;


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(config): sw-1335 openshift on-demand inventory links

### Notes
- disables all on-demand inventory links, see sw-1209 for final resolution
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. navigate to `/subscriptions/openshift` and confirm
   - OpenShift Dedicated variant inventory links no longer activate/display
   - OpenShift metrics variant inventory links no longer activate/display

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-1335
related sw-1209 sw-1294 #1129