### PR TITLE
refactor(config): sw-1987 testing, numeric inventory cells

### DIFF
--- a/src/config/__tests__/__snapshots__/product.config.test.js.snap
+++ b/src/config/__tests__/__snapshots__/product.config.test.js.snap
@@ -3504,7 +3504,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {})",
+              "content": "t(curiosity-inventory.measurement, {"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"instances-cell-undefined","data-value":"undefined"},"_owner":null,"_store":{}}})",
               "dataLabel": "t(curiosity-inventory.header, {"context":"OpenShift Container Platform"})",
               "header": [Function],
               "isSort": true,
@@ -3601,7 +3601,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {})",
+              "content": "t(curiosity-inventory.measurement, {"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"instances-cell-Cores","data-value":"undefined"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_Cores,curiosity-inventory.guestsHeader_Cores], {"context":"OpenShift-dedicated-metrics"})",
               "header": [Function],
               "isSort": true,
@@ -3610,7 +3610,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": 15,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {})",
+              "content": "t(curiosity-inventory.measurement, {"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"instances-cell-Instance-hours","data-value":"undefined"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_Instance-hours,curiosity-inventory.guestsHeader_Instance-hours], {"context":"OpenShift-dedicated-metrics"})",
               "header": [Function],
               "isSort": true,
@@ -3696,7 +3696,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {})",
+              "content": "t(curiosity-inventory.measurement, {"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"instances-cell-Cores","data-value":"undefined"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_Cores,curiosity-inventory.guestsHeader_Cores], {"context":"OpenShift-metrics"})",
               "header": [Function],
               "isSort": true,
@@ -3805,7 +3805,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": 15,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {})",
+              "content": "t(curiosity-inventory.measurement, {"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"instances-cell-Cores","data-value":"undefined"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_Cores,curiosity-inventory.guestsHeader_Cores], {"context":"rhacs"})",
               "header": [Function],
               "isSort": true,
@@ -3914,7 +3914,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {})",
+              "content": "t(curiosity-inventory.measurement, {"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"instances-cell-number_of_guests","data-value":"undefined"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_number_of_guests,curiosity-inventory.guestsHeader_number_of_guests], {"context":"RHEL for x86"})",
               "header": [Function],
               "isSort": true,
@@ -3939,7 +3939,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": 20,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {})",
+              "content": "t(curiosity-inventory.measurement, {"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"instances-cell-Sockets","data-value":"undefined"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_Sockets,curiosity-inventory.guestsHeader_Sockets], {"context":"RHEL for x86"})",
               "header": [Function],
               "isSort": true,
@@ -4140,7 +4140,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": 15,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {})",
+              "content": "t(curiosity-inventory.measurement, {"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"instances-cell-Cores","data-value":"undefined"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_Cores,curiosity-inventory.guestsHeader_Cores], {"context":"rhods"})",
               "header": [Function],
               "isSort": true,
@@ -4233,7 +4233,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {})",
+              "content": "t(curiosity-inventory.measurement, {"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"instances-cell-Cores","data-value":"undefined"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_Cores,curiosity-inventory.guestsHeader_Cores], {"context":"rosa"})",
               "header": [Function],
               "isSort": true,
@@ -4242,7 +4242,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": 15,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {})",
+              "content": "t(curiosity-inventory.measurement, {"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"instances-cell-Instance-hours","data-value":"undefined"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_Instance-hours,curiosity-inventory.guestsHeader_Instance-hours], {"context":"rosa"})",
               "header": [Function],
               "isSort": true,
@@ -4351,7 +4351,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {})",
+              "content": "t(curiosity-inventory.measurement, {"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"instances-cell-number_of_guests","data-value":"undefined"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_number_of_guests,curiosity-inventory.guestsHeader_number_of_guests], {"context":"Satellite Server"})",
               "header": [Function],
               "isSort": true,
@@ -4376,7 +4376,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": 20,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {})",
+              "content": "t(curiosity-inventory.measurement, {"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"instances-cell-Sockets","data-value":"undefined"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_Sockets,curiosity-inventory.guestsHeader_Sockets], {"context":"Satellite Server"})",
               "header": [Function],
               "isSort": true,
@@ -4481,7 +4481,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {})",
+              "content": "t(curiosity-inventory.measurement, {"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"instances-cell-undefined","data-value":"undefined"},"_owner":null,"_store":{}}})",
               "dataLabel": "t(curiosity-inventory.header, {"context":"OpenShift Container Platform"})",
               "header": [Function],
               "isSort": true,
