### PR TITLE
build(webpack): rhcloud-25607 proxy preview fix

### DIFF
--- a/config/webpack.proxy.config.js
+++ b/config/webpack.proxy.config.js
@@ -19,10 +19,10 @@ const { config: webpackConfig, plugins } = config({
     `${BETA_PREFIX}/openshift/subscriptions`,
     `${BETA_PREFIX}/application-services/subscriptions`,
     `${BETA_PREFIX}/subscriptions/usage`,
-    `preview/insights/subscriptions`,
-    `preview/openshift/subscriptions`,
-    `preview/application-services/subscriptions`,
-    `preview/subscriptions/usage`
+    `/preview/insights/subscriptions`,
+    `/preview/openshift/subscriptions`,
+    `/preview/application-services/subscriptions`,
+    `/preview/subscriptions/usage`
   ],
   client: { overlay: false },
   debug: true,


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- build(webpack): rhcloud-25607 proxy preview fix

### Notes
- this will be squashed into the prior related commits
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm access to the path `/preview/subscriptions/usage/[product]` correctly displays

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
rhcloud-25607
related #1163 