### PR TITLE
build(deps): dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 2
     target-branch: "main"
     versioning-strategy: increase
     allow:
@@ -18,6 +18,23 @@ updates:
       - dependency-name: "react-router*"
     labels:
       - "build"
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      dependencies-patch:
+        dependency-type: "production"
+        update-types:
+          - "patch"
+      dependencies-minor:
+        dependency-type: "production"
+        update-types:
+          - "minor"
 
   - package-ecosystem: github-actions
     directory: /
@@ -28,3 +45,6 @@ updates:
     target-branch: "main"
     labels:
       - "build"
+    commit-message:
+      prefix: "build"
+      include: "scope"


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- chore(build): dependabot groups

### Notes
- adds 2 groups for dependabot updates for minor & patch updates
   - dev-dependencies (development)
   - dependencies (production) 
- still need to confirm that global ignore functions in conjunction with groups
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure Docker is running, plus on network, then
1. `$ npm run start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing