### PR TITLE
fix(chartHelpers): sw-1878 compensate for victory charts textsize

### DIFF
--- a/src/components/chart/__tests__/__snapshots__/chart.test.js.snap
+++ b/src/components/chart/__tests__/__snapshots__/chart.test.js.snap
@@ -36,7 +36,7 @@ exports[`Chart Component should render a basic component: basic 1`] = `
         "themeColor": "blue",
         "tooltipDataSetLookUp": {},
         "xAxisProps": {
-          "fixLabelOverlap": true,
+          "fixLabelOverlap": false,
           "label": null,
           "tickFormat": [Function],
           "tickValues": [],

--- a/src/components/chart/__tests__/__snapshots__/chartHelpers.test.js.snap
+++ b/src/components/chart/__tests__/__snapshots__/chartHelpers.test.js.snap
@@ -3,7 +3,7 @@
 exports[`ChartHelpers should aggregated generated x,y axis props: default settings 1`] = `
 {
   "xAxisProps": {
-    "fixLabelOverlap": true,
+    "fixLabelOverlap": false,
     "label": undefined,
     "tickFormat": [Function],
     "tickValues": [],

--- a/src/components/chart/chartHelpers.js
+++ b/src/components/chart/chartHelpers.js
@@ -357,6 +357,7 @@ const generateYAxisProps = ({ dataSets = [], maxY, yAxisPropDefaults = {}, yAxis
   return axisProps;
 };
 
+// ToDo: review "allowLabelOverlap" on victory package updates, victory charts missing param guard, swatch-1878
 /**
  * Generate x,y props.
  *
@@ -380,19 +381,25 @@ const generateAxisProps = ({
   maxY,
   xAxisChartLabel,
   yAxisChartLabel,
-  xAxisFixLabelOverlap = true,
+  xAxisFixLabelOverlap,
   xAxisLabelIncrement = 1,
   xAxisTickFormat,
   yAxisTickFormat
 } = {}) => {
   const xAxisPropDefaults = {
-    fixLabelOverlap: xAxisFixLabelOverlap
+    fixLabelOverlap: false
   };
 
   const yAxisPropDefaults = {
     dependentAxis: true,
     showGrid: true
   };
+
+  const allowLabelOverlap = dataSets.filter(({ data }) => data?.length > 0).length > 0;
+
+  if (allowLabelOverlap && xAxisFixLabelOverlap === true) {
+    xAxisPropDefaults.fixLabelOverlap = true;
+  }
 
   let yAxisDataSets = [];
   let xAxisDataSet;


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(chartHelpers): sw-1878 compensate for victory charts textsize

### Notes
- we think the culprit is some aspect of victory charts helper for textsize "measureDimensionsInternal" missing a param guard for an empty string/data. Our solution confirms any data exists before attempting a label overlap
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then

BEFORE YOU UPDATE TO THIS PATCH, confirm the issue exists
1. `$ yarn start:proxy`
1. log out/in - THIS IS REQUIRED to see the issue
1. open the path to Subs RHEL
1. use the left nav to navigate towards Subs OpenShift
1. an error warning related to victory charts should appear

AFTER YOU'VE confirmed sync with this patch
1. `$ yarn start:proxy`
1. log out/in - THIS IS REQUIRED to see the issue
1. open the path to Subs RHEL
1. use the left nav to navigate towards Subs OpenShift
1. the error should no longer appear, instead the graph should load and then dependent on API and GUI response load individual graph facets/data
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-1878