### PR TITLE
feat(dateHelpers): sw-2353 added setMillisecondsFromDate

### DIFF
--- a/config/jest.setupTests.js
+++ b/config/jest.setupTests.js
@@ -291,9 +291,11 @@ global.renderHook = async (useHook = Function.prototype, options = {}) => {
   let result;
   let spyUseSelector;
   let unmountHook;
+  let rerenderHook;
 
-  const Hook = () => {
-    result = useHook();
+  // eslint-disable-next-line react/prop-types
+  const Hook = ({ args = [] }) => {
+    result = useHook(...args);
     return null;
   };
 
@@ -301,12 +303,15 @@ global.renderHook = async (useHook = Function.prototype, options = {}) => {
     await act(async () => unmountHook());
   };
 
+  const rerender = (...args) => rerenderHook(<Hook args={args} />);
+
   await act(async () => {
     if (updatedOptions.state) {
       spyUseSelector = jest.spyOn(reactRedux, 'useSelector').mockImplementation(_ => _(updatedOptions.state));
     }
-    const { unmount: unmountRender } = await render(<Hook />);
+    const { unmount: unmountRender, rerender: rerenderRender } = await render(<Hook />);
     unmountHook = unmountRender;
+    rerenderHook = rerenderRender;
   });
 
   if (updatedOptions.state) {
@@ -333,7 +338,7 @@ global.renderHook = async (useHook = Function.prototype, options = {}) => {
     });
   }
 
-  return { unmount, result: updatedResult, act };
+  return { unmount, rerender, result: updatedResult, act };
 };
 
 /**

--- a/src/common/README.md
+++ b/src/common/README.md
@@ -30,6 +30,7 @@
     * [~setStartOfDay(date)](#Helpers.module_Dates..setStartOfDay) ⇒ <code>Date</code>
     * [~setEndOfMonth(date)](#Helpers.module_Dates..setEndOfMonth) ⇒ <code>Date</code>
     * [~setRangedDateTime(params)](#Helpers.module_Dates..setRangedDateTime) ⇒ <code>Object</code>
+    * [~setMillisecondsFromDate(params)](#Helpers.module_Dates..setMillisecondsFromDate) ⇒ <code>Date</code>
     * [~getRangedDateTime(granularity)](#Helpers.module_Dates..getRangedDateTime) ⇒ <code>Object</code>
     * [~getRangedMonthDateTime(month, defaultLocale)](#Helpers.module_Dates..getRangedMonthDateTime) ⇒ <code>Object</code> \| <code>\*</code> \| <code>undefined</code>
 
@@ -190,6 +191,29 @@ Set a date range based on a granularity type.
     </tr><tr>
     <td>params.measurement</td><td><code>&#x27;days&#x27;</code> | <code>&#x27;weeks&#x27;</code> | <code>&#x27;months&#x27;</code> | <code>&#x27;years&#x27;</code></td><td><p>Granularity type .</p>
 </td>
+    </tr>  </tbody>
+</table>
+
+<a name="Helpers.module_Dates..setMillisecondsFromDate"></a>
+
+### Dates~setMillisecondsFromDate(params) ⇒ <code>Date</code>
+Set milliseconds from date. Defaults to internal current date.
+
+**Kind**: inner method of [<code>Dates</code>](#Helpers.module_Dates)  
+<table>
+  <thead>
+    <tr>
+      <th>Param</th><th>Type</th><th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+<tr>
+    <td>params</td><td><code>object</code></td><td></td>
+    </tr><tr>
+    <td>params.date</td><td><code>Date</code></td><td><p>The date to add milliseconds towards. Defaults to current date.</p>
+</td>
+    </tr><tr>
+    <td>params.ms</td><td><code>number</code></td><td></td>
     </tr>  </tbody>
 </table>
 

--- a/src/common/__tests__/__snapshots__/dateHelpers.test.js.snap
+++ b/src/common/__tests__/__snapshots__/dateHelpers.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DateHelpers should add milliseconds from date: add milliseconds 1`] = `2019-07-21T00:00:00.000Z`;
+
 exports[`DateHelpers should have specific functions: dateHelpers 1`] = `
 {
   "currentDateTime": {
@@ -27,6 +29,7 @@ exports[`DateHelpers should have specific functions: dateHelpers 1`] = `
   },
   "setEndOfDay": [Function],
   "setEndOfMonth": [Function],
+  "setMillisecondsFromDate": [Function],
   "setRangedDateTime": [Function],
   "setStartOfDay": [Function],
   "timestampDayFormats": {

--- a/src/common/__tests__/dateHelpers.test.js
+++ b/src/common/__tests__/dateHelpers.test.js
@@ -101,4 +101,8 @@ describe('DateHelpers', () => {
 
     expect(dateHelpers.setEndOfMonth(startDate).getTime()).toEqual(expectedDate.getTime());
   });
+
+  it('should add milliseconds from date', () => {
+    expect(dateHelpers.setMillisecondsFromDate({ ms: 86400000 })).toMatchSnapshot('add milliseconds');
+  });
 });

--- a/src/common/dateHelpers.js
+++ b/src/common/dateHelpers.js
@@ -84,6 +84,17 @@ const setRangedDateTime = ({ date = getCurrentDate(), subtract = 0, measurement 
 };
 
 /**
+ * Set milliseconds from date. Defaults to internal current date.
+ *
+ * @param {object} params
+ * @param {Date} params.date The date to add milliseconds towards. Defaults to current date.
+ * @param {number} params.ms
+ * @returns {Date}
+ */
+const setMillisecondsFromDate = ({ date = getCurrentDate(), ms = 0 } = {}) =>
+  new Date(new Date(date).setUTCMilliseconds(ms));
+
+/**
  * Generates the date range, starting at the beginning of getCurrentDate, and ending at the end of getCurrentDate.
  *
  * @type {{endDate: Date, startDate: Date}}
@@ -288,6 +299,7 @@ const dateHelpers = {
   setStartOfDay,
   setEndOfDay,
   setEndOfMonth,
+  setMillisecondsFromDate,
   getRangedMonthDateTime,
   getRangedDateTime,
   setRangedDateTime,
@@ -310,6 +322,7 @@ export {
   setStartOfDay,
   setEndOfDay,
   setEndOfMonth,
+  setMillisecondsFromDate,
   getRangedMonthDateTime,
   getRangedDateTime,
   setRangedDateTime,

--- a/src/common/downloadHelpers.js
+++ b/src/common/downloadHelpers.js
@@ -38,8 +38,8 @@ const downloadData = options => {
         anchorTag.click();
 
         setTimeout(() => {
+          URL.revokeObjectURL(anchorTag.href);
           document.body.removeChild(anchorTag);
-          URL.revokeObjectURL(blob);
           resolve({ fileName, data });
         }, 250);
       }


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- feat(dateHelpers): sw-2353 added setMillisecondsFromDate
- test: expand jest renderHook, allow rerender, updated args

### Notes
- incremental support work for sw-2353
- no visual updates associated with this work
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. next...
-->

### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. confirm tests come back clean

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
related sw-2353 #1328 