### PR TITLE
fix(rhods): sw-2000 data science to ai title

### DIFF
--- a/public/locales/en-US.json
+++ b/public/locales/en-US.json
@@ -418,7 +418,7 @@
     "title_rhacs": "Red Hat Advanced Cluster Security for Kubernetes",
     "subtitle_rhacs": "Monitor your usage for On-Demand subscriptions. <0>Learn more about {{appName}} reporting</0>",
     "description_rhacs": "Monitor your usage for On-Demand subscriptions.",
-    "title_rhods": "Red Hat OpenShift Data Science",
+    "title_rhods": "Red Hat OpenShift AI",
     "subtitle_rhods": "$t(curiosity-view.subtitle_rhacs)",
     "description_rhods": "$t(curiosity-view.description_rhacs)",
     "title_rhel": "$t(curiosity-view.title_RHEL)",


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(rhods): sw-2000 data science to ai title

### Notes
- minor title update
   - appears we only used `Data Science` in a single location
- separate repo for left nav update

<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start`
1. confirm page title displays as `Red Hat OpenShift AI`

<!--
### Proxy run check
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, plus on network, then
1. `$ yarn start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screen Shot 2023-12-06 at 10 09 13 AM](https://github.com/RedHatInsights/curiosity-frontend/assets/3761375/18a7a22b-e330-4a84-965f-eebf5614ecca)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-2000