### PR TITLE
build: local dev, custom mock port

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -7,14 +7,3 @@ REACT_APP_UI_DISABLED_NOTIFICATIONS=false
 
 REACT_APP_CONFIG_SERVICE_LOCALES=/locales/locales.json
 REACT_APP_CONFIG_SERVICE_LOCALES_PATH=/locales/{{lng}}.json
-
-REACT_APP_SERVICES_PLATFORM_EXPORT=http://localhost:5000/api/export/v1/exports
-REACT_APP_SERVICES_PLATFORM_EXPORT_STATUS=http://localhost:5000/api/export/v1/exports/{0}/status
-
-REACT_APP_SERVICES_RHSM_VERSION=http://localhost:5000/api/rhsm-subscriptions/v1/version
-REACT_APP_SERVICES_RHSM_TALLY=http://localhost:5000/api/rhsm-subscriptions/v1/tally/products/{0}/{1}
-REACT_APP_SERVICES_RHSM_CAPACITY=http://localhost:5000/api/rhsm-subscriptions/v1/capacity/products/{0}/{1}
-REACT_APP_SERVICES_RHSM_INVENTORY_INSTANCES=http://localhost:5000/api/rhsm-subscriptions/v1/instances/products/
-REACT_APP_SERVICES_RHSM_INVENTORY_INSTANCES_GUESTS=http://localhost:5000/api/rhsm-subscriptions/v1/instances/{0}/guests
-REACT_APP_SERVICES_RHSM_INVENTORY_SUBSCRIPTIONS=http://localhost:5000/api/rhsm-subscriptions/v1/subscriptions/products/
-REACT_APP_SERVICES_RHSM_OPTIN=http://localhost:5000/api/rhsm-subscriptions/v1/opt-in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -458,6 +458,9 @@ This is a non-networked local run designed to function with minimal resources an
    ```
    $ npm run test:dev
    ```
+   > If issues happen with the mock server port of `3030` you can set a custom port by exporting a parameter when you run start-up
+   > ie. `export MOCK_PORT=5000; npm start`    
+
 1. Make sure your browser opened around the domain `https://localhost:3000/`
 1. Start developing...
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -459,7 +459,7 @@ This is a non-networked local run designed to function with minimal resources an
    $ npm run test:dev
    ```
    > If issues happen with the mock server port of `3030` you can set a custom port by exporting a parameter when you run start-up
-   > ie. `export MOCK_PORT=5000; npm start`    
+   > ie. `$ export MOCK_PORT=5000; npm start`    
 
 1. Make sure your browser opened around the domain `https://localhost:3000/`
 1. Start developing...

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -7,7 +7,7 @@ const {
   MiniCssExtractPlugin
 } = require('weldable/lib/packages');
 
-module.exports = ({ SRC_DIR } = {}) => ({
+module.exports = ({ SRC_DIR, MOCK_PORT } = {}) => ({
   module: {
     rules: [
       {
@@ -27,5 +27,14 @@ module.exports = ({ SRC_DIR } = {}) => ({
       context: SRC_DIR,
       failOnError: false
     })
-  ]
+  ],
+  devServer: {
+    proxy: [
+      {
+        context: ['/api'],
+        target: `http://localhost:${MOCK_PORT}`,
+        secure: false
+      }
+    ]
+  }
 });

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     ]
   },
   "scripts": {
-    "api:dev": "mock -p 5000 -w ./src/services -w ./src/services/platform -w ./src/services/rhsm",
+    "api:dev": "mock -p $MOCK_PORT -w ./src/services -w ./src/services/platform -w ./src/services/rhsm",
     "api:docs": "node ./scripts/openapi.docs.js",
     "api:proxy-hosts": "bash ./scripts/proxy.api.sh",
     "build": "run-s -l build:pre build:js build:post test:integration",
@@ -52,7 +52,7 @@
     "docs:md": "node ./scripts/readme.docs.js",
     "release": "changelog -c false",
     "release:rc": "changelog --dry-run",
-    "start": "run-p -l api:dev start:standalone",
+    "start": "export MOCK_PORT=${MOCK_PORT:-3030}; run-p -l api:dev start:standalone",
     "start:js-proxy": "export NODE_ENV=development; fec dev",
     "start:proxy": "run-s -l api:proxy-hosts start:js-proxy",
     "start:standalone": "export NODE_ENV=development; weldable -l none -x config/webpack.dev.config.js",


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- build: local dev, custom mock port @mmusil 

### Notes
- allows for running a custom port when you run the local dev command
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
   - the default proxy port is now `3030`
   - confirm the API and the UI display accordingly
   - shut it down
1. `$ export MOCK_PORT=5000; npm start`
   - confirm the API and the UI display accordingly, or if you have issues with the port try a different custom port like `9000`
      - you can also see the proxy port during startup of the command, similar to
         
         ![Screenshot 2024-05-13 at 10 15 22 AM](https://github.com/RedHatInsights/curiosity-frontend/assets/3761375/3813f2e4-ccc7-48ce-8813-7bcf75606fd0)


<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing