### PR TITLE
fix(chartElements): victory charts props alteration

### DIFF
--- a/src/components/chart/__tests__/__snapshots__/chartElements.test.js.snap
+++ b/src/components/chart/__tests__/__snapshots__/chartElements.test.js.snap
@@ -42,6 +42,7 @@ exports[`ChartElements Component should handle basic element settings from conte
           groupComponent={<g />}
           labelComponent={<Unknown />}
           renderInPortal={true}
+          y={0}
         />
       }
       labels={[Function]}

--- a/src/components/chart/chartElements.js
+++ b/src/components/chart/chartElements.js
@@ -14,6 +14,14 @@ import { ChartTypeVariant } from './chartHelpers';
  */
 
 /**
+ * FixMe: Victory Charts v3.8.3+ conversion to TS alters props applied around VictoryTooltip
+ * Recent conversions to TS for Victory Charts has altered the behavior around props
+ * applied to custom label components, specifically for VictoryTooltip and the associated
+ * flyout component. Applying a superfluous y=0 to your custom label component triages the issue.
+ * Attempting to consume the PF version of tooltip instead exposes the exact same Victory Charts issue.
+ * Review this patch for future Victory resolutions or additional Victory Charts errors.
+ */
+/**
  * Aggregate, generate, a compatible Victory chart element/facet component.
  *
  * @param {object} props
@@ -56,6 +64,7 @@ const ChartElements = ({ chartTypeDefaults }) => {
           <ChartCursorTooltip
             dx={0}
             dy={0}
+            y={0}
             centerOffset={{ x: 0, y: 0 }}
             flyoutStyle={{ fill: 'transparent', stroke: 'transparent' }}
             labelComponent={<TooltipLabelComponent />}


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(chartElements): victory charts props alteration

### Notes
- triages a victory charts bug recently exposed with package updates under #1298 
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure Docker is running, plus on network, then
1. `$ npm run start:proxy`
1. navigate towards Subs UI RHEL x86 graph display
   - hover over either the left side, or right side of the graph
   - move your cursor towards the middle of the graph... no error should cause the entire page to crash
      - currently Victory Charts causes an intermittent/random'ish error that manages to take out the entire UI without this patch

<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->

![Screenshot 2024-03-22 at 4 19 44 PM](https://github.com/RedHatInsights/curiosity-frontend/assets/3761375/aff26d0b-8d7a-4e86-9487-ca217582306f)

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing
related #1298 