@@ -4578,7 +4578,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {})",
+              "content": "t(curiosity-inventory.measurement, {"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"instances-cell-Cores","data-value":"undefined"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_Cores,curiosity-inventory.guestsHeader_Cores], {"context":"OpenShift-dedicated-metrics"})",
               "header": [Function],
               "isSort": true,
@@ -4587,7 +4587,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": 15,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {})",
+              "content": "t(curiosity-inventory.measurement, {"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"instances-cell-Instance-hours","data-value":"undefined"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_Instance-hours,curiosity-inventory.guestsHeader_Instance-hours], {"context":"OpenShift-dedicated-metrics"})",
               "header": [Function],
               "isSort": true,
@@ -4673,7 +4673,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {})",
+              "content": "t(curiosity-inventory.measurement, {"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"instances-cell-Cores","data-value":"undefined"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_Cores,curiosity-inventory.guestsHeader_Cores], {"context":"OpenShift-metrics"})",
               "header": [Function],
               "isSort": true,
@@ -4775,7 +4775,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": 15,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {})",
+              "content": "t(curiosity-inventory.measurement, {"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"instances-cell-Cores","data-value":"undefined"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_Cores,curiosity-inventory.guestsHeader_Cores], {"context":"rhacs"})",
               "header": [Function],
               "isSort": true,
@@ -4877,7 +4877,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {})",
+              "content": "t(curiosity-inventory.measurement, {"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"instances-cell-number_of_guests","data-value":"undefined"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_number_of_guests,curiosity-inventory.guestsHeader_number_of_guests], {"context":"RHEL for x86"})",
               "header": [Function],
               "isSort": true,
@@ -4902,7 +4902,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": 20,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {})",
+              "content": "t(curiosity-inventory.measurement, {"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"instances-cell-Sockets","data-value":"undefined"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_Sockets,curiosity-inventory.guestsHeader_Sockets], {"context":"RHEL for x86"})",
               "header": [Function],
               "isSort": true,
@@ -5103,7 +5103,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": 15,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {})",
+              "content": "t(curiosity-inventory.measurement, {"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"instances-cell-Cores","data-value":"undefined"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_Cores,curiosity-inventory.guestsHeader_Cores], {"context":"rhods"})",
               "header": [Function],
               "isSort": true,
@@ -5196,7 +5196,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {})",
+              "content": "t(curiosity-inventory.measurement, {"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"instances-cell-Cores","data-value":"undefined"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_Cores,curiosity-inventory.guestsHeader_Cores], {"context":"rosa"})",
               "header": [Function],
               "isSort": true,
@@ -5205,7 +5205,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": 15,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {})",
+              "content": "t(curiosity-inventory.measurement, {"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"instances-cell-Instance-hours","data-value":"undefined"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_Instance-hours,curiosity-inventory.guestsHeader_Instance-hours], {"context":"rosa"})",
               "header": [Function],
               "isSort": true,
@@ -5307,7 +5307,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {})",
+              "content": "t(curiosity-inventory.measurement, {"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"instances-cell-number_of_guests","data-value":"undefined"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_number_of_guests,curiosity-inventory.guestsHeader_number_of_guests], {"context":"Satellite Server"})",
               "header": [Function],
               "isSort": true,
@@ -5332,7 +5332,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": 20,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {})",
+              "content": "t(curiosity-inventory.measurement, {"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"instances-cell-Sockets","data-value":"undefined"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_Sockets,curiosity-inventory.guestsHeader_Sockets], {"context":"Satellite Server"})",
               "header": [Function],
               "isSort": true,
@@ -5453,7 +5453,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": 15,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {"context":"value","total":1})",
+              "content": "t(curiosity-inventory.measurement, {"context":"value","total":1,"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"subscriptions-cell-quantity","data-value":"1"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_quantity,curiosity-inventory.guestsHeader_quantity], {"context":"OpenShift Container Platform"})",
               "header": [Function],
               "isSort": true,
@@ -5615,7 +5615,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": 15,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {"context":"value","total":1})",
+              "content": "t(curiosity-inventory.measurement, {"context":"value","total":1,"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"subscriptions-cell-quantity","data-value":"1"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_quantity,curiosity-inventory.guestsHeader_quantity], {"context":"rhacs"})",
               "header": [Function],
               "isSort": true,
