### PR TITLE
fix(inventoryLinks): sw-2326 use inventory_id instead of instance_id

### DIFF
--- a/src/config/__tests__/__snapshots__/product.config.test.js.snap
+++ b/src/config/__tests__/__snapshots__/product.config.test.js.snap
@@ -3528,7 +3528,8 @@ exports[`Product specific configurations should apply variations in inventory fi
           "row": {
             "cloud_provider": "dolor sit",
             "display_name": "lorem",
-            "instance_id": "XXXX-XXXX-XXXXX-XXXXX",
+            "instance_id": "i-XXXXXXXXXX",
+            "inventory_id": "XXXX-XXXX-XXXXX-XXXXX",
             "last_seen": "2022-01-01T00:00:00.000Z",
             "loremIpsum": "hello world",
           },
@@ -3641,7 +3642,8 @@ exports[`Product specific configurations should apply variations in inventory fi
           "row": {
             "cloud_provider": "dolor sit",
             "display_name": "lorem",
-            "instance_id": "XXXX-XXXX-XXXXX-XXXXX",
+            "instance_id": "i-XXXXXXXXXX",
+            "inventory_id": "XXXX-XXXX-XXXXX-XXXXX",
             "last_seen": "2022-01-01T00:00:00.000Z",
             "loremIpsum": "hello world",
           },
@@ -3734,7 +3736,8 @@ exports[`Product specific configurations should apply variations in inventory fi
           "row": {
             "cloud_provider": "dolor sit",
             "display_name": "lorem",
-            "instance_id": "XXXX-XXXX-XXXXX-XXXXX",
+            "instance_id": "i-XXXXXXXXXX",
+            "inventory_id": "XXXX-XXXX-XXXXX-XXXXX",
             "last_seen": "2022-01-01T00:00:00.000Z",
             "loremIpsum": "hello world",
           },
@@ -3797,7 +3800,7 @@ exports[`Product specific configurations should apply variations in inventory fi
             {
               "content": <Button
                 component="a"
-                href="/application-services/acs/instances/instance/XXXX-XXXX-XXXXX-XXXXX"
+                href="/application-services/acs/instances/instance/i-XXXXXXXXXX"
                 isInline={true}
                 variant="link"
               >
@@ -3843,7 +3846,8 @@ exports[`Product specific configurations should apply variations in inventory fi
           "row": {
             "cloud_provider": "dolor sit",
             "display_name": "lorem",
-            "instance_id": "XXXX-XXXX-XXXXX-XXXXX",
+            "instance_id": "i-XXXXXXXXXX",
+            "inventory_id": "XXXX-XXXX-XXXXX-XXXXX",
             "last_seen": "2022-01-01T00:00:00.000Z",
             "loremIpsum": "hello world",
           },
@@ -3977,7 +3981,8 @@ exports[`Product specific configurations should apply variations in inventory fi
           "row": {
             "cloud_provider": "dolor sit",
             "display_name": "lorem",
-            "instance_id": "XXXX-XXXX-XXXXX-XXXXX",
+            "instance_id": "i-XXXXXXXXXX",
+            "inventory_id": "XXXX-XXXX-XXXXX-XXXXX",
             "last_seen": "2022-01-01T00:00:00.000Z",
             "loremIpsum": "hello world",
           },
@@ -4076,7 +4081,8 @@ exports[`Product specific configurations should apply variations in inventory fi
           "row": {
             "cloud_provider": "dolor sit",
             "display_name": "lorem",
-            "instance_id": "XXXX-XXXX-XXXXX-XXXXX",
+            "instance_id": "i-XXXXXXXXXX",
+            "inventory_id": "XXXX-XXXX-XXXXX-XXXXX",
             "last_seen": "2022-01-01T00:00:00.000Z",
             "loremIpsum": "hello world",
           },
@@ -4178,7 +4184,8 @@ exports[`Product specific configurations should apply variations in inventory fi
           "row": {
             "cloud_provider": "dolor sit",
             "display_name": "lorem",
-            "instance_id": "XXXX-XXXX-XXXXX-XXXXX",
+            "instance_id": "i-XXXXXXXXXX",
+            "inventory_id": "XXXX-XXXX-XXXXX-XXXXX",
             "last_seen": "2022-01-01T00:00:00.000Z",
             "loremIpsum": "hello world",
           },
@@ -4280,7 +4287,8 @@ exports[`Product specific configurations should apply variations in inventory fi
           "row": {
             "cloud_provider": "dolor sit",
             "display_name": "lorem",
-            "instance_id": "XXXX-XXXX-XXXXX-XXXXX",
+            "instance_id": "i-XXXXXXXXXX",
+            "inventory_id": "XXXX-XXXX-XXXXX-XXXXX",
             "last_seen": "2022-01-01T00:00:00.000Z",
             "loremIpsum": "hello world",
           },
@@ -4414,7 +4422,8 @@ exports[`Product specific configurations should apply variations in inventory fi
           "row": {
             "cloud_provider": "dolor sit",
             "display_name": "lorem",
-            "instance_id": "XXXX-XXXX-XXXXX-XXXXX",
+            "instance_id": "i-XXXXXXXXXX",
+            "inventory_id": "XXXX-XXXX-XXXXX-XXXXX",
             "last_seen": "2022-01-01T00:00:00.000Z",
             "loremIpsum": "hello world",
           },
@@ -4519,7 +4528,8 @@ exports[`Product specific configurations should apply variations in inventory fi
           "row": {
             "cloud_provider": "dolor sit",
             "display_name": "lorem",
-            "instance_id": "XXXX-XXXX-XXXXX-XXXXX",
+            "instance_id": "i-XXXXXXXXXX",
+            "inventory_id": "XXXX-XXXX-XXXXX-XXXXX",
             "last_seen": "2022-01-01T00:00:00.000Z",
             "loremIpsum": "hello world",
           },
@@ -4625,7 +4635,8 @@ exports[`Product specific configurations should apply variations in inventory fi
           "row": {
             "cloud_provider": "dolor sit",
             "display_name": "lorem",
-            "instance_id": "XXXX-XXXX-XXXXX-XXXXX",
+            "instance_id": "i-XXXXXXXXXX",
+            "inventory_id": "XXXX-XXXX-XXXXX-XXXXX",
             "last_seen": "2022-01-01T00:00:00.000Z",
             "loremIpsum": "hello world",
           },
@@ -4711,7 +4722,8 @@ exports[`Product specific configurations should apply variations in inventory fi
           "row": {
             "cloud_provider": "dolor sit",
             "display_name": "lorem",
-            "instance_id": "XXXX-XXXX-XXXXX-XXXXX",
+            "instance_id": "i-XXXXXXXXXX",
+            "inventory_id": "XXXX-XXXX-XXXXX-XXXXX",
             "last_seen": "2022-01-01T00:00:00.000Z",
             "loremIpsum": "hello world",
           },
@@ -4813,7 +4825,8 @@ exports[`Product specific configurations should apply variations in inventory fi
           "row": {
             "cloud_provider": "dolor sit",
             "display_name": "lorem",
-            "instance_id": "XXXX-XXXX-XXXXX-XXXXX",
+            "instance_id": "i-XXXXXXXXXX",
+            "inventory_id": "XXXX-XXXX-XXXXX-XXXXX",
             "last_seen": "2022-01-01T00:00:00.000Z",
             "loremIpsum": "hello world",
           },
@@ -4940,7 +4953,8 @@ exports[`Product specific configurations should apply variations in inventory fi
           "row": {
             "cloud_provider": "dolor sit",
             "display_name": "lorem",
-            "instance_id": "XXXX-XXXX-XXXXX-XXXXX",
+            "instance_id": "i-XXXXXXXXXX",
+            "inventory_id": "XXXX-XXXX-XXXXX-XXXXX",
             "last_seen": "2022-01-01T00:00:00.000Z",
             "loremIpsum": "hello world",
           },
@@ -5039,7 +5053,8 @@ exports[`Product specific configurations should apply variations in inventory fi
           "row": {
             "cloud_provider": "dolor sit",
             "display_name": "lorem",
-            "instance_id": "XXXX-XXXX-XXXXX-XXXXX",
+            "instance_id": "i-XXXXXXXXXX",
+            "inventory_id": "XXXX-XXXX-XXXXX-XXXXX",
             "last_seen": "2022-01-01T00:00:00.000Z",
             "loremIpsum": "hello world",
           },
@@ -5141,7 +5156,8 @@ exports[`Product specific configurations should apply variations in inventory fi
           "row": {
             "cloud_provider": "dolor sit",
             "display_name": "lorem",
-            "instance_id": "XXXX-XXXX-XXXXX-XXXXX",
+            "instance_id": "i-XXXXXXXXXX",
+            "inventory_id": "XXXX-XXXX-XXXXX-XXXXX",
             "last_seen": "2022-01-01T00:00:00.000Z",
             "loremIpsum": "hello world",
           },
@@ -5243,7 +5259,8 @@ exports[`Product specific configurations should apply variations in inventory fi
           "row": {
             "cloud_provider": "dolor sit",
             "display_name": "lorem",
-            "instance_id": "XXXX-XXXX-XXXXX-XXXXX",
+            "instance_id": "i-XXXXXXXXXX",
+            "inventory_id": "XXXX-XXXX-XXXXX-XXXXX",
             "last_seen": "2022-01-01T00:00:00.000Z",
             "loremIpsum": "hello world",
           },
@@ -5370,7 +5387,8 @@ exports[`Product specific configurations should apply variations in inventory fi
           "row": {
             "cloud_provider": "dolor sit",
             "display_name": "lorem",
-            "instance_id": "XXXX-XXXX-XXXXX-XXXXX",
+            "instance_id": "i-XXXXXXXXXX",
+            "inventory_id": "XXXX-XXXX-XXXXX-XXXXX",
             "last_seen": "2022-01-01T00:00:00.000Z",
             "loremIpsum": "hello world",
           },

--- a/src/config/__tests__/product.config.test.js
+++ b/src/config/__tests__/product.config.test.js
@@ -226,7 +226,8 @@ describe('Product specific configurations', () => {
           {
             [INVENTORY_TYPES.DISPLAY_NAME]: 'lorem',
             [INVENTORY_TYPES.CLOUD_PROVIDER]: 'dolor sit',
-            [INVENTORY_TYPES.INSTANCE_ID]: 'XXXX-XXXX-XXXXX-XXXXX',
+            [INVENTORY_TYPES.INVENTORY_ID]: 'XXXX-XXXX-XXXXX-XXXXX',
+            [INVENTORY_TYPES.INSTANCE_ID]: 'i-XXXXXXXXXX',
             [INVENTORY_TYPES.LAST_SEEN]: '2022-01-01T00:00:00.000Z',
             loremIpsum: 'hello world'
           }

--- a/src/config/product.openshiftContainer.js
+++ b/src/config/product.openshiftContainer.js
@@ -194,18 +194,18 @@ const config = {
       cell: (
         {
           [INVENTORY_TYPES.DISPLAY_NAME]: displayName,
-          [INVENTORY_TYPES.INSTANCE_ID]: instanceId,
+          [INVENTORY_TYPES.INVENTORY_ID]: inventoryId,
           [INVENTORY_TYPES.NUMBER_OF_GUESTS]: numberOfGuests
         } = {},
         session
       ) => {
         const { inventory: authorized } = session?.authorized || {};
 
-        if (!instanceId) {
+        if (!inventoryId) {
           return displayName;
         }
 
-        let updatedDisplayName = displayName || instanceId;
+        let updatedDisplayName = displayName || inventoryId;
 
         if (authorized) {
           updatedDisplayName = (
@@ -213,7 +213,7 @@ const config = {
               isInline
               component="a"
               variant="link"
-              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${instanceId}/`}
+              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}/`}
             >
               {updatedDisplayName}
             </Button>

--- a/src/config/product.openshiftDedicated.js
+++ b/src/config/product.openshiftDedicated.js
@@ -233,18 +233,18 @@ const config = {
       cell: (
         {
           [INVENTORY_TYPES.DISPLAY_NAME]: displayName,
-          [INVENTORY_TYPES.INSTANCE_ID]: instanceId,
+          [INVENTORY_TYPES.INVENTORY_ID]: inventoryId,
           [INVENTORY_TYPES.NUMBER_OF_GUESTS]: numberOfGuests
         } = {},
         session
       ) => {
         const { inventory: authorized } = session?.authorized || {};
 
-        if (!instanceId) {
+        if (!inventoryId) {
           return displayName;
         }
 
-        let updatedDisplayName = displayName || instanceId;
+        let updatedDisplayName = displayName || inventoryId;
 
         if (authorized) {
           updatedDisplayName = (
@@ -252,7 +252,7 @@ const config = {
               isInline
               component="a"
               variant="link"
-              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/openshift/details/${instanceId}`}
+              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/openshift/details/${inventoryId}`}
             >
               {updatedDisplayName}
             </Button>

--- a/src/config/product.openshiftMetrics.js
+++ b/src/config/product.openshiftMetrics.js
@@ -224,18 +224,18 @@ const config = {
       cell: (
         {
           [INVENTORY_TYPES.DISPLAY_NAME]: displayName,
-          [INVENTORY_TYPES.INSTANCE_ID]: instanceId,
+          [INVENTORY_TYPES.INVENTORY_ID]: inventoryId,
           [INVENTORY_TYPES.NUMBER_OF_GUESTS]: numberOfGuests
         } = {},
         session
       ) => {
         const { inventory: authorized } = session?.authorized || {};
 
-        if (!instanceId) {
+        if (!inventoryId) {
           return displayName;
         }
 
-        let updatedDisplayName = displayName || instanceId;
+        let updatedDisplayName = displayName || inventoryId;
 
         if (authorized) {
           updatedDisplayName = (
@@ -243,7 +243,7 @@ const config = {
               isInline
               component="a"
               variant="link"
-              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/openshift/details/${instanceId}`}
+              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/openshift/details/${inventoryId}`}
             >
               {updatedDisplayName}
             </Button>

--- a/src/config/product.rhel.js
+++ b/src/config/product.rhel.js
@@ -208,14 +208,14 @@ const config = {
   initialInventoryFilters: [
     {
       metric: INVENTORY_TYPES.DISPLAY_NAME,
-      cell: ({ [INVENTORY_TYPES.DISPLAY_NAME]: displayName, [INVENTORY_TYPES.INSTANCE_ID]: instanceId }, session) => {
+      cell: ({ [INVENTORY_TYPES.DISPLAY_NAME]: displayName, [INVENTORY_TYPES.INVENTORY_ID]: inventoryId }, session) => {
         const { inventory: authorized } = session?.authorized || {};
 
-        if (!instanceId) {
+        if (!inventoryId) {
           return displayName;
         }
 
-        let updatedDisplayName = displayName || instanceId;
+        let updatedDisplayName = displayName || inventoryId;
 
         if (authorized) {
           updatedDisplayName = (
@@ -223,7 +223,7 @@ const config = {
               isInline
               component="a"
               variant="link"
-              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${instanceId}/`}
+              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}/`}
             >
               {updatedDisplayName}
             </Button>

--- a/src/config/product.rhelElsPayg.js
+++ b/src/config/product.rhelElsPayg.js
@@ -184,15 +184,15 @@ const config = {
   initialInventoryFilters: [
     {
       metric: INVENTORY_TYPES.DISPLAY_NAME,
-      cell: ({ [INVENTORY_TYPES.DISPLAY_NAME]: displayName, [INVENTORY_TYPES.INSTANCE_ID]: instanceId } = {}) => {
+      cell: ({ [INVENTORY_TYPES.DISPLAY_NAME]: displayName, [INVENTORY_TYPES.INVENTORY_ID]: inventoryId } = {}) => {
         // FixMe: Disabled, see SWATCH-1209 for resolution
         const { inventory: authorized = false } = {};
 
-        if (!instanceId) {
+        if (!inventoryId) {
           return displayName;
         }
 
-        let updatedDisplayName = displayName || instanceId;
+        let updatedDisplayName = displayName || inventoryId;
 
         if (authorized) {
           updatedDisplayName = (
@@ -200,7 +200,7 @@ const config = {
               isInline
               component="a"
               variant="link"
-              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${instanceId}/`}
+              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}/`}
             >
               {updatedDisplayName}
             </Button>

--- a/src/config/product.rhods.js
+++ b/src/config/product.rhods.js
@@ -185,15 +185,15 @@ const config = {
   initialInventoryFilters: [
     {
       metric: INVENTORY_TYPES.DISPLAY_NAME,
-      cell: ({ [INVENTORY_TYPES.DISPLAY_NAME]: displayName, [INVENTORY_TYPES.INSTANCE_ID]: instanceId }) => {
+      cell: ({ [INVENTORY_TYPES.DISPLAY_NAME]: displayName, [INVENTORY_TYPES.INVENTORY_ID]: inventoryId }) => {
         // FixMe: Disabled, see SWATCH-1209 for resolution
         const { inventory: authorized = false } = {};
 
-        if (!instanceId) {
+        if (!inventoryId) {
           return displayName;
         }
 
-        let updatedDisplayName = displayName || instanceId;
+        let updatedDisplayName = displayName || inventoryId;
 
         if (authorized) {
           updatedDisplayName = (
@@ -201,7 +201,7 @@ const config = {
               isInline
               component="a"
               variant="link"
-              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${instanceId}/`}
+              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}/`}
             >
               {updatedDisplayName}
             </Button>

--- a/src/config/product.rosa.js
+++ b/src/config/product.rosa.js
@@ -250,15 +250,15 @@ const config = {
   initialInventoryFilters: [
     {
       metric: INVENTORY_TYPES.DISPLAY_NAME,
-      cell: ({ [INVENTORY_TYPES.DISPLAY_NAME]: displayName, [INVENTORY_TYPES.INSTANCE_ID]: instanceId }) => {
+      cell: ({ [INVENTORY_TYPES.DISPLAY_NAME]: displayName, [INVENTORY_TYPES.INVENTORY_ID]: inventoryId }) => {
         // FixMe: Disabled, see SWATCH-1209 for resolution
         const { inventory: authorized = false } = {};
 
-        if (!instanceId) {
+        if (!inventoryId) {
           return displayName;
         }
 
-        let updatedDisplayName = displayName || instanceId;
+        let updatedDisplayName = displayName || inventoryId;
 
         if (authorized) {
           updatedDisplayName = (
@@ -266,7 +266,7 @@ const config = {
               isInline
               component="a"
               variant="link"
-              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${instanceId}/`}
+              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}/`}
             >
               {updatedDisplayName}
             </Button>

--- a/src/config/product.satellite.js
+++ b/src/config/product.satellite.js
@@ -185,14 +185,14 @@ const config = {
   initialInventoryFilters: [
     {
       metric: INVENTORY_TYPES.DISPLAY_NAME,
-      cell: ({ [INVENTORY_TYPES.DISPLAY_NAME]: displayName, [INVENTORY_TYPES.INSTANCE_ID]: instanceId }, session) => {
+      cell: ({ [INVENTORY_TYPES.DISPLAY_NAME]: displayName, [INVENTORY_TYPES.INVENTORY_ID]: inventoryId }, session) => {
         const { inventory: authorized } = session?.authorized || {};
 
-        if (!instanceId) {
+        if (!inventoryId) {
           return displayName;
         }
 
-        let updatedDisplayName = displayName || instanceId;
+        let updatedDisplayName = displayName || inventoryId;
 
         if (authorized) {
           updatedDisplayName = (
@@ -200,7 +200,7 @@ const config = {
               isInline
               component="a"
               variant="link"
-              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${instanceId}/`}
+              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}/`}
             >
               {updatedDisplayName}
             </Button>

--- a/src/services/rhsm/rhsmServices.js
+++ b/src/services/rhsm/rhsmServices.js
@@ -1681,7 +1681,8 @@ const getInstancesInventoryGuests = (id, params = {}, options = {}) => {
  *         {
  *           "category": "physical",
  *           "billing_account_id": "xxxxx-xxxx-CCCCC-xxxx-xxxx10",
- *           "instance_id": "CCCCC-b344-4778-831c-CCCCCCC",
+ *           "inventory_id": "CCCCC-b344-4778-831c-CCCCCCC",
+ *           "instance_id": "i-831cCCCCCCC",
  *           "subscription_manager_id": "CCCCC-5b00-42fa-CCCCC-75801d45cc6d",
  *           "display_name": "lorem.example.com",
  *           "measurements": [
@@ -1696,7 +1697,8 @@ const getInstancesInventoryGuests = (id, params = {}, options = {}) => {
  *         {
  *           "category": "virtual",
  *           "billing_account_id": "xxxxx-xxxx-FFFFF-xxxx-xxxx40",
- *           "instance_id": "FFFFF-b344-4778-831c-FFFFF",
+ *           "inventory_id": "FFFFF-b344-4778-831c-FFFFF",
+ *           "instance_id": "i-831cFFFFF",
  *           "subscription_manager_id": "FFFFF-5b00-42fa-FFFFF-75801d45cc6d",
  *           "display_name": "lorem.example.com",
  *           "measurements": [
@@ -1713,7 +1715,8 @@ const getInstancesInventoryGuests = (id, params = {}, options = {}) => {
  *           "category": "cloud",
  *           "billing_provider": "red hat",
  *           "billing_account_id": "xxxxx-xxxx-xxxx-xxxx-xxxx01",
- *           "instance_id": "d6214a0b-b344-4778-831c-d53dcacb2da3",
+ *           "inventory_id": "d6214a0b-b344-4778-831c-d53dcacb2da3",
+ *           "instance_id": "i-831cd53dcacb2da3",
  *           "subscription_manager_id": "adafd9d5-5b00-42fa-a6c9-75801d45cc6d",
  *           "display_name": "rhv.example.com",
  *           "measurements": [
@@ -1729,7 +1732,8 @@ const getInstancesInventoryGuests = (id, params = {}, options = {}) => {
  *           "category": "cloud",
  *           "billing_provider": "azure",
  *           "billing_account_id": "xxxxx-xxxx-xxxx-xxxx-xxxx02",
- *           "instance_id": "XXXXXX-b344-4778-831c-XXXXXXXX",
+ *           "inventory_id": "XXXXXX-b344-4778-831c-XXXXXXXX",
+ *           "instance_id": "i-831cXXXXXXXX",
  *           "subscription_manager_id": "XXXXXX-5b00-42fa-XXXX-75801d45cc6d",
  *           "display_name": "dolor.example.com",
  *           "measurements": [
@@ -1744,7 +1748,8 @@ const getInstancesInventoryGuests = (id, params = {}, options = {}) => {
  *         {
  *           "category": "physical",
  *           "billing_account_id": "xxxxx-xxxx-xxxx-xxxx-xxxx03",
- *           "instance_id": "BBBBB-b344-4778-831c-BBBBBBB",
+ *           "inventory_id": "BBBBB-b344-4778-831c-BBBBBBB",
+ *           "instance_id": "i-831cBBBBBBB",
  *           "subscription_manager_id": "BBBBB-5b00-42fa-BBBBB-75801d45cc6d",
  *           "display_name": "lorem.example.com",
  *           "measurements": [


### PR DESCRIPTION
## What's included
In [SWATCH-2144](https://issues.redhat.com/browse/SWATCH-2144), we changed the existing instance_id from inventory_id to the actual provider id. However, the UI was using this instance_id to build up the link to the inventory service. So, we need to provide the inventory_id, so the UI can continue building this url.

Related to https://github.com/RedHatInsights/rhsm-subscriptions/pull/3188.

## How to test
1.- `npm start`
2.- browse to `http://localhost:3000/apps/subscriptions/openshift`
3.- when moving the cursor over any item name, the link should look like `http://localhost:3000/insights/inventory/CCCCC-b344-4778-831c-CCCCCCC/` instead of `http://localhost:3000/insights/inventory/i-4778-831cCCCCCCC/`

I've also verified that the links for ACM (here, we need to keep using `instance_id`), OpenShift Metrics and OpenShift Dedicated works. 

## Updates issue/story
Jira issue: [SWATCH-2326](https://issues.redhat.com/browse/SWATCH-2326)
