### PR TITLE
3 of 3, PF5 Migration, build(proxy): sw-1689 locale file paths

### DIFF
--- a/.env.proxy
+++ b/.env.proxy
@@ -1,7 +1,5 @@
 DEV_PORT=1337
 DEV_BRANCH=stage-beta
+UI_DEPLOY_PATH_PREFIX=/beta
 
 REACT_APP_ENV=review
-
-REACT_APP_CONFIG_SERVICE_LOCALES=/locales/locales.json
-REACT_APP_CONFIG_SERVICE_LOCALES_PATH=/locales/{{lng}}.json

--- a/config/webpack.proxy.config.js
+++ b/config/webpack.proxy.config.js
@@ -1,36 +1,47 @@
 const config = require('@redhat-cloud-services/frontend-components-config');
 const { setReplacePlugin, setCommonPlugins } = require('./build.plugins');
 const { setupDotenvFilesForEnv } = require('./build.dotenv');
-const { setProxyRoutes } = require('./spandx.config');
 
-const { _BUILD_RELATIVE_DIRNAME, DEV_BRANCH, DEV_PORT } = setupDotenvFilesForEnv({
+const {
+  _BUILD_RELATIVE_DIRNAME,
+  REACT_APP_UI_DEPLOY_PATH_PREFIX: BETA_PREFIX,
+  DEV_BRANCH,
+  DEV_PORT
+} = setupDotenvFilesForEnv({
   env: 'proxy'
 });
 
-let BETA_PREFIX = '';
+const UPDATED_BETA_PREFIX = [BETA_PREFIX];
 
-if (/(prod|stage|qa|ci)-beta/.test(DEV_BRANCH)) {
-  BETA_PREFIX = '/beta';
+switch (BETA_PREFIX) {
+  case '/preview':
+    UPDATED_BETA_PREFIX.push('/beta');
+    break;
+  case '/beta':
+  default:
+    UPDATED_BETA_PREFIX.push('/preview');
+    break;
 }
 
 const { config: webpackConfig, plugins } = config({
-  appUrl: [
-    `${BETA_PREFIX}/insights/subscriptions`,
-    `${BETA_PREFIX}/openshift/subscriptions`,
-    `${BETA_PREFIX}/application-services/subscriptions`,
-    `${BETA_PREFIX}/subscriptions/usage`,
-    `/preview/insights/subscriptions`,
-    `/preview/openshift/subscriptions`,
-    `/preview/application-services/subscriptions`,
-    `/preview/subscriptions/usage`
-  ],
+  appUrl: (() => {
+    const urls = [];
+    UPDATED_BETA_PREFIX.forEach(path => {
+      urls.push(
+        `${path}/insights/subscriptions`,
+        `${path}/openshift/subscriptions`,
+        `${path}/application-services/subscriptions`,
+        `${path}/subscriptions/usage`
+      );
+    });
+    return urls;
+  })(),
   client: { overlay: false },
   debug: true,
-  deployment: (/beta/.test(BETA_PREFIX) && 'beta/apps') || 'apps',
+  deployment: (/beta/.test(BETA_PREFIX) && 'beta/apps') || (/preview/.test(BETA_PREFIX) && 'preview/apps') || 'apps',
   env: (/(prod|stage|qa|ci)(-stable|-beta)$/.test(DEV_BRANCH) && DEV_BRANCH) || 'stage-stable',
   port: Number.parseInt(DEV_PORT, 10),
   rootFolder: _BUILD_RELATIVE_DIRNAME,
-  routes: setProxyRoutes({ DEV_PORT, BETA_PREFIX }),
   standalone: false,
   useProxy: true,
   replacePlugin: setReplacePlugin()


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- build(proxy): sw-1689 locale file paths

### Notes
- not necessarily related to the PF5 migration, however it was discovered during testing. 
- solves a recent issue where our locale file during proxy run wasn't being called correctly
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. confirm proxy runs locally and
   - displays locale strings
   - locale strings update on browser refresh

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
#1202 #1194
sw-1689