### PR TITLE
fix(useReactRedux): memoize selector callback

### DIFF
--- a/src/redux/hooks/__tests__/useReactRedux.test.js
+++ b/src/redux/hooks/__tests__/useReactRedux.test.js
@@ -9,16 +9,24 @@ describe('useReactRedux', () => {
   it('should create a selector from multiple selectors', () => {
     const mockSelectorOne = jest.fn().mockImplementation(({ lorem }) => lorem);
     const mockSelectorTwo = jest.fn().mockImplementation(({ dolor }) => dolor);
-    const mockCallback = (...args) => args;
+    const mockCallback = jest.fn().mockImplementation((...args) => args);
     const results = reactReduxHooks.createSimpleSelector([mockSelectorOne, mockSelectorTwo], mockCallback);
 
     // confirm memoize
     const output = results({ lorem: 'ipsum', dolor: 'sit' });
+    results({ lorem: 'ipsum', dolor: 'sit' });
+    results({ lorem: 'ipsum', dolor: 'sit' });
     expect(output === results({ lorem: 'ipsum', dolor: 'sit' })).toBe(true);
+    expect(mockCallback).toHaveBeenCalledTimes(1);
 
     // confirm memoize
     results({ lorem: 'ipsum', dolor: 'sit', hello: 'world' });
+    results({ lorem: 'ipsum', dolor: 'sit', hello: 'world' });
+    expect(mockCallback).toHaveBeenCalledTimes(2);
+
+    // confirm memoize
     expect(output === results({ lorem: 'ipsum', dolor: 'sit' })).toBe(false);
+    expect(mockCallback).toHaveBeenCalledTimes(3);
 
     expect(output).toMatchSnapshot('createSimpleSelector, callback');
   });

--- a/src/redux/hooks/__tests__/useReactRedux.test.js
+++ b/src/redux/hooks/__tests__/useReactRedux.test.js
@@ -20,13 +20,17 @@ describe('useReactRedux', () => {
     expect(mockCallback).toHaveBeenCalledTimes(1);
 
     // confirm memoize
+    const output2 = results({ lorem: 'ipsum', dolor: 'sit', hello: 'world' });
     results({ lorem: 'ipsum', dolor: 'sit', hello: 'world' });
     results({ lorem: 'ipsum', dolor: 'sit', hello: 'world' });
-    expect(mockCallback).toHaveBeenCalledTimes(2);
+    expect(output2 === results({ lorem: 'ipsum', dolor: 'sit', hello: 'world' })).toBe(true);
+    expect(mockCallback).toHaveBeenCalledTimes(1);
 
     // confirm memoize
-    expect(output === results({ lorem: 'ipsum', dolor: 'sit' })).toBe(false);
-    expect(mockCallback).toHaveBeenCalledTimes(3);
+    expect(output === results({ lorem: 'ipsum', dolor: 'sit' })).toBe(true);
+    expect(mockCallback).toHaveBeenCalledTimes(1);
+    expect(output2 === results({ lorem: 'ipsum', dolor: 'sit', hello: 'world' })).toBe(true);
+    expect(mockCallback).toHaveBeenCalledTimes(1);
 
     expect(output).toMatchSnapshot('createSimpleSelector, callback');
   });

--- a/src/redux/hooks/useReactRedux.js
+++ b/src/redux/hooks/useReactRedux.js
@@ -23,6 +23,9 @@ import { helpers } from '../../common';
 const createSimpleSelector = (selectors, callback) => {
   const updatedSelectors = (Array.isArray(selectors) && selectors) || [selectors];
 
+  // eslint-disable-next-line prefer-spread
+  const result = helpers.memo((...resultArgs) => callback.apply(null, resultArgs));
+
   // eslint-disable-next-line func-names
   const selector = function (...args) {
     const results = [];
@@ -31,7 +34,7 @@ const createSimpleSelector = (selectors, callback) => {
       results.push(sel.apply(this, args));
     });
     // eslint-disable-next-line prefer-spread
-    return callback.apply(this, results);
+    return result.apply(this, results);
   };
 
   return helpers.memo(selector);


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(useReactRedux): memoize callback
- test(useReactRedux): expand memoize checks

### Notes
- these will be merged as a single update... 
- this issue does not appear to be currently exposed partially based on our memoized deep equality checks, and not exposed on prod since the commits are still in staging. However, the issue will be if we move over to a shallow equality check
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
To check this functionality we broke the unit test up into a **before-after** set of updates... you can see it for yourself in the commits. If you want to confirm the functionality roll the last `DEV update test to reflect new memoize` commit back on the unit test updates, then...
- confirm the unit tests fail
- then reactivate it to confirm they pass

<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure Docker is running, plus on network, then
1. `$ npm run start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing, dependent on #1264 