### PR TITLE
refactor: sw-2353 onmount, dispatch refinement

### DIFF
--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -371,7 +371,7 @@ exports[`I18n Component should generate a predictable locale key output snapshot
       },
       {
         "key": "curiosity-toolbar.notifications",
-        "match": "t('curiosity-toolbar.notifications', { context: ['export', 'completed', 'description'], count: allCompleted.length, fileName: completed?.[0]?.fileName })",
+        "match": "t('curiosity-toolbar.notifications', { context: ['export', 'completed', 'description'], count: completed.length, fileName: completed?.[0]?.fileName })",
       },
       {
         "key": "curiosity-toolbar.notifications",

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldExportContext.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldExportContext.test.js.snap
@@ -25,68 +25,44 @@ exports[`ToolbarFieldExport Component should aggregate export status, polling st
 
 exports[`ToolbarFieldExport Component should allow export service calls on existing exports: existingExports 1`] = `
 [
-  {
-    "type": "return",
-    "value": undefined,
-  },
-  {
-    "type": "return",
-    "value": {
-      "payload": "swatch-exports-status",
-      "type": "@@INSIGHTS-CORE/NOTIFICATIONS/REMOVE_NOTIFICATION",
-    },
-  },
-  {
-    "type": "return",
-    "value": {
-      "payload": {
-        "autoDismiss": false,
-        "description": <div
-          aria-live="polite"
-        >
-          t(curiosity-toolbar.notifications_export_completed_description_existing, {"context":"pending","count":1,"completed":0,"pending":1})
-          <div
-            style={
-              {
-                "paddingTop": "0.5rem",
-              }
+  [],
+  [
+    {
+      "autoDismiss": false,
+      "description": <div
+        aria-live="polite"
+      >
+        t(curiosity-toolbar.notifications_export_completed_description_existing, {"context":"pending","count":1,"completed":0,"pending":1})
+        <div
+          style={
+            {
+              "paddingTop": "0.5rem",
             }
+          }
+        >
+          <Button
+            autoFocus={true}
+            data-test="exportButtonConfirm"
+            onClick={[Function]}
+            variant="primary"
           >
-            <Button
-              autoFocus={true}
-              data-test="exportButtonConfirm"
-              onClick={[Function]}
-              variant="primary"
-            >
-              t(curiosity-toolbar.button, {"context":"yes"})
-            </Button>
-             
-            <Button
-              data-test="exportButtonCancel"
-              onClick={[Function]}
-              variant="plain"
-            >
-              t(curiosity-toolbar.button, {"context":"no"})
-            </Button>
-          </div>
-        </div>,
-        "dismissable": false,
-        "id": "swatch-exports-status",
-        "title": "t(curiosity-toolbar.notifications_export_completed_title, {"context":"existing","count":1})",
-      },
-      "type": "@@INSIGHTS-CORE/NOTIFICATIONS/ADD_NOTIFICATION",
+            t(curiosity-toolbar.button, {"context":"yes"})
+          </Button>
+           
+          <Button
+            data-test="exportButtonCancel"
+            onClick={[Function]}
+            variant="plain"
+          >
+            t(curiosity-toolbar.button, {"context":"no"})
+          </Button>
+        </div>
+      </div>,
+      "dismissable": false,
+      "id": "swatch-exports-status",
+      "title": "t(curiosity-toolbar.notifications_export_completed_title, {"context":"existing","count":1})",
     },
-  },
-  {
-    "type": "return",
-    "value": [Function],
-  },
-  {
-    "type": "return",
-    "value": {
-      "type": "SET_PLATFORM_EXPORT_RESET",
-    },
-  },
+  ],
 ]
 `;
 
@@ -94,15 +70,14 @@ exports[`ToolbarFieldExport Component should allow export service calls: createE
 [
   {
     "type": "return",
-    "value": {
-      "id": "mock-product-id",
-      "isPending": true,
-      "type": "SET_PLATFORM_EXPORT_STATUS",
-    },
-  },
-  {
-    "type": "return",
-    "value": "mock-product-id",
+    "value": [
+      {
+        "id": "mock-product-id",
+        "isPending": true,
+        "type": "SET_PLATFORM_EXPORT_STATUS",
+      },
+      "dispatch => Promise.resolve(dispatch(...args))",
+    ],
   },
   {
     "type": "return",
@@ -140,43 +115,24 @@ exports[`ToolbarFieldExport Component should allow service calls on user confirm
 
 exports[`ToolbarFieldExport Component should expose an export polling status confirmation: statusConfirmation 1`] = `
 [
-  {
-    "type": "return",
-    "value": {
-      "payload": "swatch-exports-individual-status",
-      "type": "@@INSIGHTS-CORE/NOTIFICATIONS/REMOVE_NOTIFICATION",
-    },
-  },
-  {
-    "type": "return",
-    "value": {
-      "payload": {
-        "description": "t(curiosity-toolbar.notifications_export_completed, {"context":"description","count":1,"fileName":"helloWorldFileName"})",
-        "dismissable": true,
-        "id": "swatch-exports-individual-status",
-        "title": "t(curiosity-toolbar.notifications_export_completed, {"context":"title"})",
-        "variant": "success",
+  [
+    [
+      [Function],
+      {
+        "id": "loremIpsum",
+        "isPending": false,
+        "pending": [
+          {
+            "fileName": "dolorSitFileName",
+            "id": "dolorSit",
+          },
+        ],
+        "type": "SET_PLATFORM_EXPORT_STATUS",
       },
-      "type": "@@INSIGHTS-CORE/NOTIFICATIONS/ADD_NOTIFICATION",
-    },
-  },
-  {
-    "type": "return",
-    "value": {
-      "id": "loremIpsum",
-      "isPending": false,
-      "pending": [
-        {
-          "fileName": "dolorSitFileName",
-          "id": "dolorSit",
-        },
-      ],
-      "type": "SET_PLATFORM_EXPORT_STATUS",
-    },
-  },
-  {
-    "type": "return",
-    "value": [Function],
-  },
+    ],
+  ],
+  [
+    [Function],
+  ],
 ]
 `;

--- a/src/components/toolbar/__tests__/toolbarFieldExportContext.test.js
+++ b/src/components/toolbar/__tests__/toolbarFieldExportContext.test.js
@@ -55,7 +55,7 @@ describe('ToolbarFieldExport Component', () => {
     });
 
     await unmount();
-    expect(mockDispatch.mock.results).toMatchSnapshot('statusConfirmation');
+    expect(mockDispatch.mock.calls).toMatchSnapshot('statusConfirmation');
   });
 
   it('should allow export service calls', async () => {
@@ -70,6 +70,7 @@ describe('ToolbarFieldExport Component', () => {
   it('should allow export service calls on existing exports', async () => {
     const { unmount } = await renderHook((...args) => {
       useExistingExports({
+        addNotification: mockService,
         getExistingExports: mockService,
         getExistingExportsStatus: mockService,
         deleteExistingExports: mockService,
@@ -82,7 +83,7 @@ describe('ToolbarFieldExport Component', () => {
     });
 
     await unmount();
-    expect(mockDispatch.mock.results).toMatchSnapshot('existingExports');
+    expect(mockService.mock.calls).toMatchSnapshot('existingExports');
   });
 
   it('should allow service calls on user confirmation', async () => {


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- refactor: sw-2353 onmount, dispatch refinement

### Notes
- optimizes the onmount call for existing downloads, there should be no change in behavior
- restructure the dispatch calls to remove redundancy
   - there's a limitation on multiple dispatches and the notifications redux provided through frontend components. the first call will go through, but subsequent notification calls will throw an error in a multi-dispatch situation. the quick solution is to avoid adding multiple notification adds/removals within the same dispatch
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. next...
-->

### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. confirm tests come back clean

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-2353 
related #1354 