### PR TITLE
ci: relax integration checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "build:deps": "bash ./scripts/dependencies.sh --doctor -u --doctorTest \"npm run test:deps\" --reject \"@patternfly/*, @redhat-cloud-services/frontend*, react-router, victory*\"",
     "build:deps-core": "bash ./scripts/dependencies.sh --doctor -u --doctorTest \"npm run test:deps\" --filter \"@patternfly/*, @redhat-cloud-services/frontend*, victory*\"",
     "build:docs": "run-s -l test:docs docs:md",
-    "build:ephemeral": "run-s -l build:pr_checks",
+    "build:ephemeral": "run-s -l build:pre build:js build:post test:integration-ephemeral",
     "build:pr_checks": "run-s -l build:pre build:js build:post",
     "build:js": "export NODE_ENV=production; fec build",
     "build:post": "bash ./scripts/post.sh",
@@ -72,7 +72,7 @@
     "test:spell-support": "cspell ./README.md ./config/README.md ./CONTRIBUTING.md --config ./config/cspell.config.json",
     "test:spell": "cspell './public/locales/**/en*json' './src/**/*.js' --config ./config/cspell.config.json",
     "test:local": "jest --roots=./src --watch",
-    "verify": "run-s test:ephemeral build:ephemeral",
+    "verify": "run-s test:ephemeral build:pr_checks",
     "postinstall": "ts-patch install"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "build:deps": "bash ./scripts/dependencies.sh --doctor -u --doctorTest \"npm run test:deps\" --reject \"@patternfly/*, @redhat-cloud-services/frontend*, react-router, victory*\"",
     "build:deps-core": "bash ./scripts/dependencies.sh --doctor -u --doctorTest \"npm run test:deps\" --filter \"@patternfly/*, @redhat-cloud-services/frontend*, victory*\"",
     "build:docs": "run-s -l test:docs docs:md",
-    "build:ephemeral": "run-s -l build:pre build:js build:post test:integration-ephemeral",
+    "build:ephemeral": "run-s -l build:pr_checks",
     "build:pr_checks": "run-s -l build:pre build:js build:post",
     "build:js": "export NODE_ENV=production; fec build",
     "build:post": "bash ./scripts/post.sh",

--- a/scripts/actions.commit.js
+++ b/scripts/actions.commit.js
@@ -96,7 +96,7 @@ const parseCommitMessage = (message, messageTypes = availableMessageTypes) => {
 const messagesList = (
   parsedMessages,
   {
-    issueNumberExceptions = ['build', 'chore', 'docs', 'fix', 'perf', 'refactor', 'test'],
+    issueNumberExceptions = ['build', 'chore', 'ci', 'docs', 'fix', 'perf', 'refactor', 'test'],
     maxMessageLength = 65,
     typeScopeExceptions = '*'
   } = {}


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- ci: relax integration checks

### Notes
- the integration checks seem to suffer from the same setback here too...
   - the env setup creates build output differences which in turn creates failures in the output checks. since we're already performing these checks in multiple places lets remove/relax them here too
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
- Confirm the related `ci` check now passes.
   - There may still be failure, you'll have to review the related console output to confirm
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing
related #1290 