### PR TITLE
build(webpack): rhcloud-25607 url for new subs bundle

### DIFF
--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -10,7 +10,7 @@ const { config: webpackConfig, plugins } = config({
     '/insights/subscriptions',
     '/openshift/subscriptions',
     '/application-services/subscriptions',
-    '/subscriptions'
+    '/subscriptions/usage'
   ],
   client: { overlay: false },
   debug: true,

--- a/config/webpack.proxy.config.js
+++ b/config/webpack.proxy.config.js
@@ -18,11 +18,11 @@ const { config: webpackConfig, plugins } = config({
     `${BETA_PREFIX}/insights/subscriptions`,
     `${BETA_PREFIX}/openshift/subscriptions`,
     `${BETA_PREFIX}/application-services/subscriptions`,
-    `${BETA_PREFIX}/subscriptions`,
+    `${BETA_PREFIX}/subscriptions/usage`,
     `preview/insights/subscriptions`,
     `preview/openshift/subscriptions`,
     `preview/application-services/subscriptions`,
-    `preview/subscriptions`
+    `preview/subscriptions/usage`
   ],
   client: { overlay: false },
   debug: true,


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- build(webpack): rhcloud-25607 url for new subs bundle

### Notes
- squash this update into the previous work #1158 
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
 rhcloud-25607