### PR TITLE
fix (rhsmTransformers): sw-2627 restore meta spread for subscriptions

### DIFF
--- a/src/services/rhsm/__tests__/__snapshots__/rhsmTransformers.test.js.snap
+++ b/src/services/rhsm/__tests__/__snapshots__/rhsmTransformers.test.js.snap
@@ -422,6 +422,7 @@ exports[`RHSM Transformers should attempt to parse a subscriptions response: sub
   ],
   "meta": {
     "count": undefined,
+    "lorem": "ipsum",
     "productId": undefined,
   },
 }
@@ -440,6 +441,7 @@ exports[`RHSM Transformers should attempt to parse a subscriptions response: sub
   ],
   "meta": {
     "count": undefined,
+    "lorem": "ipsum",
     "productId": undefined,
   },
 }
@@ -465,6 +467,7 @@ exports[`RHSM Transformers should attempt to parse a subscriptions response: sub
   ],
   "meta": {
     "count": undefined,
+    "lorem": "ipsum",
     "productId": undefined,
   },
 }

--- a/src/services/rhsm/__tests__/rhsmTransformers.test.js
+++ b/src/services/rhsm/__tests__/rhsmTransformers.test.js
@@ -225,7 +225,8 @@ describe('RHSM Transformers', () => {
         }
       ],
       [rhsmConstants.RHSM_API_RESPONSE_META]: {
-        [rhsmConstants.RHSM_API_RESPONSE_INSTANCES_META_TYPES.MEASUREMENTS]: ['c', 'a', 'b']
+        [rhsmConstants.RHSM_API_RESPONSE_INSTANCES_META_TYPES.MEASUREMENTS]: ['c', 'a', 'b'],
+        lorem: 'ipsum'
       }
     };
 
@@ -341,7 +342,9 @@ describe('RHSM Transformers', () => {
           [rhsmConstants.RHSM_API_RESPONSE_SUBSCRIPTIONS_DATA_TYPES.METRIC_ID]: 'Cores'
         }
       ],
-      [rhsmConstants.RHSM_API_RESPONSE_META]: {}
+      [rhsmConstants.RHSM_API_RESPONSE_META]: {
+        lorem: 'ipsum'
+      }
     };
 
     expect(rhsmTransformers.subscriptions(response)).toMatchSnapshot('subscriptions, metric_id cores');
@@ -369,7 +372,9 @@ describe('RHSM Transformers', () => {
             [rhsmConstants.RHSM_API_RESPONSE_SUBSCRIPTIONS_DATA_TYPES.METRIC_ID]: 'Sockets'
           }
         ],
-        [rhsmConstants.RHSM_API_RESPONSE_META]: {}
+        [rhsmConstants.RHSM_API_RESPONSE_META]: {
+          lorem: 'ipsum'
+        }
       })
     ).toMatchSnapshot('subscriptions, metric_id sockets, cores response');
   });

--- a/src/services/rhsm/rhsmTransformers.js
+++ b/src/services/rhsm/rhsmTransformers.js
@@ -140,6 +140,7 @@ const rhsmSubscriptions = response => {
   );
 
   updatedResponse.meta = {
+    ...meta,
     count: meta[SUBSCRIPTIONS_META_TYPES.COUNT],
     productId: meta[SUBSCRIPTIONS_META_TYPES.PRODUCT]
   };


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix (rhsmTransformers): sw-2627 restore meta spread for subscriptions

### Notes
- the work in #1305 removed the `meta` spread that allowed subsequent display of meta response properties. Specifically this affects RHEL ELS in staging since it used the `subscription_type`, but any subscription inventory display that required this property would also be affected
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. navigate to the RHEL view
  - confirm RHEL x86 ELS subscriptions inventory table displays the "subscription type" inventory column with relevant data
  - next, comment out the patch on [line 143 ](https://github.com/RedHatInsights/curiosity-frontend/pull/1334/files#diff-6e49829ef27c76e1510fbce257d5b141e4c323262910f8eb678f1122615937bfR143), let the page rebuild, confirm the RHEL x86 ELS subscriptions inventory table no longer displays the "subscription type" field

### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. navigate to the RHEL view
   - confirm RHEL x86 ELS subscriptions inventory table displays the "subscription type" inventory column with relevant data

<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-2627
related #1305 sw-1232