### PR TITLE
test(serviceConfig): sw-2256 axios param checks

### DIFF
--- a/src/services/common/__tests__/__snapshots__/serviceConfig.test.js.snap
+++ b/src/services/common/__tests__/__snapshots__/serviceConfig.test.js.snap
@@ -616,3 +616,36 @@ exports[`ServiceConfig should have specific properties and methods: specific pro
   "globalResponseCache",
 ]
 `;
+
+exports[`ServiceConfig should use a package that removes undefined, null parameters instead of applying them as empty values: undefined, null params 1`] = `
+{
+  "requestNull": [
+    {
+      "params": {
+        "dolor": "sit",
+      },
+      "url": "/test/all?dolor=sit",
+    },
+    {
+      "params": {
+        "dolor": null,
+      },
+      "url": "/test/all",
+    },
+  ],
+  "requestUndefined": [
+    {
+      "params": {
+        "lorem": "ipsum",
+      },
+      "url": "/test/all?lorem=ipsum",
+    },
+    {
+      "params": {
+        "lorem": undefined,
+      },
+      "url": "/test/all",
+    },
+  ],
+}
+`;

--- a/src/services/common/__tests__/serviceConfig.test.js
+++ b/src/services/common/__tests__/serviceConfig.test.js
@@ -69,6 +69,39 @@ describe('ServiceConfig', () => {
     expect(config).toMatchSnapshot('response configs');
   });
 
+  it('should use a package that removes undefined, null parameters instead of applying them as empty values', async () => {
+    const requestUndefined = await returnPromiseAsync(() =>
+      Promise.all([
+        serviceConfig.axiosServiceCall({ url: '/test/all', method: 'get', params: { lorem: 'ipsum' } }),
+        serviceConfig.axiosServiceCall({ url: '/test/all', method: 'get', params: { lorem: undefined } })
+      ])
+    );
+
+    const requestNull = await returnPromiseAsync(() =>
+      Promise.all([
+        serviceConfig.axiosServiceCall({ url: '/test/all', method: 'get', params: { dolor: 'sit' } }),
+        serviceConfig.axiosServiceCall({ url: '/test/all', method: 'get', params: { dolor: null } })
+      ])
+    );
+
+    expect({
+      requestUndefined:
+        (Array.isArray(requestUndefined) &&
+          requestUndefined.map(({ request, config }) => ({
+            url: request.url,
+            params: config.params
+          }))) ||
+        requestUndefined,
+      requestNull:
+        (Array.isArray(requestNull) &&
+          requestNull.map(({ request, config }) => ({
+            url: request.url,
+            params: config.params
+          }))) ||
+        requestNull
+    }).toMatchSnapshot('undefined, null params');
+  });
+
   it('should handle cancelling service calls', async () => {
     // Highlight cancel takes into account url and method
     const responseAll = await returnPromiseAsync(() =>


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- test(serviceConfig): sw-2256 axios param checks

### Notes
- cover axios implementation of `undefined` and `null` query parameters
   - the gui is reliant on this feature to help in resets
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure Docker is running, plus on network, then
1. `$ npm run start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
