### PR TITLE
fix(i18nHelpers): sw-1537 apply multicontext to all keys

### DIFF
--- a/src/components/graphCard/__tests__/__snapshots__/graphCardChartLegend.test.js.snap
+++ b/src/components/graphCard/__tests__/__snapshots__/graphCardChartLegend.test.js.snap
@@ -88,7 +88,7 @@ exports[`GraphCardChartLegend Component should render a basic component: basic 1
         tabIndex={0}
         variant="link"
       >
-        t([curiosity-graph.label_loremIpsum,curiosity-graph.label_no], {"product":"mock-product-label","context":"mock-product-id"})
+        t([curiosity-graph.label_loremIpsum,curiosity-graph.label_no_loremIpsum], {"product":"mock-product-label","context":"mock-product-id"})
       </Button>
     </span>
   </Tooltip>
@@ -132,7 +132,7 @@ exports[`GraphCardChartLegend Component should render basic data: data 1`] = `
         tabIndex={0}
         variant="link"
       >
-        t([curiosity-graph.label_loremIpsum,curiosity-graph.label_no], {"product":"mock-product-label","context":"mock-product-id"})
+        t([curiosity-graph.label_loremIpsum,curiosity-graph.label_no_loremIpsum], {"product":"mock-product-label","context":"mock-product-id"})
       </Button>
     </span>
   </Tooltip>
@@ -166,7 +166,7 @@ exports[`GraphCardChartLegend Component should render basic data: data 1`] = `
         tabIndex={0}
         variant="link"
       >
-        t([curiosity-graph.label_ametConsectetur,curiosity-graph.label_no], {"product":"mock-product-label","context":"mock-product-id"})
+        t([curiosity-graph.label_ametConsectetur,curiosity-graph.label_no_ametConsectetur], {"product":"mock-product-label","context":"mock-product-id"})
       </Button>
     </span>
   </Tooltip>
@@ -205,7 +205,7 @@ exports[`GraphCardChartLegend Component should render basic data: data 1`] = `
         tabIndex={0}
         variant="link"
       >
-        t([curiosity-graph.label_threshold_dolorSit,curiosity-graph.label_no], {"product":"mock-product-label","context":"mock-product-id"})
+        t([curiosity-graph.label_threshold_dolorSit,curiosity-graph.label_no_threshold_dolorSit], {"product":"mock-product-label","context":"mock-product-id"})
       </Button>
     </span>
   </Tooltip>
@@ -244,7 +244,7 @@ exports[`GraphCardChartLegend Component should render basic data: data 1`] = `
         tabIndex={0}
         variant="link"
       >
-        t([curiosity-graph.label_threshold_nonCursus,curiosity-graph.label_no], {"product":"mock-product-label","context":"mock-product-id"})
+        t([curiosity-graph.label_threshold_nonCursus,curiosity-graph.label_no_threshold_nonCursus], {"product":"mock-product-label","context":"mock-product-id"})
       </Button>
     </span>
   </Tooltip>

--- a/src/components/i18n/i18nHelpers.js
+++ b/src/components/i18n/i18nHelpers.js
@@ -85,7 +85,7 @@ const parseContext = (
       const lastContext = tempContext.pop();
 
       if (Array.isArray(updatedTranslateKey)) {
-        updatedTranslateKey[0] = `${updatedTranslateKey[0]}_${tempContext.join('_')}`;
+        updatedTranslateKey = updatedTranslateKey.map(value => `${value}_${tempContext.join('_')}`);
       } else {
         updatedTranslateKey = `${updatedTranslateKey}_${tempContext.join('_')}`;
       }


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(i18nHelpers): sw-1537 apply multicontext to all keys

### Notes
- expands multi-context to all available keys (values) when an Array of string keys is used
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. confirm products graphs, and related tooltips display as intended

<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->

### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. confirm tests come back clean

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-1537