@@ -5742,7 +5742,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": 15,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {"context":"value","total":1})",
+              "content": "t(curiosity-inventory.measurement, {"context":"value","total":1,"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"subscriptions-cell-quantity","data-value":"1"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_quantity,curiosity-inventory.guestsHeader_quantity], {"context":"RHEL for x86"})",
               "header": [Function],
               "isSort": true,
@@ -5904,7 +5904,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": 15,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {"context":"value","total":1})",
+              "content": "t(curiosity-inventory.measurement, {"context":"value","total":1,"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"subscriptions-cell-quantity","data-value":"1"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_quantity,curiosity-inventory.guestsHeader_quantity], {"context":"rhel-for-x86-els-payg"})",
               "header": [Function],
               "isSort": true,
@@ -6050,7 +6050,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": 15,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {"context":"value","total":1})",
+              "content": "t(curiosity-inventory.measurement, {"context":"value","total":1,"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"subscriptions-cell-quantity","data-value":"1"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_quantity,curiosity-inventory.guestsHeader_quantity], {"context":"rhods"})",
               "header": [Function],
               "isSort": true,
@@ -6146,7 +6146,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {"context":"value","total":1})",
+              "content": "t(curiosity-inventory.measurement, {"context":"value","total":1,"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"subscriptions-cell-quantity","data-value":"1"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_quantity,curiosity-inventory.guestsHeader_quantity], {"context":"rosa"})",
               "header": [Function],
               "isSort": true,
@@ -6280,7 +6280,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": 15,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {"context":"value","total":1})",
+              "content": "t(curiosity-inventory.measurement, {"context":"value","total":1,"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"subscriptions-cell-quantity","data-value":"1"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_quantity,curiosity-inventory.guestsHeader_quantity], {"context":"OpenShift Container Platform"})",
               "header": [Function],
               "isSort": true,
@@ -6442,7 +6442,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": 15,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {"context":"value","total":1})",
+              "content": "t(curiosity-inventory.measurement, {"context":"value","total":1,"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"subscriptions-cell-quantity","data-value":"1"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_quantity,curiosity-inventory.guestsHeader_quantity], {"context":"rhacs"})",
               "header": [Function],
               "isSort": true,
@@ -6569,7 +6569,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": 15,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {"context":"value","total":1})",
+              "content": "t(curiosity-inventory.measurement, {"context":"value","total":1,"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"subscriptions-cell-quantity","data-value":"1"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_quantity,curiosity-inventory.guestsHeader_quantity], {"context":"RHEL for x86"})",
               "header": [Function],
               "isSort": true,
@@ -6731,7 +6731,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": 15,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {"context":"value","total":1})",
+              "content": "t(curiosity-inventory.measurement, {"context":"value","total":1,"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"subscriptions-cell-quantity","data-value":"1"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_quantity,curiosity-inventory.guestsHeader_quantity], {"context":"rhel-for-x86-els-payg"})",
               "header": [Function],
               "isSort": true,
@@ -6877,7 +6877,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": 15,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {"context":"value","total":1})",
+              "content": "t(curiosity-inventory.measurement, {"context":"value","total":1,"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"subscriptions-cell-quantity","data-value":"1"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_quantity,curiosity-inventory.guestsHeader_quantity], {"context":"rhods"})",
               "header": [Function],
               "isSort": true,
@@ -6973,7 +6973,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.measurement, {"context":"value","total":1})",
+              "content": "t(curiosity-inventory.measurement, {"context":"value","total":1,"testId":{"type":"span","key":null,"ref":null,"props":{"data-test":"subscriptions-cell-quantity","data-value":"1"},"_owner":null,"_store":{}}})",
               "dataLabel": "t([curiosity-inventory.header_quantity,curiosity-inventory.guestsHeader_quantity], {"context":"rosa"})",
               "header": [Function],
               "isSort": true,

--- a/src/config/product.openshiftContainer.js
+++ b/src/config/product.openshiftContainer.js
@@ -241,7 +241,8 @@ const config = {
         const total = data?.[uom];
         return translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
-          total
+          total,
+          testId: <span data-test={`inventory-cell-${uom}`} data-value={total} />
         });
       },
       isSort: true,
@@ -284,7 +285,8 @@ const config = {
       cell: ({ [SUBSCRIPTIONS_INVENTORY_TYPES.QUANTITY]: total } = {}) =>
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
-          total
+          total,
+          testId: <span data-test={`inventory-cell-${SUBSCRIPTIONS_INVENTORY_TYPES.QUANTITY}`} data-value={total} />
         }),
       isSort: true,
       isWrap: true,
