### PR TITLE
refactor(config): sw-1215 reduce metric card mantissa

### DIFF
--- a/src/config/product.openshiftDedicated.js
+++ b/src/config/product.openshiftDedicated.js
@@ -96,7 +96,7 @@ const config = {
                 .numberDisplay(dataSets?.[0]?.display?.dailyValue)
                 ?.format({
                   average: true,
-                  mantissa: 5,
+                  mantissa: 1,
                   trimMantissa: true,
                   lowPrecision: false
                 })
@@ -128,7 +128,7 @@ const config = {
                 .numberDisplay(dataSets?.[0]?.display?.monthlyValue)
                 ?.format({
                   average: true,
-                  mantissa: 5,
+                  mantissa: 1,
                   trimMantissa: true,
                   lowPrecision: false
                 })

--- a/src/config/product.openshiftDedicated.js
+++ b/src/config/product.openshiftDedicated.js
@@ -96,7 +96,7 @@ const config = {
                 .numberDisplay(dataSets?.[0]?.display?.dailyValue)
                 ?.format({
                   average: true,
-                  mantissa: 1,
+                  mantissa: 2,
                   trimMantissa: true,
                   lowPrecision: false
                 })
@@ -128,7 +128,7 @@ const config = {
                 .numberDisplay(dataSets?.[0]?.display?.monthlyValue)
                 ?.format({
                   average: true,
-                  mantissa: 1,
+                  mantissa: 2,
                   trimMantissa: true,
                   lowPrecision: false
                 })

--- a/src/config/product.openshiftMetrics.js
+++ b/src/config/product.openshiftMetrics.js
@@ -87,7 +87,7 @@ const config = {
                 .numberDisplay(dataSets?.[0]?.display?.dailyValue)
                 ?.format({
                   average: true,
-                  mantissa: 1,
+                  mantissa: 2,
                   trimMantissa: true,
                   lowPrecision: false
                 })
@@ -119,7 +119,7 @@ const config = {
                 .numberDisplay(dataSets?.[0]?.display?.monthlyValue)
                 ?.format({
                   average: true,
-                  mantissa: 1,
+                  mantissa: 2,
                   trimMantissa: true,
                   lowPrecision: false
                 })

--- a/src/config/product.openshiftMetrics.js
+++ b/src/config/product.openshiftMetrics.js
@@ -87,7 +87,7 @@ const config = {
                 .numberDisplay(dataSets?.[0]?.display?.dailyValue)
                 ?.format({
                   average: true,
-                  mantissa: 5,
+                  mantissa: 1,
                   trimMantissa: true,
                   lowPrecision: false
                 })
@@ -119,7 +119,7 @@ const config = {
                 .numberDisplay(dataSets?.[0]?.display?.monthlyValue)
                 ?.format({
                   average: true,
-                  mantissa: 5,
+                  mantissa: 1,
                   trimMantissa: true,
                   lowPrecision: false
                 })

--- a/src/config/product.rhacs.js
+++ b/src/config/product.rhacs.js
@@ -91,7 +91,7 @@ const config = {
                 .numberDisplay(dataSets?.[0]?.display?.dailyValue)
                 ?.format({
                   average: true,
-                  mantissa: 5,
+                  mantissa: 1,
                   trimMantissa: true,
                   lowPrecision: false
                 })
@@ -123,7 +123,7 @@ const config = {
                 .numberDisplay(dataSets?.[0]?.display?.monthlyValue)
                 ?.format({
                   average: true,
-                  mantissa: 5,
+                  mantissa: 1,
                   trimMantissa: true,
                   lowPrecision: false
                 })

--- a/src/config/product.rhacs.js
+++ b/src/config/product.rhacs.js
@@ -91,7 +91,7 @@ const config = {
                 .numberDisplay(dataSets?.[0]?.display?.dailyValue)
                 ?.format({
                   average: true,
-                  mantissa: 1,
+                  mantissa: 2,
                   trimMantissa: true,
                   lowPrecision: false
                 })
@@ -123,7 +123,7 @@ const config = {
                 .numberDisplay(dataSets?.[0]?.display?.monthlyValue)
                 ?.format({
                   average: true,
-                  mantissa: 1,
+                  mantissa: 2,
                   trimMantissa: true,
                   lowPrecision: false
                 })

--- a/src/config/product.rhods.js
+++ b/src/config/product.rhods.js
@@ -86,7 +86,7 @@ const config = {
                 .numberDisplay(dataSets?.[0]?.display?.dailyValue)
                 ?.format({
                   average: true,
-                  mantissa: 5,
+                  mantissa: 1,
                   trimMantissa: true,
                   lowPrecision: false
                 })
@@ -118,7 +118,7 @@ const config = {
                 .numberDisplay(dataSets?.[0]?.display?.monthlyValue)
                 ?.format({
                   average: true,
-                  mantissa: 5,
+                  mantissa: 1,
                   trimMantissa: true,
                   lowPrecision: false
                 })

--- a/src/config/product.rhods.js
+++ b/src/config/product.rhods.js
@@ -86,7 +86,7 @@ const config = {
                 .numberDisplay(dataSets?.[0]?.display?.dailyValue)
                 ?.format({
                   average: true,
-                  mantissa: 1,
+                  mantissa: 2,
                   trimMantissa: true,
                   lowPrecision: false
                 })
@@ -118,7 +118,7 @@ const config = {
                 .numberDisplay(dataSets?.[0]?.display?.monthlyValue)
                 ?.format({
                   average: true,
-                  mantissa: 1,
+                  mantissa: 2,
                   trimMantissa: true,
                   lowPrecision: false
                 })

--- a/src/config/product.rhosak.js
+++ b/src/config/product.rhosak.js
@@ -113,7 +113,7 @@ const config = {
                 .numberDisplay(dataSets?.[0]?.display?.dailyValue)
                 ?.format({
                   average: true,
-                  mantissa: 1,
+                  mantissa: 2,
                   trimMantissa: true,
                   lowPrecision: false
                 })
@@ -145,7 +145,7 @@ const config = {
                 .numberDisplay(dataSets?.[0]?.display?.monthlyValue)
                 ?.format({
                   average: true,
-                  mantissa: 1,
+                  mantissa: 2,
                   trimMantissa: true,
                   lowPrecision: false
                 })

--- a/src/config/product.rhosak.js
+++ b/src/config/product.rhosak.js
@@ -113,7 +113,7 @@ const config = {
                 .numberDisplay(dataSets?.[0]?.display?.dailyValue)
                 ?.format({
                   average: true,
-                  mantissa: 5,
+                  mantissa: 1,
                   trimMantissa: true,
                   lowPrecision: false
                 })
@@ -145,7 +145,7 @@ const config = {
                 .numberDisplay(dataSets?.[0]?.display?.monthlyValue)
                 ?.format({
                   average: true,
-                  mantissa: 5,
+                  mantissa: 1,
                   trimMantissa: true,
                   lowPrecision: false
                 })

--- a/src/config/product.rosa.js
+++ b/src/config/product.rosa.js
@@ -131,7 +131,7 @@ const config = {
                 .numberDisplay(dataSets?.[0]?.display?.dailyValue)
                 ?.format({
                   average: true,
-                  mantissa: 5,
+                  mantissa: 1,
                   trimMantissa: true,
                   lowPrecision: false
                 })
@@ -163,7 +163,7 @@ const config = {
                 .numberDisplay(dataSets?.[0]?.display?.remainingCapacity)
                 ?.format({
                   average: true,
-                  mantissa: 5,
+                  mantissa: 1,
                   trimMantissa: true,
                   lowPrecision: false
                 })

--- a/src/config/product.rosa.js
+++ b/src/config/product.rosa.js
@@ -131,7 +131,7 @@ const config = {
                 .numberDisplay(dataSets?.[0]?.display?.dailyValue)
                 ?.format({
                   average: true,
-                  mantissa: 1,
+                  mantissa: 2,
                   trimMantissa: true,
                   lowPrecision: false
                 })
@@ -163,7 +163,7 @@ const config = {
                 .numberDisplay(dataSets?.[0]?.display?.remainingCapacity)
                 ?.format({
                   average: true,
-                  mantissa: 1,
+                  mantissa: 2,
                   trimMantissa: true,
                   lowPrecision: false
                 })


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- refactor(config): sw-1215 reduce metric card mantissa

### Notes
- reduces the potential decimals displayed if a float is passed to the GUI. 
   - it is understood that the API should now be passing an int with a math ceil on it 
   - this GUI update does NOT prevent the display of a float, but instead reduces the number of potential decimal places.  
      - this update helps retain the potential to display values such as ~`1.2K` or `1.5M` etc~ `1.23K` or `1.52M` etc
      - we can perform a subsequent fix for `Number.parseIn(someValue, 10)` if the API fails to pass the correct values
- this affects the following product configurations
   - OpenShift Dedicated
   - OpenShift metrics
   - RHACS
   - RHODS
   - formerly RHOSAK
   - ROSA
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. once the API passes integers for these values
   - confirm the GUI responds by passing the expected integer value


### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. confirm the build checks come back clean


## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-1215