### PR TITLE
fix(toolbarFieldGroupVariant): sw-1889 set maxHeight

### DIFF
--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldGroupVariant.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldGroupVariant.test.js.snap
@@ -90,7 +90,7 @@ exports[`ToolbarFieldGroupVariant Component should render a basic component: bas
     isFlipEnabled={false}
     isInline={true}
     isToggleText={true}
-    maxHeight={null}
+    maxHeight={310}
     name={null}
     onSelect={[Function]}
     onSplitButton={[Function]}
@@ -157,7 +157,7 @@ exports[`ToolbarFieldGroupVariant Component should return a standalone component
       isFlipEnabled={false}
       isInline={true}
       isToggleText={true}
-      maxHeight={null}
+      maxHeight={310}
       name={null}
       onSelect={[Function]}
       onSplitButton={[Function]}

--- a/src/components/toolbar/toolbarFieldGroupVariant.js
+++ b/src/components/toolbar/toolbarFieldGroupVariant.js
@@ -120,6 +120,7 @@ const ToolbarFieldGroupVariant = ({
         selectedOptions={updatedValue}
         placeholder={t('curiosity-toolbar.placeholder', { context: [isFilter && 'filter', 'groupVariant'] })}
         position={position}
+        maxHeight={310}
         data-test="toolbarFieldGroupVariant"
       />
     </ToolbarContent>


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(toolbarFieldGroupVariant): sw-1889 set maxHeight

 ### Notes
- the number of variants in the RHEL display has expanded greatly. this applies a select/dropdown max height to implement a scrolling overflow
- this scrollbar should not appear on variant listings, like OpenShift, that do not hit the height requirement
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. navigate towards RHEL `subscriptions/rhel` or some current path under [subscriptions/usage]
   - confirm the dropdown/select displays a scrollbar


### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. confirm tests come back clean

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screen Shot 2023-11-03 at 10 36 03 AM](https://github.com/RedHatInsights/curiosity-frontend/assets/3761375/24978ca7-4af7-480d-b949-2d17d92de080)


### before
![Screen Shot 2023-11-03 at 2 11 35 PM](https://github.com/RedHatInsights/curiosity-frontend/assets/3761375/9ea4da5b-d890-460b-9931-c3040f1adb31)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
related sw-1889 sw-1890 sw-1891 sw-1692