@@ -311,7 +313,10 @@ const config = {
         }
         return translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
-          total
+          total,
+          testId: (
+            <span data-test={`inventory-cell-${SUBSCRIPTIONS_INVENTORY_TYPES.TOTAL_CAPACITY}`} data-value={total} />
+          )
         });
       },
       isSort: true,

--- a/src/config/product.openshiftContainer.js
+++ b/src/config/product.openshiftContainer.js
@@ -242,7 +242,7 @@ const config = {
         return translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
           total,
-          testId: <span data-test={`inventory-cell-${uom}`} data-value={total} />
+          testId: <span data-test={`instances-cell-${uom}`} data-value={`${total}`} />
         });
       },
       isSort: true,
@@ -286,7 +286,9 @@ const config = {
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
           total,
-          testId: <span data-test={`inventory-cell-${SUBSCRIPTIONS_INVENTORY_TYPES.QUANTITY}`} data-value={total} />
+          testId: (
+            <span data-test={`subscriptions-cell-${SUBSCRIPTIONS_INVENTORY_TYPES.QUANTITY}`} data-value={`${total}`} />
+          )
         }),
       isSort: true,
       isWrap: true,
@@ -315,7 +317,10 @@ const config = {
           context: (total && 'value') || undefined,
           total,
           testId: (
-            <span data-test={`inventory-cell-${SUBSCRIPTIONS_INVENTORY_TYPES.TOTAL_CAPACITY}`} data-value={total} />
+            <span
+              data-test={`subscriptions-cell-${SUBSCRIPTIONS_INVENTORY_TYPES.TOTAL_CAPACITY}`}
+              data-value={`${total}`}
+            />
           )
         });
       },

--- a/src/config/product.openshiftDedicated.js
+++ b/src/config/product.openshiftDedicated.js
@@ -275,7 +275,8 @@ const config = {
       cell: ({ [RHSM_API_PATH_METRIC_TYPES.CORES]: total } = {}) =>
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
-          total: (total && Number.parseFloat(total).toFixed(2)) || undefined
+          total: (total && Number.parseFloat(total).toFixed(2)) || undefined,
+          testId: <span data-test={`inventory-cell-${RHSM_API_PATH_METRIC_TYPES.CORES}`} data-value={total} />
         }),
       isSort: true,
       isWrap: true,
@@ -286,7 +287,8 @@ const config = {
       cell: ({ [RHSM_API_PATH_METRIC_TYPES.INSTANCE_HOURS]: total } = {}) =>
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
-          total: (total && Number.parseFloat(total).toFixed(2)) || undefined
+          total: (total && Number.parseFloat(total).toFixed(2)) || undefined,
+          testId: <span data-test={`inventory-cell-${RHSM_API_PATH_METRIC_TYPES.INSTANCE_HOURS}`} data-value={total} />
         }),
       isSort: true,
       isWrap: true,

--- a/src/config/product.openshiftDedicated.js
+++ b/src/config/product.openshiftDedicated.js
@@ -276,7 +276,7 @@ const config = {
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
           total: (total && Number.parseFloat(total).toFixed(2)) || undefined,
-          testId: <span data-test={`inventory-cell-${RHSM_API_PATH_METRIC_TYPES.CORES}`} data-value={total} />
+          testId: <span data-test={`instances-cell-${RHSM_API_PATH_METRIC_TYPES.CORES}`} data-value={`${total}`} />
         }),
       isSort: true,
       isWrap: true,
@@ -288,7 +288,9 @@ const config = {
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
           total: (total && Number.parseFloat(total).toFixed(2)) || undefined,
-          testId: <span data-test={`inventory-cell-${RHSM_API_PATH_METRIC_TYPES.INSTANCE_HOURS}`} data-value={total} />
+          testId: (
+            <span data-test={`instances-cell-${RHSM_API_PATH_METRIC_TYPES.INSTANCE_HOURS}`} data-value={`${total}`} />
+          )
         }),
       isSort: true,
       isWrap: true,

