### PR TITLE
refactor(config): sw-938 activate rosa subscriptions

### DIFF
--- a/src/config/__tests__/__snapshots__/product.rosa.test.js.snap
+++ b/src/config/__tests__/__snapshots__/product.rosa.test.js.snap
@@ -471,6 +471,118 @@ exports[`Product ROSA config should apply graph configuration: settings 1`] = `
 }
 `;
 
+exports[`Product ROSA config should apply subscriptions inventory configuration: filtered 1`] = `
+{
+  "cells": [
+    {
+      "title": "lorem",
+    },
+    {
+      "title": "",
+    },
+    {
+      "title": "2022-01-01",
+    },
+  ],
+  "columnHeaders": [
+    {
+      "title": "t(curiosity-inventory.header_product_name, {"context":"rosa"})",
+      "transforms": [],
+    },
+    {
+      "title": "t(curiosity-inventory.header_quantity, {"context":"rosa"})",
+      "transforms": [
+        [Function],
+      ],
+    },
+    {
+      "title": "t(curiosity-inventory.header_next_event_date, {"context":"rosa"})",
+      "transforms": [
+        [Function],
+      ],
+    },
+  ],
+  "data": {
+    "has_infinite_quantity": {
+      "title": "t(curiosity-inventory.header_has_infinite_quantity, {"context":"rosa"})",
+      "value": true,
+    },
+    "next_event_date": {
+      "title": "t(curiosity-inventory.header_next_event_date, {"context":"rosa"})",
+      "value": "2022-01-01T00:00:00.000Z",
+    },
+    "product_name": {
+      "title": "t(curiosity-inventory.header_product_name, {"context":"rosa"})",
+      "value": "lorem",
+    },
+    "service_level": {
+      "title": "t(curiosity-inventory.header_service_level, {"context":"rosa"})",
+      "value": "hello world",
+    },
+    "total_capacity": {
+      "title": "t(curiosity-inventory.header_total_capacity, {"context":"rosa"})",
+      "value": 2000,
+    },
+  },
+}
+`;
+
+exports[`Product ROSA config should apply subscriptions inventory configuration: filtered, fallback display 1`] = `
+{
+  "cells": [
+    {
+      "title": "lorem",
+    },
+    {
+      "title": "",
+    },
+    {
+      "title": "",
+    },
+  ],
+  "columnHeaders": [
+    {
+      "title": "t(curiosity-inventory.header_product_name, {"context":"rosa"})",
+      "transforms": [],
+    },
+    {
+      "title": "t(curiosity-inventory.header_quantity, {"context":"rosa"})",
+      "transforms": [
+        [Function],
+      ],
+    },
+    {
+      "title": "t(curiosity-inventory.header_next_event_date, {"context":"rosa"})",
+      "transforms": [
+        [Function],
+      ],
+    },
+  ],
+  "data": {
+    "has_infinite_quantity": {
+      "title": "t(curiosity-inventory.header_has_infinite_quantity, {"context":"rosa"})",
+      "value": true,
+    },
+    "next_event_date": {
+      "title": "t(curiosity-inventory.header_next_event_date, {"context":"rosa"})",
+      "value": null,
+    },
+    "product_name": {
+      "title": "t(curiosity-inventory.header_product_name, {"context":"rosa"})",
+      "value": "lorem",
+    },
+    "service_level": {
+      "title": "t(curiosity-inventory.header_service_level, {"context":"rosa"})",
+      "value": null,
+    },
+    "total_capacity": {
+      "title": "t(curiosity-inventory.header_total_capacity, {"context":"rosa"})",
+      "value": 2000,
+    },
+  },
+}
+`;
+
 exports[`Product ROSA config should apply toolbar configuration: filters 1`] = `
 [
   {

--- a/src/config/__tests__/product.rosa.test.js
+++ b/src/config/__tests__/product.rosa.test.js
@@ -5,7 +5,8 @@ import {
   RHSM_API_PATH_METRIC_TYPES,
   RHSM_API_QUERY_INVENTORY_SORT_DIRECTION_TYPES as SORT_DIRECTION_TYPES,
   RHSM_API_QUERY_SET_TYPES,
-  RHSM_API_RESPONSE_INSTANCES_DATA_TYPES as INVENTORY_TYPES
+  RHSM_API_RESPONSE_INSTANCES_DATA_TYPES as INVENTORY_TYPES,
+  RHSM_API_RESPONSE_SUBSCRIPTIONS_DATA_TYPES as SUBSCRIPTIONS_INVENTORY_TYPES
 } from '../../services/rhsm/rhsmConstants';
 
 describe('Product ROSA config', () => {
@@ -174,6 +175,46 @@ describe('Product ROSA config', () => {
     });
 
     expect(filteredInventoryDataNotAuthorized).toMatchSnapshot('filtered, NOT authorized');
+
+    expect(inventoryQuery[RHSM_API_QUERY_SET_TYPES.DIRECTION] === SORT_DIRECTION_TYPES.DESCENDING).toBe(true);
+  });
+
+  it('should apply subscriptions inventory configuration', () => {
+    const {
+      initialSubscriptionsInventoryFilters: initialFilters,
+      inventorySubscriptionsQuery: inventoryQuery,
+      productId
+    } = config;
+
+    const inventoryData = {
+      [SUBSCRIPTIONS_INVENTORY_TYPES.PRODUCT_NAME]: 'lorem',
+      [SUBSCRIPTIONS_INVENTORY_TYPES.SERVICE_LEVEL]: 'hello world',
+      [SUBSCRIPTIONS_INVENTORY_TYPES.NEXT_EVENT_DATE]: '2022-01-01T00:00:00.000Z',
+      [SUBSCRIPTIONS_INVENTORY_TYPES.TOTAL_CAPACITY]: 2000,
+      [SUBSCRIPTIONS_INVENTORY_TYPES.HAS_INFINITE_QUANTITY]: true
+    };
+
+    const filteredInventoryData = parseRowCellsListData({
+      filters: initialFilters,
+      cellData: inventoryData,
+      productId
+    });
+
+    expect(filteredInventoryData).toMatchSnapshot('filtered');
+
+    const fallbackInventoryData = {
+      ...inventoryData,
+      [SUBSCRIPTIONS_INVENTORY_TYPES.SERVICE_LEVEL]: null,
+      [SUBSCRIPTIONS_INVENTORY_TYPES.NEXT_EVENT_DATE]: null
+    };
+
+    const fallbackFilteredInventoryData = parseRowCellsListData({
+      filters: initialFilters,
+      cellData: fallbackInventoryData,
+      productId
+    });
+
+    expect(fallbackFilteredInventoryData).toMatchSnapshot('filtered, fallback display');
 
     expect(inventoryQuery[RHSM_API_QUERY_SET_TYPES.DIRECTION] === SORT_DIRECTION_TYPES.DESCENDING).toBe(true);
   });

--- a/src/config/product.rosa.js
+++ b/src/config/product.rosa.js
@@ -18,6 +18,7 @@ import {
   RHSM_API_QUERY_INVENTORY_SUBSCRIPTIONS_SORT_TYPES as SUBSCRIPTIONS_SORT_TYPES,
   RHSM_API_QUERY_SET_TYPES,
   RHSM_API_RESPONSE_INSTANCES_DATA_TYPES as INVENTORY_TYPES,
+  RHSM_API_RESPONSE_SUBSCRIPTIONS_DATA_TYPES as SUBSCRIPTIONS_INVENTORY_TYPES,
   RHSM_INTERNAL_PRODUCT_DISPLAY_TYPES as DISPLAY_TYPES
 } from '../services/rhsm/rhsmConstants';
 import { dateHelpers, helpers } from '../common';
@@ -257,7 +258,27 @@ const config = {
       cellWidth: 15
     }
   ],
-  initialSubscriptionsInventoryFilters: undefined,
+  initialSubscriptionsInventoryFilters: [
+    {
+      id: SUBSCRIPTIONS_INVENTORY_TYPES.PRODUCT_NAME,
+      isSortable: true,
+      isWrappable: true
+    },
+    {
+      id: SUBSCRIPTIONS_INVENTORY_TYPES.QUANTITY,
+      isSortable: true,
+      cellWidth: 10,
+      isWrappable: true
+    },
+    {
+      id: SUBSCRIPTIONS_INVENTORY_TYPES.NEXT_EVENT_DATE,
+      cell: ({ [SUBSCRIPTIONS_INVENTORY_TYPES.NEXT_EVENT_DATE]: nextEventDate } = {}) =>
+        (nextEventDate?.value && moment.utc(nextEventDate?.value).format('YYYY-MM-DD')) || '',
+      isSortable: true,
+      isWrappable: true,
+      cellWidth: 15
+    }
+  ],
   initialToolbarFilters: [
     {
       id: 'rangedMonthly',


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- refactor(config): sw-938 activate rosa subscriptions

<!-- ### Notes -->
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm checks come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm ROSA variant subscriptions inventory displays


### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. confirm checks come back clean


## Example
<!-- Append a demo/screenshot/animated gif of the solution -->

![Screen Shot 2023-06-20 at 3 43 36 PM](https://github.com/RedHatInsights/curiosity-frontend/assets/3761375/8ea2d59d-e415-4682-8a3c-c64deb3dd9e4)

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
