### PR TITLE
fix(tableEmpty): correct refresh flash on empty state

### DIFF
--- a/src/components/README.md
+++ b/src/components/README.md
@@ -5760,7 +5760,7 @@ Apply an onSort handler.
 <a name="Table.module_TableEmpty..TableEmpty"></a>
 
 ### TableEmpty~TableEmpty(props) ⇒ <code>React.ReactNode</code>
-Render an empty table.
+Render an empty table component. Apply an empty version of an actual HTML table to help with testing.
 
 **Kind**: inner method of [<code>TableEmpty</code>](#Table.module_TableEmpty)  
 <table>

--- a/src/components/table/__tests__/__snapshots__/table.test.js.snap
+++ b/src/components/table/__tests__/__snapshots__/table.test.js.snap
@@ -701,7 +701,7 @@ exports[`Table Component should pass child components, nodes when there are no r
           summary="Lorem ipsum summary"
         />
         <div
-          class="pf-v5-c-empty-state pf-m-sm"
+          class="pf-v5-c-empty-state pf-m-sm fadein"
         >
           <div
             class="pf-v5-c-empty-state__content"
@@ -805,7 +805,7 @@ exports[`Table Component should render a basic component: basic 1`] = `
           class=""
         />
         <div
-          class="pf-v5-c-empty-state pf-m-sm"
+          class="pf-v5-c-empty-state pf-m-sm fadein"
         >
           <div
             class="pf-v5-c-empty-state__content"

--- a/src/components/table/__tests__/__snapshots__/tableEmpty.test.js.snap
+++ b/src/components/table/__tests__/__snapshots__/tableEmpty.test.js.snap
@@ -6,6 +6,7 @@ exports[`TableEmpty Component should have fallback checks for certain props: fal
     aria-label={null}
   />
   <EmptyState
+    className="fadein"
     variant="sm"
   >
     <EmptyStateIcon
@@ -28,6 +29,7 @@ exports[`TableEmpty Component should render a basic component: basic 1`] = `
     aria-label={null}
   />
   <EmptyState
+    className="fadein"
     variant="sm"
   >
     <EmptyStateIcon

--- a/src/components/table/tableEmpty.js
+++ b/src/components/table/tableEmpty.js
@@ -16,7 +16,7 @@ import { EmptyTable as PlatformEmptyTableWrapper } from '@redhat-cloud-services/
  */
 
 /**
- * Render an empty table.
+ * Render an empty table component. Apply an empty version of an actual HTML table to help with testing.
  *
  * @param {object} props
  * @param {string} props.ariaLabel
@@ -30,7 +30,7 @@ import { EmptyTable as PlatformEmptyTableWrapper } from '@redhat-cloud-services/
 const TableEmpty = ({ ariaLabel, icon, message, tableHeading, title, variant, ...props }) => (
   <PlatformEmptyTableWrapper>
     <table aria-label={ariaLabel} {...props} />
-    <EmptyState variant={variant}>
+    <EmptyState className="fadein" variant={variant}>
       {icon && <EmptyStateIcon icon={icon} />}
       <EmptyStateHeader titleText={title} headingLevel={tableHeading} />
       <EmptyStateBody>{message}</EmptyStateBody>


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(tableEmpty): correct refresh flash on empty state

### Notes
- minor visual correction
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->

### Proxy run check
BEFORE APPLYING THIS COMMIT, note the behavior
1. update the NPM packages with `$ npm install`
1. make sure Docker is running, plus on network, then
1. `$ npm run start:proxy`
1. navigate towards an product
   - attempt to switch between product variants and note the "clear filters" messaging
   - apply this commit
   - now note the "clear filters" messaging is absent dependent on network speed

<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing