### PR TITLE
test(toolbarFieldContext): sw-2353 add notification testIds

### DIFF
--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -363,11 +363,11 @@ exports[`I18n Component should generate a predictable locale key output snapshot
     "keys": [
       {
         "key": "curiosity-toolbar.notifications",
-        "match": "t('curiosity-toolbar.notifications', { context: ['export', 'pending', 'title'] })",
+        "match": "t('curiosity-toolbar.notifications', { context: ['export', 'pending', 'title'], testId: 'exportNotification-individual-pending' })",
       },
       {
         "key": "curiosity-toolbar.notifications",
-        "match": "t('curiosity-toolbar.notifications', { context: ['export', 'completed', 'title'] })",
+        "match": "t('curiosity-toolbar.notifications', { context: ['export', 'completed', 'title'], testId: 'exportNotification-individual-completed' })",
       },
       {
         "key": "curiosity-toolbar.notifications",
@@ -375,7 +375,7 @@ exports[`I18n Component should generate a predictable locale key output snapshot
       },
       {
         "key": "curiosity-toolbar.notifications",
-        "match": "t('curiosity-toolbar.notifications', { context: ['export', 'error', 'title'] })",
+        "match": "t('curiosity-toolbar.notifications', { context: ['export', 'error', 'title'], testId: 'exportNotification-individual-error' })",
       },
       {
         "key": "curiosity-toolbar.notifications",
@@ -383,11 +383,11 @@ exports[`I18n Component should generate a predictable locale key output snapshot
       },
       {
         "key": "curiosity-toolbar.notifications",
-        "match": "t('curiosity-toolbar.notifications', { context: ['export', 'pending', 'titleGlobal'] })",
+        "match": "t('curiosity-toolbar.notifications', { context: ['export', 'pending', 'titleGlobal'], testId: 'exportNotification-existing-pending' })",
       },
       {
         "key": "curiosity-toolbar.notifications",
-        "match": "t('curiosity-toolbar.notifications', { context: ['export', 'completed', 'titleGlobal'], count: allResults.length })",
+        "match": "t('curiosity-toolbar.notifications', { context: ['export', 'completed', 'titleGlobal'], count: allResults.length, testId: 'exportNotification-existing-completed' })",
       },
       {
         "key": "curiosity-toolbar.notifications",
@@ -395,7 +395,7 @@ exports[`I18n Component should generate a predictable locale key output snapshot
       },
       {
         "key": "curiosity-toolbar.notifications",
-        "match": "t('curiosity-toolbar.notifications', { context: ['export', 'completed', 'title', 'existing'], count: totalResults })",
+        "match": "t('curiosity-toolbar.notifications', { context: ['export', 'completed', 'title', 'existing'], count: totalResults, testId: 'exportNotification-existing-confirmation' })",
       },
       {
         "key": "curiosity-toolbar.notifications",

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldExportContext.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldExportContext.test.js.snap
@@ -60,7 +60,7 @@ exports[`ToolbarFieldExport Component should allow export service calls on exist
       </div>,
       "dismissable": false,
       "id": "swatch-exports-status",
-      "title": "t(curiosity-toolbar.notifications_export_completed_title, {"context":"existing","count":1})",
+      "title": "t(curiosity-toolbar.notifications_export_completed_title, {"context":"existing","count":1,"testId":"exportNotification-existing-confirmation"})",
     },
   ],
 ]
@@ -105,7 +105,7 @@ exports[`ToolbarFieldExport Component should allow service calls on user confirm
       "pending": {
         "dismissable": true,
         "id": "swatch-exports-existing-confirmation",
-        "title": "t(curiosity-toolbar.notifications_export_pending, {"context":"titleGlobal"})",
+        "title": "t(curiosity-toolbar.notifications_export_pending, {"context":"titleGlobal","testId":"exportNotification-existing-pending"})",
         "variant": "info",
       },
     },

--- a/src/components/toolbar/toolbarFieldExportContext.js
+++ b/src/components/toolbar/toolbarFieldExportContext.js
@@ -54,7 +54,8 @@ const useExportConfirmation = ({
           id: 'swatch-exports-individual-status',
           variant: 'info',
           title: t('curiosity-toolbar.notifications', {
-            context: ['export', 'pending', 'title']
+            context: ['export', 'pending', 'title'],
+            testId: 'exportNotification-individual-pending'
           }),
           dismissable: true
         };
@@ -65,7 +66,8 @@ const useExportConfirmation = ({
           id: 'swatch-exports-individual-status',
           variant: 'success',
           title: t('curiosity-toolbar.notifications', {
-            context: ['export', 'completed', 'title']
+            context: ['export', 'completed', 'title'],
+            testId: 'exportNotification-individual-completed'
           }),
           description: t('curiosity-toolbar.notifications', {
             context: ['export', 'completed', 'description'],
@@ -127,7 +129,8 @@ const useExport = ({
             rejected: {
               variant: 'warning',
               title: t('curiosity-toolbar.notifications', {
-                context: ['export', 'error', 'title']
+                context: ['export', 'error', 'title'],
+                testId: 'exportNotification-individual-error'
               }),
               description: t('curiosity-toolbar.notifications', {
                 context: ['export', 'error', 'description']
@@ -179,7 +182,10 @@ const useExistingExportsConfirmation = ({
         pending: {
           id: 'swatch-exports-existing-confirmation',
           variant: 'info',
-          title: t('curiosity-toolbar.notifications', { context: ['export', 'pending', 'titleGlobal'] }),
+          title: t('curiosity-toolbar.notifications', {
+            context: ['export', 'pending', 'titleGlobal'],
+            testId: 'exportNotification-existing-pending'
+          }),
           dismissable: true
         }
       })(dispatch).then(() => {
@@ -190,7 +196,8 @@ const useExistingExportsConfirmation = ({
               variant: 'success',
               title: t('curiosity-toolbar.notifications', {
                 context: ['export', 'completed', 'titleGlobal'],
-                count: allResults.length
+                count: allResults.length,
+                testId: 'exportNotification-existing-completed'
               }),
               description: t('curiosity-toolbar.notifications', {
                 context: ['export', 'completed', 'descriptionGlobal'],
@@ -261,7 +268,8 @@ const useExistingExports = ({
           id: 'swatch-exports-status',
           title: t('curiosity-toolbar.notifications', {
             context: ['export', 'completed', 'title', 'existing'],
-            count: totalResults
+            count: totalResults,
+            testId: 'exportNotification-existing-confirmation'
           }),
           description: (
             <div aria-live="polite">


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- test(toolbarFieldConext): sw-2353 add notification testIds

### Notes
- added testIds to toast notification titles
   - for existing exports there are `3` notification ids available ( note: there is no error notification for existing on purpose. it's a non-blocking error. if the existing export fails the result is the "existing notification" reappears on next application mount )
      - Custom status type (the confirmation buttons title) = testId, `exportNotification-existing-confirmation`
      - Upon hitting `yes` the following IDs should be available
         - Info type (the pending title) = testId, `exportNotification-existing-pending`
         - Success type (the success title) = testId, `exportNotification-existing-completed`
   - for individual exports per variant there are `3` notification ids available
      - Warning type (the warning/error title) = testId, `exportNotification-individual-error`
      - Info type (the pending title) = testId, `exportNotification-individual-pending`
      - Success type (the success title) = testId, `exportNotification-individual-completed`
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. open the developer console
   - attempt to right click and inspect the toast notifications for export pending and success.
      - the ids should align to the above `notes` description

<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
related sw-2353