### PR TITLE
refactor: sw-1594 quarterly range expand to 5 years

### DIFF
--- a/public/locales/en-US.json
+++ b/public/locales/en-US.json
@@ -326,7 +326,7 @@
     "label_granularity_Daily": "Past 30 days (daily)",
     "label_granularity_Weekly": "Past 12 weeks (weekly)",
     "label_granularity_Monthly": "Past year (monthly)",
-    "label_granularity_Quarterly": "Past 3 years (quarterly)",
+    "label_granularity_Quarterly": "Past 5 years (quarterly)",
     "label_granularityRangedMonthly": "{{context}}",
     "label_granularityRangedMonthly_current": "This month",
     "label_groupVariant": "Variant:",

--- a/src/common/README.md
+++ b/src/common/README.md
@@ -61,7 +61,7 @@ Generates the date range, starting 12 months prior to getCurrentDate, and ending
 <a name="Helpers.module_Dates..quarterlyDateTime"></a>
 
 ### Dates~quarterlyDateTime : <code>Object</code>
-Generates the date range, starting 36 months prior to getCurrentDate, and ending at the end of getCurrentDate.
+Generates the date range, starting 60 months prior to getCurrentDate, and ending at the end of getCurrentDate.
 
 **Kind**: inner constant of [<code>Dates</code>](#Helpers.module_Dates)  
 <a name="Helpers.module_Dates..rangedYearDateTime"></a>

--- a/src/common/__tests__/__snapshots__/dateHelpers.test.js.snap
+++ b/src/common/__tests__/__snapshots__/dateHelpers.test.js.snap
@@ -19,7 +19,7 @@ exports[`DateHelpers should have specific functions: dateHelpers 1`] = `
   },
   "quarterlyDateTime": {
     "endDate": 2019-07-01T23:59:59.999Z,
-    "startDate": 2016-07-01T00:00:00.000Z,
+    "startDate": 2014-07-01T00:00:00.000Z,
   },
   "rangedYearDateTime": {
     "endDate": 2019-07-31T23:59:59.999Z,
@@ -422,7 +422,7 @@ exports[`DateHelpers should return a predictable range based on granularity: gra
     "granularity": "Quarterly",
     "range": {
       "endDate": 2019-07-01T23:59:59.999Z,
-      "startDate": 2016-07-01T00:00:00.000Z,
+      "startDate": 2014-07-01T00:00:00.000Z,
     },
   },
 ]

--- a/src/common/dateHelpers.js
+++ b/src/common/dateHelpers.js
@@ -125,12 +125,12 @@ const monthlyDateTime = setRangedDateTime({
 });
 
 /**
- *  Generates the date range, starting 36 months prior to getCurrentDate, and ending at the end of getCurrentDate.
+ *  Generates the date range, starting 60 months prior to getCurrentDate, and ending at the end of getCurrentDate.
  *
  * @type {{endDate: Date, startDate: Date}}
  */
 const quarterlyDateTime = setRangedDateTime({
-  subtract: 36,
+  subtract: 60,
   measurement: 'months'
 });
 

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -902,6 +902,8 @@ Generate X axis props, ticks, tick formatting.
 <tr>
     <td>params</td><td><code>object</code></td>
     </tr><tr>
+    <td>params.chartWidth</td><td><code>number</code></td>
+    </tr><tr>
     <td>params.dataSet</td><td><code>object</code></td>
     </tr><tr>
     <td>params.maxX</td><td><code>number</code></td>
@@ -955,6 +957,8 @@ Generate x,y props.
   <tbody>
 <tr>
     <td>params</td><td><code>object</code></td>
+    </tr><tr>
+    <td>params.chartWidth</td><td><code>number</code></td>
     </tr><tr>
     <td>params.dataSets</td><td><code>Array</code></td>
     </tr><tr>
@@ -2487,14 +2491,18 @@ Format x-axis ticks.
     </tr><tr>
     <td>params.callback</td><td><code>function</code></td><td></td>
     </tr><tr>
