### PR TITLE
fix(config): sw-2480 revert inventory_id to instance_id

### DIFF
--- a/src/config/__tests__/__snapshots__/product.config.test.js.snap
+++ b/src/config/__tests__/__snapshots__/product.config.test.js.snap
@@ -3618,7 +3618,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "content": <React.Fragment>
                 <Button
                   component="a"
-                  href="/openshift/details/XXXX-XXXX-XXXXX-XXXXX"
+                  href="/openshift/details/i-XXXXXXXXXX"
                   isInline={true}
                   variant="link"
                 >
@@ -3721,7 +3721,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "content": <React.Fragment>
                 <Button
                   component="a"
-                  href="/openshift/details/XXXX-XXXX-XXXXX-XXXXX"
+                  href="/openshift/details/i-XXXXXXXXXX"
                   isInline={true}
                   variant="link"
                 >

--- a/src/config/product.openshiftDedicated.js
+++ b/src/config/product.openshiftDedicated.js
@@ -233,18 +233,18 @@ const config = {
       cell: (
         {
           [INVENTORY_TYPES.DISPLAY_NAME]: displayName,
-          [INVENTORY_TYPES.INVENTORY_ID]: inventoryId,
+          [INVENTORY_TYPES.INSTANCE_ID]: instanceId,
           [INVENTORY_TYPES.NUMBER_OF_GUESTS]: numberOfGuests
         } = {},
         session
       ) => {
         const { inventory: authorized } = session?.authorized || {};
 
-        if (!inventoryId) {
+        if (!instanceId) {
           return displayName;
         }
 
-        let updatedDisplayName = displayName || inventoryId;
+        let updatedDisplayName = displayName || instanceId;
 
         if (authorized) {
           updatedDisplayName = (
@@ -252,7 +252,7 @@ const config = {
               isInline
               component="a"
               variant="link"
-              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/openshift/details/${inventoryId}`}
+              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/openshift/details/${instanceId}`}
             >
               {updatedDisplayName}
             </Button>

--- a/src/config/product.openshiftMetrics.js
+++ b/src/config/product.openshiftMetrics.js
@@ -224,18 +224,18 @@ const config = {
       cell: (
         {
           [INVENTORY_TYPES.DISPLAY_NAME]: displayName,
-          [INVENTORY_TYPES.INVENTORY_ID]: inventoryId,
+          [INVENTORY_TYPES.INSTANCE_ID]: instanceId,
           [INVENTORY_TYPES.NUMBER_OF_GUESTS]: numberOfGuests
         } = {},
         session
       ) => {
         const { inventory: authorized } = session?.authorized || {};
 
-        if (!inventoryId) {
+        if (!instanceId) {
           return displayName;
         }
 
-        let updatedDisplayName = displayName || inventoryId;
+        let updatedDisplayName = displayName || instanceId;
 
         if (authorized) {
           updatedDisplayName = (
@@ -243,7 +243,7 @@ const config = {
               isInline
               component="a"
               variant="link"
-              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/openshift/details/${inventoryId}`}
+              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/openshift/details/${instanceId}`}
             >
               {updatedDisplayName}
             </Button>

--- a/src/config/product.rhelElsPayg.js
+++ b/src/config/product.rhelElsPayg.js
@@ -184,15 +184,15 @@ const config = {
   initialInventoryFilters: [
     {
       metric: INVENTORY_TYPES.DISPLAY_NAME,
-      cell: ({ [INVENTORY_TYPES.DISPLAY_NAME]: displayName, [INVENTORY_TYPES.INVENTORY_ID]: inventoryId } = {}) => {
+      cell: ({ [INVENTORY_TYPES.DISPLAY_NAME]: displayName, [INVENTORY_TYPES.INSTANCE_ID]: instanceId } = {}) => {
         // FixMe: Disabled, see SWATCH-1209 for resolution
         const { inventory: authorized = false } = {};
 
-        if (!inventoryId) {
+        if (!instanceId) {
           return displayName;
         }
 
-        let updatedDisplayName = displayName || inventoryId;
+        let updatedDisplayName = displayName || instanceId;
 
         if (authorized) {
           updatedDisplayName = (
@@ -200,7 +200,7 @@ const config = {
               isInline
               component="a"
               variant="link"
-              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}/`}
+              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${instanceId}/`}
             >
               {updatedDisplayName}
             </Button>

--- a/src/config/product.rhods.js
+++ b/src/config/product.rhods.js
@@ -186,7 +186,7 @@ const config = {
     {
       metric: INVENTORY_TYPES.DISPLAY_NAME,
       cell: ({ [INVENTORY_TYPES.DISPLAY_NAME]: displayName, [INVENTORY_TYPES.INVENTORY_ID]: inventoryId }) => {
-        // FixMe: Disabled, see SWATCH-1209 for resolution
+        // FixMe: Disabled, see SWATCH-1209 for resolution. Related to SWATCH-2326 and SWATCH-2480
         const { inventory: authorized = false } = {};
 
         if (!inventoryId) {

--- a/src/config/product.rosa.js
+++ b/src/config/product.rosa.js
@@ -250,15 +250,15 @@ const config = {
   initialInventoryFilters: [
     {
       metric: INVENTORY_TYPES.DISPLAY_NAME,
-      cell: ({ [INVENTORY_TYPES.DISPLAY_NAME]: displayName, [INVENTORY_TYPES.INVENTORY_ID]: inventoryId }) => {
+      cell: ({ [INVENTORY_TYPES.DISPLAY_NAME]: displayName, [INVENTORY_TYPES.INSTANCE_ID]: instanceId }) => {
         // FixMe: Disabled, see SWATCH-1209 for resolution
         const { inventory: authorized = false } = {};
 
-        if (!inventoryId) {
+        if (!instanceId) {
           return displayName;
         }
 
-        let updatedDisplayName = displayName || inventoryId;
+        let updatedDisplayName = displayName || instanceId;
 
         if (authorized) {
           updatedDisplayName = (
@@ -266,7 +266,7 @@ const config = {
               isInline
               component="a"
               variant="link"
-              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}/`}
+              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${instanceId}/`}
             >
               {updatedDisplayName}
             </Button>


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(config): sw-2480 revert inventory_id to instance_id

### Notes
- Reverts towards using instance_id for on-demand'ish products
- Expanded the annotation for RHODS/AI until linking can be enabled
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. confirm the related products now correctly navigate using "instance_id" instead of "inventory_id"
   - OpenShift Dedicated metrics
   - OpenShift Container metrics
   - RHEL ELS PAYG
   - ROSA

<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
related sw-2326 sw-1209
sw-2480