### PR TITLE
feat(toolbarFieldExport): sw-2768 activate instances data

### DIFF
--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldExport.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldExport.test.js.snap
@@ -24,6 +24,11 @@ exports[`ToolbarFieldExport Component should handle updating export through redu
           "filters": {},
           "resource": "subscriptions",
         },
+        {
+          "application": "subscriptions",
+          "filters": {},
+          "resource": "instances",
+        },
       ],
     },
   ],

--- a/src/components/toolbar/toolbarFieldExport.js
+++ b/src/components/toolbar/toolbarFieldExport.js
@@ -58,6 +58,13 @@ const useOnSelect = ({
         [SOURCE_TYPES.FILTERS]: {
           ...exportQuery
         }
+      },
+      {
+        [SOURCE_TYPES.APPLICATION]: APP_TYPES.SUBSCRIPTIONS,
+        [SOURCE_TYPES.RESOURCE]: RESOURCE_TYPES.INSTANCES,
+        [SOURCE_TYPES.FILTERS]: {
+          ...exportQuery
+        }
       }
     ];
 


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- feat(toolbarFieldExport): sw-2768 activate instances data

### Notes
- **download note** - the downloaded data ONLY makes a human readable distinction between the instances and subscriptions reports via the `meta.json` file that is included in the package
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. navigate towards the ui and select an export for JSON
   - confirm the downloaded file expands and contains both Subscriptions and Instances

<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-2768