### PR TITLE
fix(build): sw-1885 rollback to beta prefix

### DIFF
--- a/scripts/pre.sh
+++ b/scripts/pre.sh
@@ -14,7 +14,7 @@ deployPaths()
   # Note: allow Container build
   if [[ $CONTAINER_BUILD_ENV == "true" ]]; then
     DEPLOY_STAGE="Preview"
-    DEPLOY_PATH_PREFIX=/preview
+    DEPLOY_PATH_PREFIX=/beta
     DEPLOY_PATH_LINK_PREFIX=/preview
   fi
 


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(build): sw-1885 rollback to beta prefix

<!-- ### Notes -->
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
- After the container build is confirmed and pushed to environment
- Log into stage-preview/beta 
   - confirm Subs UI is updated by accessing the hash under the browser developer console
      - `$  curiosity.UI_VERSION`
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-1885
related sw-1792