+    <td>params.chartWidth</td><td><code>number</code></td><td></td>
+    </tr><tr>
     <td>params.date</td><td><code>Date</code></td><td></td>
     </tr><tr>
     <td>params.granularity</td><td><code>string</code></td><td><p>See enum of RHSM_API_QUERY_GRANULARITY_TYPES</p>
 </td>
     </tr><tr>
-    <td>params.tick</td><td><code>number</code> | <code>string</code></td><td></td>
+    <td>params.nextDate</td><td><code>Date</code></td><td></td>
     </tr><tr>
     <td>params.previousDate</td><td><code>Date</code></td><td></td>
+    </tr><tr>
+    <td>params.tick</td><td><code>number</code> | <code>string</code></td><td></td>
     </tr>  </tbody>
 </table>
 

--- a/src/components/chart/__tests__/__snapshots__/chartHelpers.test.js.snap
+++ b/src/components/chart/__tests__/__snapshots__/chartHelpers.test.js.snap
@@ -754,6 +754,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
 [
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-02-12T00:00:00.000Z",
         "hasData": false,
@@ -777,6 +778,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-02-13T00:00:00.000Z",
         "hasData": false,
@@ -807,6 +809,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-02-14T00:00:00.000Z",
         "hasData": false,
@@ -837,6 +840,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-02-15T00:00:00.000Z",
         "hasData": false,
@@ -867,6 +871,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-02-16T00:00:00.000Z",
         "hasData": false,
@@ -897,6 +902,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-02-17T00:00:00.000Z",
         "hasData": false,
@@ -927,6 +933,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-02-18T00:00:00.000Z",
         "hasData": false,
@@ -957,6 +964,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-02-19T00:00:00.000Z",
         "hasData": false,
@@ -987,6 +995,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-02-20T00:00:00.000Z",
         "hasData": false,
@@ -1017,6 +1026,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-02-21T00:00:00.000Z",
         "hasData": true,
@@ -1047,6 +1057,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-02-22T00:00:00.000Z",
         "hasData": true,
@@ -1077,6 +1088,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-02-23T00:00:00.000Z",
         "hasData": true,
@@ -1107,6 +1119,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-02-24T00:00:00.000Z",
         "hasData": true,
@@ -1137,6 +1150,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-02-25T00:00:00.000Z",
         "hasData": true,
@@ -1167,6 +1181,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-02-26T00:00:00.000Z",
         "hasData": true,
@@ -1197,6 +1212,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-02-27T00:00:00.000Z",
         "hasData": true,
@@ -1227,6 +1243,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-02-28T00:00:00.000Z",
         "hasData": true,
@@ -1257,6 +1274,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-03-01T00:00:00.000Z",
         "hasData": true,
@@ -1287,6 +1305,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-03-02T00:00:00.000Z",
         "hasData": false,
@@ -1317,6 +1336,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-03-03T00:00:00.000Z",
         "hasData": true,
@@ -1347,6 +1367,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-03-04T00:00:00.000Z",
         "hasData": true,
@@ -1377,6 +1398,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-03-05T00:00:00.000Z",
         "hasData": true,
@@ -1407,6 +1429,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-03-06T00:00:00.000Z",
         "hasData": true,
@@ -1437,6 +1460,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-03-07T00:00:00.000Z",
         "hasData": true,
@@ -1467,6 +1491,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-03-08T00:00:00.000Z",
         "hasData": true,
@@ -1497,6 +1522,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-03-09T00:00:00.000Z",
         "hasData": true,
@@ -1527,6 +1553,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-03-10T00:00:00.000Z",
         "hasData": true,
@@ -1557,6 +1584,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-03-11T00:00:00.000Z",
         "hasData": true,
@@ -1587,6 +1615,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-03-12T00:00:00.000Z",
         "hasData": true,
@@ -1617,6 +1646,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-03-13T00:00:00.000Z",
         "hasData": true,
@@ -1647,6 +1677,7 @@ exports[`ChartHelpers should generate x axis props: format callback 1`] = `
   ],
   [
     {
+      "chartWidth": undefined,
       "item": {
         "date": "2023-03-14T00:00:00.000Z",
         "hasData": true,

--- a/src/components/chart/chart.js
+++ b/src/components/chart/chart.js
@@ -81,6 +81,7 @@ const Chart = ({
       const { maxX, maxY } = chartHelpers.generateMaxXY({ dataSets: toggledDataSets });
       const { individualMaxY } = chartHelpers.generateMaxXY({ dataSets });
       const { xAxisProps, yAxisProps } = chartHelpers.generateAxisProps({
+        chartWidth,
         dataSets,
         individualMaxY,
         maxX,

--- a/src/components/chart/chartHelpers.js
+++ b/src/components/chart/chartHelpers.js
@@ -255,6 +255,7 @@ const generateTooltipData = ({ content = helpers.noop, dataSets = [] } = {}) => 
  * Generate X axis props, ticks, tick formatting.
  *
  * @param {object} params
+ * @param {number} params.chartWidth
  * @param {object} params.dataSet
  * @param {number} params.maxX
  * @param {number} params.xAxisLabelIncrement
@@ -263,6 +264,7 @@ const generateTooltipData = ({ content = helpers.noop, dataSets = [] } = {}) => 
  * @returns {{tickFormat: Function, tickValues: *}}
  */
 const generateXAxisProps = ({
+  chartWidth,
   dataSet = {},
   maxX,
   xAxisLabelIncrement,
@@ -292,7 +294,7 @@ const generateXAxisProps = ({
       const nextItem = { ...data[axisProps.tickValues[tickIndex + 1]] };
       const item = { ...data[tick] };
 
-      return xAxisTickFormat({ tick, previousItem, item, nextItem, maxX });
+      return xAxisTickFormat({ chartWidth, item, maxX, nextItem, previousItem, tick });
     };
   }
 
@@ -362,6 +364,7 @@ const generateYAxisProps = ({ dataSets = [], maxY, yAxisPropDefaults = {}, yAxis
  * Generate x,y props.
  *
  * @param {object} params
+ * @param {number} params.chartWidth
  * @param {Array} params.dataSets
  * @param {object} params.individualMaxY
  * @param {number} params.maxX
@@ -375,6 +378,7 @@ const generateYAxisProps = ({ dataSets = [], maxY, yAxisPropDefaults = {}, yAxis
  * @returns {{xAxisProps: object, yAxisProps: Array}}
  */
 const generateAxisProps = ({
+  chartWidth,
   dataSets = [],
   individualMaxY = {},
   maxX,
@@ -439,6 +443,7 @@ const generateAxisProps = ({
 
   return {
     xAxisProps: generateXAxisProps({
+      chartWidth,
       dataSet: xAxisDataSet,
       maxX,
       xAxisLabelIncrement,

--- a/src/components/graphCard/__tests__/__snapshots__/graphCardHelpers.test.js.snap
+++ b/src/components/graphCard/__tests__/__snapshots__/graphCardHelpers.test.js.snap
@@ -211,6 +211,16 @@ exports[`GraphCardHelpers xAxisTickFormat should produce consistent x axis tick 
     "Jul",
     "Oct",
     "Jan
+2015",
+    "Apr",
+    "Jul",
+    "Oct",
+    "Jan
+2016",
+    "Apr",
+    "Jul",
+    "Oct",
+    "Jan
 2017",
     "Apr",
     "Jul",
@@ -222,6 +232,34 @@ exports[`GraphCardHelpers xAxisTickFormat should produce consistent x axis tick 
     "Oct",
     "Jan
 2019",
+    "Apr",
+    "Jul",
+  ],
+  "quarterlySmallGraph": [
+    "Jul",
+    "Oct
+2014",
+    "Jan",
+    "Apr",
+    "Jul",
+    "Oct
+2015",
+    "Jan",
+    "Apr",
+    "Jul",
+    "Oct
+2016",
+    "Jan",
+    "Apr",
+    "Jul",
+    "Oct
+2017",
+    "Jan",
+    "Apr",
+    "Jul",
+    "Oct
+2018",
+    "Jan",
     "Apr",
     "Jul",
   ],

--- a/src/components/graphCard/__tests__/__snapshots__/graphCardHelpers.test.js.snap
+++ b/src/components/graphCard/__tests__/__snapshots__/graphCardHelpers.test.js.snap
@@ -236,32 +236,48 @@ exports[`GraphCardHelpers xAxisTickFormat should produce consistent x axis tick 
     "Jul",
   ],
   "quarterlySmallGraph": [
-    "Jul",
+    "Jul
+2014",
     "Oct
 2014",
-    "Jan",
-    "Apr",
-    "Jul",
+    "Jan
+2015",
+    "Apr
+2015",
+    "Jul
+2015",
     "Oct
 2015",
-    "Jan",
-    "Apr",
-    "Jul",
+    "Jan
+2016",
+    "Apr
+2016",
+    "Jul
+2016",
     "Oct
 2016",
-    "Jan",
-    "Apr",
-    "Jul",
+    "Jan
+2017",
+    "Apr
+2017",
+    "Jul
+2017",
     "Oct
 2017",
-    "Jan",
-    "Apr",
-    "Jul",
+    "Jan
+2018",
+    "Apr
+2018",
+    "Jul
+2018",
     "Oct
 2018",
-    "Jan",
-    "Apr",
-    "Jul",
+    "Jan
+2019",
+    "Apr
+2019",
+    "Jul
+2019",
   ],
   "weekly": [
     "Apr 21",

--- a/src/components/graphCard/__tests__/graphCardHelpers.test.js
+++ b/src/components/graphCard/__tests__/graphCardHelpers.test.js
@@ -50,16 +50,24 @@ describe('GraphCardHelpers', () => {
    * Now we emulate an API like response with "generateTicks".
    */
   it('xAxisTickFormat should produce consistent x axis tick values', () => {
-    const generateTicks = ({ startDate, endDate, granularity, momentGranularity }) => {
+    const generateTicks = ({ startDate, endDate, granularity, momentGranularity, chartWidth = 940 }) => {
       const endDateStartDateDiff = moment(endDate).diff(startDate, momentGranularity);
       const generatedTicks = [];
 
       for (let i = 0; i <= endDateStartDateDiff; i++) {
         const date = moment.utc(startDate).add(i, momentGranularity).startOf(momentGranularity);
         const previousDate = moment(date).subtract(1, momentGranularity).startOf(momentGranularity);
+        const nextDate = moment(date).add(1, momentGranularity).startOf(momentGranularity);
 
         generatedTicks.push(
-          xAxisTickFormat({ date: date.toISOString(), granularity, tick: i, previousDate: previousDate.toISOString() })
+          xAxisTickFormat({
+            chartWidth,
+            date: date.toISOString(),
+            granularity,
+            nextDate: nextDate.toISOString(),
+            previousDate: previousDate.toISOString(),
+            tick: i
+          })
         );
       }
 
@@ -87,7 +95,14 @@ describe('GraphCardHelpers', () => {
       momentGranularity: 'quarters'
     });
 
-    expect({ daily, weekly, monthly, quarterly }).toMatchSnapshot('x axis tick values');
+    const quarterlySmallGraph = generateTicks({
+      ...dateHelpers.quarterlyDateTime,
+      granularity: GRANULARITY_TYPES.QUARTERLY,
+      momentGranularity: 'quarters',
+      chartWidth: 900
+    });
+
+    expect({ daily, weekly, monthly, quarterly, quarterlySmallGraph }).toMatchSnapshot('x axis tick values');
 
     expect({
       missingDate: xAxisTickFormat({ granularity: GRANULARITY_TYPES.DAILY, tick: 0 }),

--- a/src/components/graphCard/__tests__/graphCardHelpers.test.js
+++ b/src/components/graphCard/__tests__/graphCardHelpers.test.js
@@ -50,7 +50,7 @@ describe('GraphCardHelpers', () => {
    * Now we emulate an API like response with "generateTicks".
    */
   it('xAxisTickFormat should produce consistent x axis tick values', () => {
-    const generateTicks = ({ startDate, endDate, granularity, momentGranularity, chartWidth = 940 }) => {
+    const generateTicks = ({ startDate, endDate, granularity, momentGranularity, chartWidth = 935 }) => {
       const endDateStartDateDiff = moment(endDate).diff(startDate, momentGranularity);
       const generatedTicks = [];
 

--- a/src/components/graphCard/graphCardHelpers.js
+++ b/src/components/graphCard/graphCardHelpers.js
@@ -248,27 +248,24 @@ const xAxisTickFormat = ({ callback, chartWidth, date, granularity, nextDate, pr
   }
 
   const momentDate = moment.utc(date);
-  const isNewYearStart =
-    previousDate && Number.parseInt(momentDate.year(), 10) !== Number.parseInt(moment.utc(previousDate).year(), 10);
+  const getIsNewYear = previousNextDate =>
+    previousDate &&
+    nextDate &&
+    Number.parseInt(momentDate.year(), 10) !== Number.parseInt(moment.utc(previousNextDate).year(), 10);
+  const isYearStart = getIsNewYear(previousDate);
   let formattedDate;
 
   switch (granularity) {
     case GRANULARITY_TYPES.QUARTERLY:
-      let isYearStartEnd = isNewYearStart;
-
-      if (chartWidth < 940) {
-        isYearStartEnd =
-          nextDate && Number.parseInt(momentDate.year(), 10) !== Number.parseInt(moment.utc(nextDate).year(), 10);
-      }
-
-      formattedDate = isYearStartEnd
-        ? momentDate.format(dateHelpers.timestampQuarterFormats.yearShort)
-        : momentDate.format(dateHelpers.timestampQuarterFormats.short);
+      formattedDate =
+        isYearStart || chartWidth < 935
+          ? momentDate.format(dateHelpers.timestampQuarterFormats.yearShort)
+          : momentDate.format(dateHelpers.timestampQuarterFormats.short);
 
       formattedDate = formattedDate.replace(/\s/, '\n');
       break;
     case GRANULARITY_TYPES.MONTHLY:
-      formattedDate = isNewYearStart
+      formattedDate = isYearStart
         ? momentDate.format(dateHelpers.timestampMonthFormats.yearShort)
         : momentDate.format(dateHelpers.timestampMonthFormats.short);
 
@@ -277,7 +274,7 @@ const xAxisTickFormat = ({ callback, chartWidth, date, granularity, nextDate, pr
     case GRANULARITY_TYPES.WEEKLY:
     case GRANULARITY_TYPES.DAILY:
     default:
-      formattedDate = isNewYearStart
+      formattedDate = isYearStart
         ? momentDate.format(dateHelpers.timestampDayFormats.yearShort)
         : momentDate.format(dateHelpers.timestampDayFormats.short);
 


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- refactor: sw-1594 quarterly range expand to 5 years

### Notes
- Due to the number of entries for quarterly views the graph x-axis ticks require an adjustment.
   - We attempted a different solution where we flipped the year from being applied to the beginning months to the end months. The primary reason being, we're unable to determine which ticks victory charts dynamically hides beyond "[every other one]". However this failed to show the graph display year when the browser/display date moved within the July quarter and recreated the original scenario.
   - To avoid having to do fine-grain date tick display logic now, and in the future, we're opting to stick with the solution proposed where we just show all dates for each of the x axis ticks since it bypasses the issues
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. confirm actual data is being returned for the graph (we tested using the RHEL x86 product display)
   - flip the granularity to Quarterly and confirm
      - the copy is updated correctly
      - 5 years (60 months) from the current quarter is displayed
      - scale the browser down and confirm the `year` moves from `Jan` to `Oct` at smaller graph sizes

<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->


Final small display size
![Screenshot 2024-05-22 at 1 10 49 PM](https://github.com/RedHatInsights/curiosity-frontend/assets/3761375/eee95f37-6c21-406f-9c8e-2cc223eeeb1c)


Final full size
![Screenshot 2024-05-21 at 10 58 41 PM](https://github.com/RedHatInsights/curiosity-frontend/assets/3761375/392beff8-591e-4ddc-b23c-26a44f8dda6f)

Attempt at reducing size by moving the dates to the last date. This fails with victory dynamic tick hiding/scaling when the July quarter displays
![Screenshot 2024-05-21 at 10 52 54 PM](https://github.com/RedHatInsights/curiosity-frontend/assets/3761375/3f57c6a2-3ed2-43c5-a72d-fe5191be6099)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-1594