### PR TITLE
fix(inventoryCard): adjust load flash on empty state

### DIFF
--- a/src/components/inventoryCard/inventoryCard.js
+++ b/src/components/inventoryCard/inventoryCard.js
@@ -133,7 +133,7 @@ const InventoryCard = ({
       <MinHeight key="bodyMinHeight">
         <CardBody className="curiosity-card__body">
           <div className={(error && 'blur') || (pending && 'fadein') || ''}>
-            {pending && (
+            {(pending && (
               <Loader
                 variant="table"
                 tableProps={{
@@ -147,8 +147,7 @@ const InventoryCard = ({
                   isHeader: true
                 }}
               />
-            )}
-            {!pending && (
+            )) || (
               <Table
                 key="inventory-table"
                 ariaLabel={tableAriaLabel}


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(inventoryCard): adjust load flash on empty state

### Notes
- depending on network speeds the empty inventory state flashes between receiving data then displaying it... turn the condition into an `OR` instead of attempting parallel-like display
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure Docker is running, plus on network, then
1. `$ npm run start:proxy`
1. navigate to and between product views and confirm that after inventory loads the "empty state clear filters" display no longer flash displays
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
related #1277 
ongoing