### PR TITLE
chore(build): sw-1647 deployment env variable

### DIFF
--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -11,7 +11,7 @@ const {
 
 const { config: webpackConfig, plugins } = config({
   rootFolder: _BUILD_RELATIVE_DIRNAME,
-  deployment: (/beta/.test(BETA_PREFIX) && 'beta/apps') || 'apps',
+  deployment: (/beta/.test(BETA_PREFIX) && 'beta/apps') || (/preview/.test(BETA_PREFIX) && 'preview/apps') || 'apps',
   replacePlugin: setReplacePlugin()
 });
 

--- a/scripts/pre.sh
+++ b/scripts/pre.sh
@@ -7,10 +7,15 @@ deployPaths()
 {
   local DEPLOY_BRANCH=$1
   local DEPLOY_BUILD_STAGE=$2
+  local CONTAINER_BUILD_ENV=$3
 
   DEPLOY_PATH_PREFIX=""
 
-  if [[ $DEPLOY_BUILD_STAGE == *"Beta"* ]]; then
+  # Note: allow Container build, fallback to Travis build
+  if [[ $CONTAINER_BUILD_ENV == "true" ]]; then
+    DEPLOY_PATH_PREFIX=/preview
+    DEPLOY_PATH_LINK_PREFIX=/preview
+  elif [[ $DEPLOY_BUILD_STAGE == *"Beta"* ]]; then
     DEPLOY_PATH_PREFIX=/beta
     DEPLOY_PATH_LINK_PREFIX=/preview
   fi
@@ -57,6 +62,8 @@ clean()
   clean
   version
 
-  # see .travis.yml globals
-  deployPaths "${BRANCH:-local}" "${BUILD_STAGE:-Local Deploy}"
+  # Note: See .travis.yml globals, GitHub actions, and Container Build environment variables
+  # - Travis, GitHub actions: BRANCH, BUILD_STAGE
+  # - Container Build: BETA
+  deployPaths "${BRANCH:-local}" "${BUILD_STAGE:-Local Deploy}" "${BETA:-local env}"
 }


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- chore(build): sw-1647 deployment env variable

### Notes
- step 2 of sw-1647, allow an additional BETA env variable for container builds
- there should be no change to the current Travis deployed build
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->

### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. confirm tests come back clean

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-1647 step 3