### PR TITLE
fix(services): sw-1605 mock update for deprecated ids

### DIFF
--- a/src/services/rhsm/rhsmServices.js
+++ b/src/services/rhsm/rhsmServices.js
@@ -238,7 +238,7 @@ const getApiVersion = (options = {}) => {
  *         "has_cloudigrade_data": false,
  *         "has_cloudigrade_mismatch": true,
  *         "metric_id": "Sockets",
- *         "product": "RHEL",
+ *         "product": "RHEL for x86",
  *         "service_level": "",
  *         "total_monthly": {
  *           "date": "2020-07-31T00:00:00Z",
@@ -433,7 +433,7 @@ const getApiVersion = (options = {}) => {
  *         "has_cloudigrade_data": false,
  *         "has_cloudigrade_mismatch": true,
  *         "metric_id": "Cores",
- *         "product": "RHEL",
+ *         "product": "RHEL for x86",
  *         "service_level": "",
  *         "total_monthly": {
  *           "date": "2020-07-31T00:00:00Z",
@@ -617,7 +617,7 @@ const getApiVersion = (options = {}) => {
  *         "has_cloudigrade_data": true,
  *         "has_cloudigrade_mismatch": true,
  *         "metric_id": "Transfer-gibibytes",
- *         "product": "RHEL",
+ *         "product": "RHEL for x86",
  *         "service_level": "",
  *         "total_monthly": {
  *           "date": "2020-07-31T00:00:00Z",
@@ -801,7 +801,7 @@ const getApiVersion = (options = {}) => {
  *         "has_cloudigrade_data": true,
  *         "has_cloudigrade_mismatch": true,
  *         "metric_id": "Storage-gibibyte",
- *         "product": "RHEL",
+ *         "product": "RHEL for x86",
  *         "service_level": "",
  *         "total_monthly": {
  *           "date": "2020-07-31T00:00:00Z",
@@ -985,7 +985,7 @@ const getApiVersion = (options = {}) => {
  *         "has_cloudigrade_data": true,
  *         "has_cloudigrade_mismatch": true,
  *         "metric_id": "Storage-gibibyte-months",
- *         "product": "RHEL",
+ *         "product": "RHEL for x86",
  *         "service_level": "",
  *         "total_monthly": {
  *           "date": "2020-07-31T00:00:00Z",
@@ -1168,7 +1168,7 @@ const getApiVersion = (options = {}) => {
  *         "has_cloudigrade_data": true,
  *         "has_cloudigrade_mismatch": true,
  *         "metric_id": "Instance-hours",
- *         "product": "RHEL",
+ *         "product": "RHEL for x86",
  *         "service_level": "",
  *         "total_monthly": {
  *           "date": "2020-07-31T00:00:00Z",
@@ -1434,7 +1434,7 @@ const getGraphTally = (id, params = {}, options = {}) => {
  *       "links": {},
  *       "meta": {
  *         "count": 31,
- *         "product": "RHEL",
+ *         "product": "RHEL for x86",
  *         "metric_id": "Sockets",
  *         "granularity": "daily",
  *         "service_level": "",
@@ -1759,7 +1759,7 @@ const getInstancesInventoryGuests = (id, params = {}, options = {}) => {
  *           "Storage-gibibyte-months",
  *           "Transfer-gibibytes"
  *         ],
- *         "product": "RHEL",
+ *         "product": "RHEL for x86",
  *         "service_level": "Premium",
  *         "usage": "Production"
  *       }


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(services): sw-1605 mock update for deprecated ids

### Notes
- affects local run only, staging and prod environments are unaffected
- the schema checks actually catch the issue and continue 
- local run mock updates, replace RHEL with RHEL for x86
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. confirm the capacity response on local run appears as intended

<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-1605
#1166 