### PR TITLE
Fixes for swatch-1537, clean up for swatch-1689 PF5 update

### DIFF
--- a/src/components/README.md
+++ b/src/components/README.md
@@ -5748,6 +5748,8 @@ Render an empty table.
 <tr>
     <td>props</td><td><code>object</code></td>
     </tr><tr>
+    <td>props.ariaLabel</td><td><code>string</code></td>
+    </tr><tr>
     <td>props.icon</td><td><code>React.ReactNode</code> | <code>function</code></td>
     </tr><tr>
     <td>props.message</td><td><code>React.ReactNode</code></td>

--- a/src/components/chart/chartIcon.js
+++ b/src/components/chart/chartIcon.js
@@ -118,7 +118,7 @@ const ChartIcon = ({ fill, symbol, size, title, ...props }) => {
  */
 ChartIcon.propTypes = {
   fill: PropTypes.string,
-  size: PropTypes.oneOf([...Object.keys(IconSize)]),
+  size: PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([...Object.keys(IconSize)])]),
   symbol: PropTypes.oneOf(['dash', 'eye', 'eyeSlash', 'infinity', 'square', 'threshold']),
   title: PropTypes.string
 };

--- a/src/components/table/__tests__/__snapshots__/tableEmpty.test.js.snap
+++ b/src/components/table/__tests__/__snapshots__/tableEmpty.test.js.snap
@@ -2,7 +2,9 @@
 
 exports[`TableEmpty Component should have fallback checks for certain props: fallback display 1`] = `
 <EmptyTable>
-  <table />
+  <table
+    aria-label={null}
+  />
   <EmptyState
     variant="small"
   >
@@ -24,7 +26,9 @@ exports[`TableEmpty Component should have fallback checks for certain props: fal
 
 exports[`TableEmpty Component should render a basic component: basic 1`] = `
 <EmptyTable>
-  <table />
+  <table
+    aria-label={null}
+  />
   <EmptyState
     variant="small"
   >

--- a/src/components/table/tableEmpty.js
+++ b/src/components/table/tableEmpty.js
@@ -13,6 +13,7 @@ import { EmptyTable as PlatformEmptyTableWrapper } from '@redhat-cloud-services/
  * Render an empty table.
  *
  * @param {object} props
+ * @param {string} props.ariaLabel
  * @param {React.ReactNode|Function} props.icon
  * @param {React.ReactNode} props.message
  * @param {string} props.tableHeading
@@ -20,9 +21,9 @@ import { EmptyTable as PlatformEmptyTableWrapper } from '@redhat-cloud-services/
  * @param {string} props.variant
  * @returns {React.ReactNode}
  */
-const TableEmpty = ({ icon, message, tableHeading, title, variant, ...props }) => (
+const TableEmpty = ({ ariaLabel, icon, message, tableHeading, title, variant, ...props }) => (
   <PlatformEmptyTableWrapper>
-    <table {...props} />
+    <table aria-label={ariaLabel} {...props} />
     <EmptyState variant={variant}>
       {icon && <EmptyStateIcon icon={icon} />}
       <Title headingLevel={tableHeading} size="lg">
@@ -37,9 +38,10 @@ const TableEmpty = ({ icon, message, tableHeading, title, variant, ...props }) =
  * Prop types.
  *
  * @type {{icon: React.ReactNode|Function, variant: string, message: React.ReactNode, title: React.ReactNode,
- *     tableHeading: string}}
+ *     tableHeading: string, ariaLabel: string}}
  */
 TableEmpty.propTypes = {
+  ariaLabel: PropTypes.string,
   icon: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   message: PropTypes.node.isRequired,
   tableHeading: PropTypes.string,
@@ -50,9 +52,10 @@ TableEmpty.propTypes = {
 /**
  * Default props.
  *
- * @type {{icon: null, variant: EmptyStateVariant.small, tableHeading: string}}
+ * @type {{icon: null, variant: EmptyStateVariant.small, tableHeading: string, ariaLabel: null}}
  */
 TableEmpty.defaultProps = {
+  ariaLabel: null,
   icon: SearchIcon,
   tableHeading: 'h2',
   variant: EmptyStateVariant.small


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(tableEmpty): sw-1537 aria-label attribute format
- fix(chartIcon): sw-1689 size prop type warning

### Notes
- couple of fixes that popped up during the work for PF5 sw-1689
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->

### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. confirm tests come back clean

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
related #1194 sw-1689 sw-1537