--- a/src/config/product.openshiftMetrics.js
+++ b/src/config/product.openshiftMetrics.js
@@ -266,7 +266,8 @@ const config = {
       cell: ({ [RHSM_API_PATH_METRIC_TYPES.CORES]: total } = {}) =>
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
-          total: (total && Number.parseFloat(total).toFixed(2)) || undefined
+          total: (total && Number.parseFloat(total).toFixed(2)) || undefined,
+          testId: <span data-test={`inventory-cell-${RHSM_API_PATH_METRIC_TYPES.CORES}`} data-value={total} />
         }),
       isSort: true,
       isWrap: true,

--- a/src/config/product.openshiftMetrics.js
+++ b/src/config/product.openshiftMetrics.js
@@ -267,7 +267,7 @@ const config = {
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
           total: (total && Number.parseFloat(total).toFixed(2)) || undefined,
-          testId: <span data-test={`inventory-cell-${RHSM_API_PATH_METRIC_TYPES.CORES}`} data-value={total} />
+          testId: <span data-test={`instances-cell-${RHSM_API_PATH_METRIC_TYPES.CORES}`} data-value={`${total}`} />
         }),
       isSort: true,
       isWrap: true,

--- a/src/config/product.rhacs.js
+++ b/src/config/product.rhacs.js
@@ -227,7 +227,7 @@ const config = {
         translate('curiosity-inventory.measurement', {
           context: (total && RHSM_API_PATH_METRIC_TYPES.CORES) || undefined,
           total: helpers.numberDisplay(total)?.format({ mantissa: 5, trimMantissa: true }),
-          testId: <span data-test={`inventory-cell-${RHSM_API_PATH_METRIC_TYPES.CORES}`} data-value={total} />
+          testId: <span data-test={`instances-cell-${RHSM_API_PATH_METRIC_TYPES.CORES}`} data-value={`${total}`} />
         }),
       isSort: true,
       isWrap: true,
@@ -280,7 +280,9 @@ const config = {
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
           total,
-          testId: <span data-test={`inventory-cell-${SUBSCRIPTIONS_INVENTORY_TYPES.QUANTITY}`} data-value={total} />
+          testId: (
+            <span data-test={`subscriptions-cell-${SUBSCRIPTIONS_INVENTORY_TYPES.QUANTITY}`} data-value={`${total}`} />
+          )
         }),
       isSort: true,
       isWrap: true,

--- a/src/config/product.rhacs.js
+++ b/src/config/product.rhacs.js
@@ -226,7 +226,8 @@ const config = {
       cell: ({ [RHSM_API_PATH_METRIC_TYPES.CORES]: total }) =>
         translate('curiosity-inventory.measurement', {
           context: (total && RHSM_API_PATH_METRIC_TYPES.CORES) || undefined,
-          total: helpers.numberDisplay(total)?.format({ mantissa: 5, trimMantissa: true })
+          total: helpers.numberDisplay(total)?.format({ mantissa: 5, trimMantissa: true }),
+          testId: <span data-test={`inventory-cell-${RHSM_API_PATH_METRIC_TYPES.CORES}`} data-value={total} />
         }),
       isSort: true,
       isWrap: true,
@@ -278,7 +279,8 @@ const config = {
       cell: ({ [SUBSCRIPTIONS_INVENTORY_TYPES.QUANTITY]: total } = {}) =>
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
-          total
+          total,
+          testId: <span data-test={`inventory-cell-${SUBSCRIPTIONS_INVENTORY_TYPES.QUANTITY}`} data-value={total} />
         }),
       isSort: true,
       isWrap: true,

--- a/src/config/product.rhel.js
+++ b/src/config/product.rhel.js
@@ -239,7 +239,8 @@ const config = {
       cell: ({ [INVENTORY_TYPES.NUMBER_OF_GUESTS]: total } = {}) =>
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
-          total
+          total,
+          testId: <span data-test={`inventory-cell-${INVENTORY_TYPES.NUMBER_OF_GUESTS}`} data-value={total} />
         }),
       isSort: true,
       isWrap: true,
@@ -268,7 +269,8 @@ const config = {
       cell: ({ [RHSM_API_PATH_METRIC_TYPES.SOCKETS]: total } = {}) =>
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
-          total
+          total,
+          testId: <span data-test={`inventory-cell-${RHSM_API_PATH_METRIC_TYPES.SOCKETS}`} data-value={total} />
         }),
       isSort: true,
       isWrap: true,
@@ -310,7 +312,8 @@ const config = {
       cell: ({ [SUBSCRIPTIONS_INVENTORY_TYPES.QUANTITY]: total } = {}) =>
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
-          total
+          total,
+          testId: <span data-test={`inventory-cell-${SUBSCRIPTIONS_INVENTORY_TYPES.QUANTITY}`} data-value={total} />
         }),
       isSort: true,
       isWrap: true,
@@ -338,7 +341,10 @@ const config = {
         }
         return translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
-          total
+          total,
+          testId: (
+            <span data-test={`inventory-cell-${SUBSCRIPTIONS_INVENTORY_TYPES.TOTAL_CAPACITY}`} data-value={total} />
+          )
         });
       },
       isSort: true,

--- a/src/config/product.rhel.js
+++ b/src/config/product.rhel.js
@@ -240,7 +240,7 @@ const config = {
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
           total,
-          testId: <span data-test={`inventory-cell-${INVENTORY_TYPES.NUMBER_OF_GUESTS}`} data-value={total} />
+          testId: <span data-test={`instances-cell-${INVENTORY_TYPES.NUMBER_OF_GUESTS}`} data-value={`${total}`} />
         }),
       isSort: true,
       isWrap: true,
@@ -270,7 +270,7 @@ const config = {
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
           total,
-          testId: <span data-test={`inventory-cell-${RHSM_API_PATH_METRIC_TYPES.SOCKETS}`} data-value={total} />
+          testId: <span data-test={`instances-cell-${RHSM_API_PATH_METRIC_TYPES.SOCKETS}`} data-value={`${total}`} />
         }),
       isSort: true,
       isWrap: true,
@@ -313,7 +313,9 @@ const config = {
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
           total,
-          testId: <span data-test={`inventory-cell-${SUBSCRIPTIONS_INVENTORY_TYPES.QUANTITY}`} data-value={total} />
+          testId: (
+            <span data-test={`subscriptions-cell-${SUBSCRIPTIONS_INVENTORY_TYPES.QUANTITY}`} data-value={`${total}`} />
+          )
         }),
       isSort: true,
       isWrap: true,
@@ -343,7 +345,10 @@ const config = {
           context: (total && 'value') || undefined,
           total,
           testId: (
-            <span data-test={`inventory-cell-${SUBSCRIPTIONS_INVENTORY_TYPES.TOTAL_CAPACITY}`} data-value={total} />
+            <span
+              data-test={`subscriptions-cell-${SUBSCRIPTIONS_INVENTORY_TYPES.TOTAL_CAPACITY}`}
+              data-value={`${total}`}
+            />
           )
         });
       },

--- a/src/config/product.rhelElsPayg.js
+++ b/src/config/product.rhelElsPayg.js
@@ -227,7 +227,7 @@ const config = {
         translate('curiosity-inventory.measurement', {
           context: (total && RHSM_API_PATH_METRIC_TYPES.VCPUS) || undefined,
           total: helpers.numberDisplay(total)?.format({ mantissa: 5, trimMantissa: true }),
-          testId: <span data-test={`inventory-cell-${RHSM_API_PATH_METRIC_TYPES.VCPUS}`} data-value={total} />
+          testId: <span data-test={`instances-cell-${RHSM_API_PATH_METRIC_TYPES.VCPUS}`} data-value={`${total}`} />
         }),
       isSort: true,
       isWrap: true,
@@ -280,7 +280,9 @@ const config = {
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
           total,
-          testId: <span data-test={`inventory-cell-${SUBSCRIPTIONS_INVENTORY_TYPES.QUANTITY}`} data-value={total} />
+          testId: (
+            <span data-test={`subscriptions-cell-${SUBSCRIPTIONS_INVENTORY_TYPES.QUANTITY}`} data-value={`${total}`} />
+          )
         }),
       isSort: true,
       isWrap: true,

--- a/src/config/product.rhelElsPayg.js
+++ b/src/config/product.rhelElsPayg.js
@@ -226,7 +226,8 @@ const config = {
         (!total && '--') ||
         translate('curiosity-inventory.measurement', {
           context: (total && RHSM_API_PATH_METRIC_TYPES.VCPUS) || undefined,
-          total: helpers.numberDisplay(total)?.format({ mantissa: 5, trimMantissa: true })
+          total: helpers.numberDisplay(total)?.format({ mantissa: 5, trimMantissa: true }),
+          testId: <span data-test={`inventory-cell-${RHSM_API_PATH_METRIC_TYPES.VCPUS}`} data-value={total} />
         }),
       isSort: true,
       isWrap: true,
@@ -278,7 +279,8 @@ const config = {
       cell: ({ [SUBSCRIPTIONS_INVENTORY_TYPES.QUANTITY]: total } = {}) =>
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
-          total
+          total,
+          testId: <span data-test={`inventory-cell-${SUBSCRIPTIONS_INVENTORY_TYPES.QUANTITY}`} data-value={total} />
         }),
       isSort: true,
       isWrap: true,

