### PR TITLE
feat(rhsmTransformers): sw-1537 subs, guest responses

### DIFF
--- a/src/redux/README.md
+++ b/src/redux/README.md
@@ -655,6 +655,7 @@ State hooks for dispatch and selectors.
 
 
 * [UseReactRedux](#Hooks.module_UseReactRedux)
+    * [~deepEqual](#Hooks.module_UseReactRedux..deepEqual) ⇒ <code>boolean</code>
     * [~useDispatch()](#Hooks.module_UseReactRedux..useDispatch) ⇒ <code>function</code>
     * [~useSelector(selector, value, options)](#Hooks.module_UseReactRedux..useSelector) ⇒ <code>\*</code>
     * [~useSelectors(selectors, value, options)](#Hooks.module_UseReactRedux..useSelectors) ⇒ <code>Array</code> \| <code>object</code>
@@ -662,6 +663,28 @@ State hooks for dispatch and selectors.
     * [~useSelectorsAllSettledResponse(selectors, options)](#Hooks.module_UseReactRedux..useSelectorsAllSettledResponse) ⇒ <code>Object</code>
     * [~useSelectorsAnyResponse(selectors, options)](#Hooks.module_UseReactRedux..useSelectorsAnyResponse) ⇒ <code>Object</code>
     * [~useSelectorsRaceResponse(selectors, options)](#Hooks.module_UseReactRedux..useSelectorsRaceResponse) ⇒ <code>Object</code>
+
+<a name="Hooks.module_UseReactRedux..deepEqual"></a>
+
+### UseReactRedux~deepEqual ⇒ <code>boolean</code>
+Deep equal comparison with extended memoized cache. Is argument A equal to argument B.
+
+**Kind**: inner constant of [<code>UseReactRedux</code>](#Hooks.module_UseReactRedux)  
+<table>
+  <thead>
+    <tr>
+      <th>Param</th><th>Type</th>
+    </tr>
+  </thead>
+  <tbody>
+<tr>
+    <td>args</td><td><code>object</code></td>
+    </tr><tr>
+    <td>args.A</td><td><code>object</code> | <code>any</code></td>
+    </tr><tr>
+    <td>args.B</td><td><code>object</code> | <code>any</code></td>
+    </tr>  </tbody>
+</table>
 
 <a name="Hooks.module_UseReactRedux..useDispatch"></a>
 

--- a/src/redux/hooks/__tests__/__snapshots__/useReactRedux.test.js.snap
+++ b/src/redux/hooks/__tests__/__snapshots__/useReactRedux.test.js.snap
@@ -764,6 +764,7 @@ exports[`useReactRedux should return a list or object with ID for multiple selec
 
 exports[`useReactRedux should return specific properties: specific properties 1`] = `
 {
+  "deepEqual": [Function],
   "shallowEqual": [Function],
   "useDispatch": [Function],
   "useSelector": [Function],

--- a/src/redux/hooks/useReactRedux.js
+++ b/src/redux/hooks/useReactRedux.js
@@ -2,6 +2,7 @@
 import { useSelector as useReactReduxSelector, shallowEqual } from 'react-redux';
 import { createSelector } from 'reselect';
 import _cloneDeep from 'lodash/cloneDeep';
+import _isEqual from 'lodash/isEqual';
 import { store } from '../store';
 import { helpers } from '../../common';
 
@@ -11,6 +12,16 @@ import { helpers } from '../../common';
  * @memberof Hooks
  * @module UseReactRedux
  */
+
+/**
+ * Deep equal comparison with extended memoized cache. Is argument A equal to argument B.
+ *
+ * @param {object} args
+ * @param {object|any} args.A
+ * @param {object|any} args.B
+ * @returns {boolean}
+ */
+const deepEqual = helpers.memo((...args) => _isEqual(...args), { cacheLimit: 50 });
 
 /**
  * FixMe: Appears to be an issue in trying to use Redux Promise with the default "useDispatch"
@@ -480,6 +491,7 @@ const useSelectorsRaceResponse = (
 };
 
 const reactReduxHooks = {
+  deepEqual,
   shallowEqual,
   useDispatch,
   useSelector,
@@ -493,6 +505,7 @@ const reactReduxHooks = {
 export {
   reactReduxHooks as default,
   reactReduxHooks,
+  deepEqual,
   shallowEqual,
   useDispatch,
   useSelector,

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -1004,13 +1004,72 @@ Transform RHSM responses. Replaces selector usage.
 
 
 * [RhsmTransformers](#Rhsm.module_RhsmTransformers)
+    * [~rhsmInstancesGuestsCache](#Rhsm.module_RhsmTransformers..rhsmInstancesGuestsCache) : <code>Object</code>
     * [~rhsmInstances(response, config)](#Rhsm.module_RhsmTransformers..rhsmInstances) ⇒ <code>object</code>
+    * [~rhsmInstancesGuests(response, config)](#Rhsm.module_RhsmTransformers..rhsmInstancesGuests) ⇒ <code>object</code>
+    * [~rhsmSubscriptions(response, config)](#Rhsm.module_RhsmTransformers..rhsmSubscriptions) ⇒ <code>object</code>
     * [~rhsmTallyCapacity(response, config)](#Rhsm.module_RhsmTransformers..rhsmTallyCapacity) ⇒ <code>object</code>
 
+<a name="Rhsm.module_RhsmTransformers..rhsmInstancesGuestsCache"></a>
+
+### RhsmTransformers~rhsmInstancesGuestsCache : <code>Object</code>
+Temporary guests response cache.
+
+**Kind**: inner constant of [<code>RhsmTransformers</code>](#Rhsm.module_RhsmTransformers)  
 <a name="Rhsm.module_RhsmTransformers..rhsmInstances"></a>
 
 ### RhsmTransformers~rhsmInstances(response, config) ⇒ <code>object</code>
 Parse RHSM instances response for caching.
+
+**Kind**: inner method of [<code>RhsmTransformers</code>](#Rhsm.module_RhsmTransformers)  
+<table>
+  <thead>
+    <tr>
+      <th>Param</th><th>Type</th>
+    </tr>
+  </thead>
+  <tbody>
+<tr>
+    <td>response</td><td><code>object</code></td>
+    </tr><tr>
+    <td>config</td><td><code>object</code></td>
+    </tr><tr>
+    <td>config.params</td><td><code>object</code></td>
+    </tr>  </tbody>
+</table>
+
+<a name="Rhsm.module_RhsmTransformers..rhsmInstancesGuests"></a>
+
+### RhsmTransformers~rhsmInstancesGuests(response, config) ⇒ <code>object</code>
+Parse RHSM guests instances response. Return an infinite list at the transformer level.
+
+**Kind**: inner method of [<code>RhsmTransformers</code>](#Rhsm.module_RhsmTransformers)  
+<table>
+  <thead>
+    <tr>
+      <th>Param</th><th>Type</th>
+    </tr>
+  </thead>
+  <tbody>
+<tr>
+    <td>response</td><td><code>object</code></td>
+    </tr><tr>
+    <td>config</td><td><code>object</code></td>
+    </tr><tr>
+    <td>config.params</td><td><code>object</code></td>
+    </tr><tr>
+    <td>config._id</td><td><code>object</code></td>
+    </tr>  </tbody>
+</table>
+
+<a name="Rhsm.module_RhsmTransformers..rhsmSubscriptions"></a>
+
+### RhsmTransformers~rhsmSubscriptions(response, config) ⇒ <code>object</code>
+Parse RHSM subscriptions response for caching.
+The Subscriptions' response "meta" includes the uom field if it is included within the query parameters. We attempt to
+normalize this for both casing, similar to the Instances meta response, BUT we also add a concatenated string uom for responses
+without the uom query parameter in the form of "Sockets", "Sockets-Cores", or "Cores", dependent on the returned response
+data.
 
 **Kind**: inner method of [<code>RhsmTransformers</code>](#Rhsm.module_RhsmTransformers)  
 <table>

--- a/src/services/rhsm/__tests__/__snapshots__/rhsmTransformers.test.js.snap
+++ b/src/services/rhsm/__tests__/__snapshots__/rhsmTransformers.test.js.snap
@@ -364,6 +364,100 @@ exports[`RHSM Transformers should attempt to parse a capacity response: capacity
 }
 `;
 
+exports[`RHSM Transformers should attempt to parse a guests response: guests 1`] = `
+{
+  "data": [
+    {
+      "lorem": "ipsum",
+    },
+  ],
+  "meta": {},
+}
+`;
+
+exports[`RHSM Transformers should attempt to parse a guests response: guests, cache 1`] = `
+{
+  "data": [
+    {
+      "lorem": "ipsum",
+    },
+    {
+      "dolor": "sit",
+    },
+    {
+      "hello": "world",
+    },
+  ],
+  "meta": {},
+}
+`;
+
+exports[`RHSM Transformers should attempt to parse a guests response: guests, failed 1`] = `
+{
+  "data": [],
+  "meta": {},
+}
+`;
+
+exports[`RHSM Transformers should attempt to parse a subscriptions response: subscriptions, failed 1`] = `
+{
+  "data": [],
+  "meta": {
+    "count": undefined,
+    "productId": undefined,
+    "uom": "",
+  },
+}
+`;
+
+exports[`RHSM Transformers should attempt to parse a subscriptions response: subscriptions, uom cores 1`] = `
+{
+  "data": [
+    {
+      "uom": "Cores",
+    },
+  ],
+  "meta": {
+    "count": undefined,
+    "productId": undefined,
+    "uom": "Cores",
+  },
+}
+`;
+
+exports[`RHSM Transformers should attempt to parse a subscriptions response: subscriptions, uom sockets as parameter 1`] = `
+{
+  "data": [
+    {
+      "uom": "Cores",
+    },
+  ],
+  "meta": {
+    "count": undefined,
+    "productId": undefined,
+    "uom": "Sockets",
+  },
+}
+`;
+
+exports[`RHSM Transformers should attempt to parse a subscriptions response: subscriptions, uom sockets, cores response 1`] = `
+{
+  "data": [
+    {
+      "uom": "Cores",
+    },
+    {
+      "uom": "Sockets",
+    },
+  ],
+  "meta": {
+    "count": undefined,
+    "productId": undefined,
+    "uom": "Sockets-Cores",
+  },
+}
+`;
+
 exports[`RHSM Transformers should attempt to parse a tally response: tally 1`] = `
 {
   "data": [],
@@ -852,7 +946,9 @@ exports[`RHSM Transformers should attempt to parse an instances response: instan
 
 exports[`RHSM Transformers should have specific response transformers: specific transformers 1`] = `
 {
+  "guests": [Function],
   "instances": [Function],
+  "subscriptions": [Function],
   "tallyCapacity": [Function],
 }
 `;

--- a/src/services/rhsm/__tests__/rhsmTransformers.test.js
+++ b/src/services/rhsm/__tests__/rhsmTransformers.test.js
@@ -1,7 +1,8 @@
 import { rhsmTransformers } from '../rhsmTransformers';
 import {
   rhsmConstants,
-  RHSM_API_RESPONSE_TALLY_CAPACITY_DATA_TYPES as TALLY_CAPACITY_DATA_TYPES
+  RHSM_API_RESPONSE_TALLY_CAPACITY_DATA_TYPES as TALLY_CAPACITY_DATA_TYPES,
+  RHSM_API_QUERY_SET_TYPES
 } from '../rhsmConstants';
 
 describe('RHSM Transformers', () => {
@@ -278,11 +279,115 @@ describe('RHSM Transformers', () => {
         },
         {
           params: {
-            [rhsmConstants.RHSM_API_RESPONSE_INSTANCES_META_TYPES.UOM]: 'cores'
+            [rhsmConstants.RHSM_API_QUERY_SET_INVENTORY_TYPES.UOM]: 'cores'
           }
         }
       )
     ).toMatchSnapshot('instances, uom cores as parameter');
+  });
+
+  it('should attempt to parse a guests response', () => {
+    expect(rhsmTransformers.guests(undefined)).toMatchSnapshot('guests, failed');
+
+    const response = {
+      [rhsmConstants.RHSM_API_RESPONSE_DATA]: [
+        {
+          lorem: 'ipsum'
+        }
+      ],
+      [rhsmConstants.RHSM_API_RESPONSE_META]: {}
+    };
+
+    expect(rhsmTransformers.guests(response)).toMatchSnapshot('guests');
+
+    rhsmTransformers.guests(
+      {
+        [rhsmConstants.RHSM_API_RESPONSE_DATA]: [
+          {
+            lorem: 'ipsum'
+          }
+        ],
+        [rhsmConstants.RHSM_API_RESPONSE_META]: {}
+      },
+      {
+        params: { [RHSM_API_QUERY_SET_TYPES.OFFSET]: 0, [RHSM_API_QUERY_SET_TYPES.LIMIT]: 1 },
+        _id: 'test'
+      }
+    );
+
+    rhsmTransformers.guests(
+      {
+        [rhsmConstants.RHSM_API_RESPONSE_DATA]: [
+          {
+            dolor: 'sit'
+          }
+        ],
+        [rhsmConstants.RHSM_API_RESPONSE_META]: {}
+      },
+      {
+        params: { [RHSM_API_QUERY_SET_TYPES.OFFSET]: 1, [RHSM_API_QUERY_SET_TYPES.LIMIT]: 1 },
+        _id: 'test'
+      }
+    );
+
+    expect(
+      rhsmTransformers.guests(
+        {
+          [rhsmConstants.RHSM_API_RESPONSE_DATA]: [
+            {
+              hello: 'world'
+            }
+          ],
+          [rhsmConstants.RHSM_API_RESPONSE_META]: {}
+        },
+        {
+          params: { [RHSM_API_QUERY_SET_TYPES.OFFSET]: 2, [RHSM_API_QUERY_SET_TYPES.LIMIT]: 1 },
+          _id: 'test'
+        }
+      )
+    ).toMatchSnapshot('guests, cache');
+  });
+
+  it('should attempt to parse a subscriptions response', () => {
+    expect(rhsmTransformers.subscriptions(undefined)).toMatchSnapshot('subscriptions, failed');
+
+    const response = {
+      [rhsmConstants.RHSM_API_RESPONSE_DATA]: [
+        {
+          [rhsmConstants.RHSM_API_RESPONSE_SUBSCRIPTIONS_DATA_TYPES.UOM]: 'Cores'
+        }
+      ],
+      [rhsmConstants.RHSM_API_RESPONSE_META]: {}
+    };
+
+    expect(rhsmTransformers.subscriptions(response)).toMatchSnapshot('subscriptions, uom cores');
+
+    expect(
+      rhsmTransformers.subscriptions(
+        {
+          ...response
+        },
+        {
+          params: {
+            [rhsmConstants.RHSM_API_QUERY_SET_INVENTORY_TYPES.UOM]: 'sockets'
+          }
+        }
+      )
+    ).toMatchSnapshot('subscriptions, uom sockets as parameter');
+
+    expect(
+      rhsmTransformers.subscriptions({
+        [rhsmConstants.RHSM_API_RESPONSE_DATA]: [
+          {
+            [rhsmConstants.RHSM_API_RESPONSE_SUBSCRIPTIONS_DATA_TYPES.UOM]: 'Cores'
+          },
+          {
+            [rhsmConstants.RHSM_API_RESPONSE_SUBSCRIPTIONS_DATA_TYPES.UOM]: 'Sockets'
+          }
+        ],
+        [rhsmConstants.RHSM_API_RESPONSE_META]: {}
+      })
+    ).toMatchSnapshot('subscriptions, uom sockets, cores response');
   });
 
   it('should attempt to parse a tally response', () => {

--- a/src/services/rhsm/rhsmSchemas.js
+++ b/src/services/rhsm/rhsmSchemas.js
@@ -129,6 +129,7 @@ const guestsResponseSchema = Joi.object().keys({
  */
 const instancesMetaSchema = metaResponseSchema
   .keys({
+    count: Joi.number().integer().default(0),
     measurements: Joi.array()
       .items(Joi.string().valid(...Object.values(rhsmConstants.RHSM_API_PATH_METRIC_TYPES)))
       .default([])

--- a/src/services/rhsm/rhsmServices.js
+++ b/src/services/rhsm/rhsmServices.js
@@ -1661,7 +1661,8 @@ const getInstancesInventoryGuests = (id, params = {}, options = {}) => {
     cancel,
     cancelId,
     schema,
-    transform
+    transform,
+    _id: updatedId
   });
 };
 

--- a/src/services/rhsm/rhsmTransformers.js
+++ b/src/services/rhsm/rhsmTransformers.js
@@ -4,6 +4,8 @@ import {
   RHSM_API_PATH_METRIC_TYPES,
   RHSM_API_RESPONSE_INSTANCES_DATA_TYPES as INSTANCES_DATA_TYPES,
   RHSM_API_RESPONSE_INSTANCES_META_TYPES as INSTANCES_META_TYPES,
+  RHSM_API_RESPONSE_SUBSCRIPTIONS_DATA_TYPES as SUBSCRIPTIONS_DATA_TYPES,
+  RHSM_API_RESPONSE_SUBSCRIPTIONS_META_TYPES as SUBSCRIPTIONS_META_TYPES,
   RHSM_API_RESPONSE_TALLY_CAPACITY_DATA_TYPES as TALLY_CAPACITY_DATA_TYPES,
   RHSM_API_RESPONSE_TALLY_CAPACITY_META_TYPES as TALLY_CAPACITY_META_TYPES,
   rhsmConstants
@@ -68,6 +70,110 @@ const rhsmInstances = (response, { params } = {}) => {
     count: meta[INSTANCES_META_TYPES.COUNT],
     uom: normalizedUom,
     productId: meta[INSTANCES_META_TYPES.PRODUCT]
+  };
+
+  return updatedResponse;
+};
+
+/**
+ * Temporary guests response cache.
+ *
+ * @type {{}}
+ */
+const rhsmInstancesGuestsCache = {};
+
+/**
+ * Parse RHSM guests instances response. Return an infinite list at the transformer level.
+ *
+ * @param {object} response
+ * @param {object} config
+ * @param {object} config.params
+ * @param {object} config._id
+ * @returns {object}
+ */
+const rhsmInstancesGuests = (response, { params, _id } = {}) => {
+  const updatedResponse = {};
+  const { [rhsmConstants.RHSM_API_RESPONSE_DATA]: data = [], [rhsmConstants.RHSM_API_RESPONSE_META]: meta = {} } =
+    response || {};
+
+  updatedResponse.data = data;
+  updatedResponse.meta = meta;
+
+  if (_id) {
+    let cacheIndex =
+      Number.parseInt(params?.[RHSM_API_QUERY_SET_TYPES.OFFSET], 10) /
+      Number.parseInt(params?.[RHSM_API_QUERY_SET_TYPES.LIMIT], 10);
+
+    // Note: null is considered "finite"
+    cacheIndex = (!Number.isNaN(cacheIndex) && Number.isFinite(cacheIndex) && cacheIndex) || 0;
+
+    if (cacheIndex <= 0) {
+      rhsmInstancesGuestsCache[_id] = [];
+    }
+
+    rhsmInstancesGuestsCache[_id][cacheIndex] = data;
+
+    updatedResponse.data = rhsmInstancesGuestsCache[_id].flat();
+  }
+
+  return updatedResponse;
+};
+
+/**
+ * Parse RHSM subscriptions response for caching.
+ * The Subscriptions' response "meta" includes the uom field if it is included within the query parameters. We attempt to
+ * normalize this for both casing, similar to the Instances meta response, BUT we also add a concatenated string uom for responses
+ * without the uom query parameter in the form of "Sockets", "Sockets-Cores", or "Cores", dependent on the returned response
+ * data.
+ *
+ * @param {object} response
+ * @param {object} config
+ * @param {object} config.params
+ * @returns {object}
+ */
+const rhsmSubscriptions = (response, { params } = {}) => {
+  const updatedResponse = {};
+  const { [rhsmConstants.RHSM_API_RESPONSE_DATA]: data = [], [rhsmConstants.RHSM_API_RESPONSE_META]: meta = {} } =
+    response || {};
+
+  updatedResponse.data = data;
+
+  let normalizedUom = params?.[RHSM_API_QUERY_SET_TYPES.UOM];
+
+  if (!normalizedUom) {
+    const tempUom = [];
+
+    const isSocketsUom =
+      data.find(({ [SUBSCRIPTIONS_DATA_TYPES.UOM]: uom }) =>
+        new RegExp(RHSM_API_PATH_METRIC_TYPES.SOCKETS, 'i').test(uom)
+      ) !== undefined;
+
+    if (isSocketsUom) {
+      tempUom.push(RHSM_API_PATH_METRIC_TYPES.SOCKETS);
+    }
+
+    const isCoresUom =
+      data.find(({ [SUBSCRIPTIONS_DATA_TYPES.UOM]: uom }) =>
+        new RegExp(RHSM_API_PATH_METRIC_TYPES.CORES, 'i').test(uom)
+      ) !== undefined;
+
+    if (isCoresUom) {
+      tempUom.push(RHSM_API_PATH_METRIC_TYPES.CORES);
+    }
+
+    normalizedUom = tempUom.join('-');
+  }
+  if (normalizedUom?.toLowerCase() === RHSM_API_PATH_METRIC_TYPES.SOCKETS.toLowerCase()) {
+    normalizedUom = RHSM_API_PATH_METRIC_TYPES.SOCKETS;
+  } else if (normalizedUom?.toLowerCase() === RHSM_API_PATH_METRIC_TYPES.CORES.toLowerCase()) {
+    normalizedUom = RHSM_API_PATH_METRIC_TYPES.CORES;
+  }
+
+  updatedResponse.meta = {
+    ...meta,
+    count: meta[SUBSCRIPTIONS_META_TYPES.COUNT],
+    uom: normalizedUom,
+    productId: meta[SUBSCRIPTIONS_META_TYPES.PRODUCT]
   };
 
   return updatedResponse;
@@ -160,8 +266,17 @@ const rhsmTallyCapacity = (response, { _isCapacity, params } = {}) => {
 };
 
 const rhsmTransformers = {
+  guests: rhsmInstancesGuests,
   instances: rhsmInstances,
+  subscriptions: rhsmSubscriptions,
   tallyCapacity: rhsmTallyCapacity
 };
 
-export { rhsmTransformers as default, rhsmTransformers, rhsmInstances, rhsmTallyCapacity };
+export {
+  rhsmTransformers as default,
+  rhsmTransformers,
+  rhsmInstances,
+  rhsmInstancesGuests,
+  rhsmSubscriptions,
+  rhsmTallyCapacity
+};


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- feat(rhsmTransformers): sw-1537 subs, guest responses

### Notes
- standalone updates, currently not active. activation will happen with #1168 
- transformations for guests and subscriptions
- deep equal comparison for redux hooks
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->

### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. confirm tests come back clean

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-1537

related #1184 #1168