### PR TITLE
chore(build): ephemeral build fix for prchecks failure

### DIFF
--- a/deploy/build_deploy.sh
+++ b/deploy/build_deploy.sh
@@ -11,7 +11,7 @@ export APP_NAME=`node -e 'console.log(require("./package.json").insights.appname
 export APP_ROOT=$(pwd)
 export NODE_BUILD_VERSION=`node -e 'console.log(require("./package.json").engines.node.match(/(\d+)\.\d+\.\d+/)[1])'`
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
-
+export YARN_BUILD_SCRIPT="build:pr_checks"
 # --------------------------------------------
 # Options that must be configured by app owner
 # --------------------------------------------

--- a/deploy/pr_check.sh
+++ b/deploy/pr_check.sh
@@ -18,7 +18,8 @@ COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-fronten
 export COMPONENT_NAME="curiosity-frontend"
 export IQE_RP_ARGS="true"
 export IQE_PARALLEL_ENABLED="false"
-
+# Skips the unit integration tests for pr_checks build, since these are run in GH actions
+export YARN_BUILD_SCRIPT="build:pr_checks"
 # --------------------------------------------
 # Run unit tests, build container and push it to quay
 # --------------------------------------------

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "build:deps-core": "bash ./scripts/dependencies.sh --doctor -u --doctorTest \"npm run test:deps\" --filter \"@patternfly/*, @redhat-cloud-services/frontend*, victory*\"",
     "build:docs": "run-s -l test:docs docs:md",
     "build:ephemeral": "run-s -l build:pre build:js build:post test:integration-ephemeral",
+    "build:pr_checks": "run-s -l build:pre build:js build:post",
     "build:js": "export NODE_ENV=production; fec build",
     "build:post": "bash ./scripts/post.sh",
     "build:pre": "bash ./scripts/pre.sh",


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
...

<!-- ### Notes -->
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure Docker is running, plus on network, then
1. `$ npm run start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