--- a/src/config/product.rhods.js
+++ b/src/config/product.rhods.js
@@ -228,7 +228,7 @@ const config = {
         translate('curiosity-inventory.measurement', {
           context: (total && RHSM_API_PATH_METRIC_TYPES.CORES) || undefined,
           total: helpers.numberDisplay(total)?.format({ mantissa: 5, trimMantissa: true }),
-          testId: <span data-test={`inventory-cell-${RHSM_API_PATH_METRIC_TYPES.CORES}`} data-value={total} />
+          testId: <span data-test={`instances-cell-${RHSM_API_PATH_METRIC_TYPES.CORES}`} data-value={`${total}`} />
         }),
       isSort: true,
       isWrap: true,
@@ -281,7 +281,9 @@ const config = {
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
           total,
-          testId: <span data-test={`inventory-cell-${SUBSCRIPTIONS_INVENTORY_TYPES.QUANTITY}`} data-value={total} />
+          testId: (
+            <span data-test={`subscriptions-cell-${SUBSCRIPTIONS_INVENTORY_TYPES.QUANTITY}`} data-value={`${total}`} />
+          )
         }),
       isSort: true,
       isWrap: true,

--- a/src/config/product.rhods.js
+++ b/src/config/product.rhods.js
@@ -227,7 +227,8 @@ const config = {
       cell: ({ [RHSM_API_PATH_METRIC_TYPES.CORES]: total }) =>
         translate('curiosity-inventory.measurement', {
           context: (total && RHSM_API_PATH_METRIC_TYPES.CORES) || undefined,
-          total: helpers.numberDisplay(total)?.format({ mantissa: 5, trimMantissa: true })
+          total: helpers.numberDisplay(total)?.format({ mantissa: 5, trimMantissa: true }),
+          testId: <span data-test={`inventory-cell-${RHSM_API_PATH_METRIC_TYPES.CORES}`} data-value={total} />
         }),
       isSort: true,
       isWrap: true,
@@ -279,7 +280,8 @@ const config = {
       cell: ({ [SUBSCRIPTIONS_INVENTORY_TYPES.QUANTITY]: total } = {}) =>
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
-          total
+          total,
+          testId: <span data-test={`inventory-cell-${SUBSCRIPTIONS_INVENTORY_TYPES.QUANTITY}`} data-value={total} />
         }),
       isSort: true,
       isWrap: true,

--- a/src/config/product.rosa.js
+++ b/src/config/product.rosa.js
@@ -282,7 +282,8 @@ const config = {
       cell: ({ [RHSM_API_PATH_METRIC_TYPES.CORES]: total } = {}) =>
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
-          total: (total && Number.parseFloat(total).toFixed(2)) || undefined
+          total: (total && Number.parseFloat(total).toFixed(2)) || undefined,
+          testId: <span data-test={`inventory-cell-${RHSM_API_PATH_METRIC_TYPES.CORES}`} data-value={total} />
         }),
       isSort: true,
       isWrap: true,
@@ -293,7 +294,8 @@ const config = {
       cell: ({ [RHSM_API_PATH_METRIC_TYPES.INSTANCE_HOURS]: total } = {}) =>
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
-          total: (total && Number.parseFloat(total).toFixed(2)) || undefined
+          total: (total && Number.parseFloat(total).toFixed(2)) || undefined,
+          testId: <span data-test={`inventory-cell-${RHSM_API_PATH_METRIC_TYPES.INSTANCE_HOURS}`} data-value={total} />
         }),
       isSort: true,
       isWrap: true,
@@ -329,7 +331,8 @@ const config = {
       cell: ({ [SUBSCRIPTIONS_INVENTORY_TYPES.QUANTITY]: total } = {}) =>
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
-          total
+          total,
+          testId: <span data-test={`inventory-cell-${SUBSCRIPTIONS_INVENTORY_TYPES.QUANTITY}`} data-value={total} />
         }),
       isSort: true,
       isWrap: true,

--- a/src/config/product.rosa.js
+++ b/src/config/product.rosa.js
@@ -283,7 +283,7 @@ const config = {
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
           total: (total && Number.parseFloat(total).toFixed(2)) || undefined,
-          testId: <span data-test={`inventory-cell-${RHSM_API_PATH_METRIC_TYPES.CORES}`} data-value={total} />
+          testId: <span data-test={`instances-cell-${RHSM_API_PATH_METRIC_TYPES.CORES}`} data-value={`${total}`} />
         }),
       isSort: true,
       isWrap: true,
@@ -295,7 +295,9 @@ const config = {
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
           total: (total && Number.parseFloat(total).toFixed(2)) || undefined,
-          testId: <span data-test={`inventory-cell-${RHSM_API_PATH_METRIC_TYPES.INSTANCE_HOURS}`} data-value={total} />
+          testId: (
+            <span data-test={`instances-cell-${RHSM_API_PATH_METRIC_TYPES.INSTANCE_HOURS}`} data-value={`${total}`} />
+          )
         }),
       isSort: true,
       isWrap: true,
@@ -332,7 +334,9 @@ const config = {
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
           total,
-          testId: <span data-test={`inventory-cell-${SUBSCRIPTIONS_INVENTORY_TYPES.QUANTITY}`} data-value={total} />
+          testId: (
+            <span data-test={`subscriptions-cell-${SUBSCRIPTIONS_INVENTORY_TYPES.QUANTITY}`} data-value={`${total}`} />
+          )
         }),
       isSort: true,
       isWrap: true,

--- a/src/config/product.satellite.js
+++ b/src/config/product.satellite.js
@@ -216,7 +216,8 @@ const config = {
       cell: ({ [INVENTORY_TYPES.NUMBER_OF_GUESTS]: total } = {}) =>
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
-          total
+          total,
+          testId: <span data-test={`inventory-cell-${INVENTORY_TYPES.NUMBER_OF_GUESTS}`} data-value={total} />
         }),
       isSort: true,
       isWrap: true,
@@ -245,7 +246,8 @@ const config = {
       cell: ({ [RHSM_API_PATH_METRIC_TYPES.SOCKETS]: total } = {}) =>
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
-          total
+          total,
+          testId: <span data-test={`inventory-cell-${RHSM_API_PATH_METRIC_TYPES.SOCKETS}`} data-value={total} />
         }),
       isSort: true,
       isWrap: true,

--- a/src/config/product.satellite.js
+++ b/src/config/product.satellite.js
@@ -217,7 +217,7 @@ const config = {
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
           total,
-          testId: <span data-test={`inventory-cell-${INVENTORY_TYPES.NUMBER_OF_GUESTS}`} data-value={total} />
+          testId: <span data-test={`instances-cell-${INVENTORY_TYPES.NUMBER_OF_GUESTS}`} data-value={`${total}`} />
         }),
       isSort: true,
       isWrap: true,
@@ -247,7 +247,7 @@ const config = {
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
           total,
-          testId: <span data-test={`inventory-cell-${RHSM_API_PATH_METRIC_TYPES.SOCKETS}`} data-value={total} />
+          testId: <span data-test={`instances-cell-${RHSM_API_PATH_METRIC_TYPES.SOCKETS}`} data-value={`${total}`} />
         }),
       isSort: true,
       isWrap: true,


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- refactor(config): sw-1987 testing, numeric inventory cells

### Notes
- expose all inventory numeric cell values under a `data-value` and associated `data-test=[instances|subscriptions]-cell-[field name]` attributes on a surrounding `<span />` tag
- LIMITATIONS
   - currently we do not include the row count anywhere in the display
   - if a value is `undefined` it will display as the string `undefined`... this shouldn't happen, ~but we planned for it~ but this is the expected result if it happens
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. open each product view and confirm that `data-test` and `data-value` appear on a `<span />` tag wrapped around numeric inventory content


### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure Docker is running, plus on network, then
1. `$ npm run start:proxy`
1. open each product view and confirm that `data-test` and `data-value` appear on a `<span />` tag wrapped around numeric inventory content
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
Instances inventory cells
```
<span
    data-test="instances-cell-[field or metric id]"
    data-value="[original value]"
>
    [numeric display string]
</span>
```
Subscriptions inventory cells
```
<span
    data-test="subscriptions-cell-[field or metric id]"
    data-value="[original value]"
>
    [numeric display string]
</span>
```

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-1987