### PR TITLE
fix(config): sw-2480 link rosa to openshift details

### DIFF
--- a/src/config/__tests__/__snapshots__/product.config.test.js.snap
+++ b/src/config/__tests__/__snapshots__/product.config.test.js.snap
@@ -4265,7 +4265,7 @@ exports[`Product specific configurations should apply variations in inventory fi
             {
               "content": <Button
                 component="a"
-                href="/insights/inventory/i-XXXXXXXXXX/"
+                href="/openshift/details/i-XXXXXXXXXX/"
                 isInline={true}
                 variant="link"
               >

--- a/src/config/product.rosa.js
+++ b/src/config/product.rosa.js
@@ -268,7 +268,7 @@ const config = {
               isInline
               component="a"
               variant="link"
-              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${instanceId}/`}
+              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/openshift/details/${instanceId}/`}
             >
               {updatedDisplayName}
             </Button>


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(config): sw-2480 link rosa to openshift details

### Notes
- points rosa link over to openshift details from the old inventory link
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
related sw-2480