### PR TITLE
fix(config): rhods, app-services default product

### DIFF
--- a/src/config/product.rhods.js
+++ b/src/config/product.rhods.js
@@ -31,7 +31,7 @@ const productId = RHSM_API_PATH_PRODUCT_TYPES.RHODS;
 const productLabel = RHSM_API_PATH_PRODUCT_TYPES.RHODS;
 
 const config = {
-  aliases: ['data', 'science', 'ods'],
+  aliases: ['application-services', 'data', 'science', 'ods'],
   productGroup,
   productId,
   productLabel,

--- a/src/config/product.rhosak.js
+++ b/src/config/product.rhosak.js
@@ -40,7 +40,7 @@ const productId = RHSM_API_PATH_PRODUCT_TYPES.RHOSAK;
 const productLabel = RHSM_API_PATH_PRODUCT_TYPES.RHOSAK;
 
 const config = {
-  aliases: ['application-services', productGroup.toLowerCase(), 'apache', 'kafka'],
+  aliases: [productGroup.toLowerCase(), 'apache', 'kafka'],
   productGroup,
   productId,
   productLabel,

--- a/tests/__snapshots__/dist.test.js.snap
+++ b/tests/__snapshots__/dist.test.js.snap
@@ -420,6 +420,17 @@ exports[`Build distribution should have a predictable ephemeral navigation based
   },
   {
     "coverage": "FALSE",
+    "path": "/application-services",
+    "productGroup": [
+      "rhods",
+    ],
+    "productId": [
+      "rhods",
+    ],
+    "productVariants": [],
+  },
+  {
+    "coverage": "FALSE",
     "path": "/data",
     "productGroup": [
       "rhods",
@@ -454,17 +465,6 @@ exports[`Build distribution should have a predictable ephemeral navigation based
   {
     "coverage": "TRUE",
     "path": "/streams",
-    "productGroup": [
-      "rhosak",
-    ],
-    "productId": [
-      "rhosak",
-    ],
-    "productVariants": [],
-  },
-  {
-    "coverage": "FALSE",
-    "path": "/application-services",
     "productGroup": [
       "rhosak",
     ],


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(config): rhods, app-services default product

### Notes
- corrects the root path for "application-services/subscriptions/" towards using RHODS
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. type in `application-services/subscriptions/` into the browser url path
   - confirm that the `RHODS` card highlights

<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->

### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. confirm tests come back clean

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing