### PR TITLE
chore(build): sw-1647 workflow mod, prep for branch rename

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 1
-    target-branch: "dev"
+    target-branch: "main"
     versioning-strategy: increase
     allow:
       - dependency-type: direct
@@ -25,6 +25,6 @@ updates:
       interval: monthly
       day: monday
     open-pull-requests-limit: 2
-    target-branch: "dev"
+    target-branch: "main"
     labels:
       - "build"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,7 +1,7 @@
 name: Pull request
 on:
   pull_request:
-    branches: [ master, main, prod, stage, test**, qa**, dev**, ci** ]
+    branches: [ master, main, prod, stable, stage, test**, qa**, dev**, ci** ]
 env:
   BRANCH: ${{ github.base_ref }}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,11 @@ jobs:
       script: yarn test
       after_success: codecov
     - stage: Beta Deploy
-      if: branch IN (master, main, prod, dev) OR tag IS present
+      if: branch IN (stable, main) OR tag IS present
       script: yarn build && curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/bootstrap.sh
         | bash -s
     - stage: Stable Deploy
-      if: branch IN (master, main, prod) OR tag IS present
+      if: branch IN (stable) OR tag IS present
       script: yarn build && curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/bootstrap.sh
         | bash -s
 env:

--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -18,12 +18,12 @@ release()
 #
 releaseDev()
 {
-  if [[ "${TRAVIS_BRANCH}" = "dev" ]] && [[ $TRAVIS_BUILD_STAGE_NAME == *"Beta"* ]]; then
+  if [[ "${TRAVIS_BRANCH}" = "main" ]] && [[ $TRAVIS_BUILD_STAGE_NAME == *"Beta"* ]]; then
     release "ci-beta"
     release "qa-beta"
   fi
 
-  if [[ "${TRAVIS_BRANCH}" = "main" || "${TRAVIS_BRANCH}" = "master" ]] && [[ $TRAVIS_BUILD_STAGE_NAME != *"Beta"* ]];  then
+  if [[ "${TRAVIS_BRANCH}" = "stable" ]] && [[ $TRAVIS_BUILD_STAGE_NAME != *"Beta"* ]];  then
     release "ci-stable"
     release "qa-stable"
   fi
@@ -37,7 +37,7 @@ releaseProd()
   local UPDATED_UI_VERSION="$(node -p 'require(`./package.json`).version')";
 
   if [[ "${TRAVIS_COMMIT_MESSAGE}" = *"chore(release):"* ]]; then
-    if [[ "${TRAVIS_BRANCH}" = "v${UPDATED_UI_VERSION}" || "${TRAVIS_BRANCH}" = "prod" || "${TRAVIS_BRANCH}" = "prod-stable" ]] && [[ $TRAVIS_BUILD_STAGE_NAME != *"Beta"* ]]; then
+    if [[ "${TRAVIS_BRANCH}" = "v${UPDATED_UI_VERSION}" ]] && [[ $TRAVIS_BUILD_STAGE_NAME != *"Beta"* ]]; then
       release "ci-stable"
       release "qa-stable"
       release "prod-beta"


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- chore(build): workflow mod, prep for branch rename

### Notes
- Prep work for moving to using `main` and `stable` branches where...
   - `main` is a representation of `beta`/`preview` staging
   - `stable` is a representation of `stable` staging, and related Git hashes are used to do production releases
- Aligns documentation to the branching structure
- Aligns GitHub action workflows to the branching structure
- Aligns Travis temporarily to the new branch structure while behind the scenes routing shifts to the container build
- This will deactivate ROSA in the OpenShift group variant select/dropdown across all environments @diegomaranhao . ROSA will still be directly available at `[subscriptions ui]/rosa`
- AFTER this PR is merged...
   - We'll confirm that Travis is still functioning and pushed related code towards `stage-preview`, then 
   - A new `stable` branch will be created, then
   - We'll confirm that Travis is still functioning and pushed related code towards `stage-stable`
   - If any failures happen at the Travis level we'll merge subsequent mods
   - The `dev` branch will be dated/renamed, then retired
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-1647