### PR TITLE
feat(toolbarFieldExport): sw-2769 activate csv export 

### DIFF
--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldExport.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldExport.test.js.snap
@@ -4,6 +4,11 @@ exports[`ToolbarFieldExport Component should export select options: toolbarField
 [
   {
     "selected": false,
+    "title": "t(curiosity-toolbar.label_export, {"context":"csv"})",
+    "value": "csv",
+  },
+  {
+    "selected": false,
     "title": "t(curiosity-toolbar.label_export, {"context":"json"})",
     "value": "json",
   },
@@ -56,6 +61,12 @@ exports[`ToolbarFieldExport Component should render a basic component: basic 1`]
   onSplitButton={null}
   options={
     [
+      {
+        "isDisabled": false,
+        "selected": false,
+        "title": "t(curiosity-toolbar.label_export, {"context":"csv"})",
+        "value": "csv",
+      },
       {
         "isDisabled": false,
         "selected": false,

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldExportContext.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldExportContext.test.js.snap
@@ -74,6 +74,12 @@ exports[`ToolbarFieldExport Component should allow export service calls: createE
       {
         "id": "mock-product-id",
         "isPending": true,
+        "isSelectUpdated": true,
+        "pending": [
+          {
+            "format": undefined,
+          },
+        ],
         "type": "SET_PLATFORM_EXPORT_STATUS",
       },
       "dispatch => Promise.resolve(dispatch(...args))",

--- a/src/components/toolbar/__tests__/toolbarFieldExportContext.test.js
+++ b/src/components/toolbar/__tests__/toolbarFieldExportContext.test.js
@@ -47,6 +47,7 @@ describe('ToolbarFieldExport Component', () => {
             loremIpsum: {
               completed: [{ id: 'helloWorld', fileName: 'helloWorldFileName' }],
               isCompleted: true,
+              isPending: false,
               pending: [{ id: 'dolorSit', fileName: 'dolorSitFileName' }]
             }
           }

--- a/src/components/toolbar/toolbarFieldExport.js
+++ b/src/components/toolbar/toolbarFieldExport.js
@@ -106,13 +106,11 @@ const ToolbarFieldExport = ({
   const updatedOptions = options.map(option => ({
     ...option,
     title:
-      (((isProductPending && !pendingProductFormats?.length) ||
-        (isProductPending && pendingProductFormats?.includes(option.value))) &&
+      (isProductPending &&
+        pendingProductFormats?.includes(option.value) &&
         t('curiosity-toolbar.label', { context: ['export', 'loading'] })) ||
       option.title,
-    selected:
-      (isProductPending && !pendingProductFormats?.length) ||
-      (isProductPending && pendingProductFormats?.includes(option.value)),
+    selected: isProductPending && pendingProductFormats?.includes(option.value),
     isDisabled:
       (isProductPending && !pendingProductFormats?.length) ||
       (isProductPending && pendingProductFormats?.includes(option.value))

--- a/src/components/toolbar/toolbarFieldExportContext.js
+++ b/src/components/toolbar/toolbarFieldExportContext.js
@@ -3,6 +3,7 @@ import { useEffectOnce, useUnmount } from 'react-use';
 import { Button } from '@patternfly/react-core';
 import { reduxActions, reduxTypes, storeHooks } from '../../redux';
 import { useProduct } from '../productView/productViewContext';
+import { PLATFORM_API_EXPORT_POST_TYPES as POST_TYPES } from '../../services/platform/platformConstants';
 import { translate } from '../i18n/i18n';
 import { useAppLoad } from '../../hooks/useApp';
 
@@ -124,7 +125,9 @@ const useExport = ({
         {
           type: reduxTypes.platform.SET_PLATFORM_EXPORT_STATUS,
           id,
-          isPending: true
+          isPending: true,
+          isSelectUpdated: true,
+          pending: [{ format: data?.[POST_TYPES.FORMAT] }]
         },
         createAliasExport(
           id,

--- a/src/components/toolbar/toolbarFieldExportContext.js
+++ b/src/components/toolbar/toolbarFieldExportContext.js
@@ -41,54 +41,59 @@ const useExportConfirmation = ({
 
   return useCallback(
     ({ error, data } = {}, retryCount) => {
-      const { completed = [], isCompleted, pending = [] } = data?.data?.products?.[productId] || {};
-      const isPending = !isCompleted;
-      let notification;
+      const { completed = [], isCompleted, isPending, pending = [] } = data?.data?.products?.[productId] || {};
 
       if (error || !confirmAppLoaded()) {
         return;
       }
 
+      // Display pending notification. No data is returned on the initial status response.
       if (retryCount === -1) {
-        notification = {
-          id: 'swatch-exports-individual-status',
-          variant: 'info',
-          title: t('curiosity-toolbar.notifications', {
-            context: ['export', 'pending', 'title'],
-            testId: 'exportNotification-individual-pending'
-          }),
-          dismissable: true
-        };
-      }
-
-      if (isCompleted) {
-        notification = {
-          id: 'swatch-exports-individual-status',
-          variant: 'success',
-          title: t('curiosity-toolbar.notifications', {
-            context: ['export', 'completed', 'title'],
-            testId: 'exportNotification-individual-completed'
-          }),
-          description: t('curiosity-toolbar.notifications', {
-            context: ['export', 'completed', 'description'],
-            count: completed.length,
-            fileName: completed?.[0]?.fileName
-          }),
-          dismissable: true
-        };
-      }
-
-      if (notification) {
         dispatch([
-          addAliasNotification(notification),
-          {
-            type: reduxTypes.platform.SET_PLATFORM_EXPORT_STATUS,
-            id: productId,
-            isPending,
-            pending
-          }
+          addAliasNotification({
+            id: 'swatch-exports-individual-status',
+            variant: 'info',
+            title: t('curiosity-toolbar.notifications', {
+              context: ['export', 'pending', 'title'],
+              testId: 'exportNotification-individual-pending'
+            }),
+            dismissable: true
+          })
         ]);
+        return;
       }
+
+      // Dispatch a status regardless of completion
+      const updatedDispatch = [
+        {
+          type: reduxTypes.platform.SET_PLATFORM_EXPORT_STATUS,
+          id: productId,
+          isPending,
+          pending
+        }
+      ];
+
+      // Display completed notification
+      if (isCompleted) {
+        updatedDispatch.unshift(
+          addAliasNotification({
+            id: 'swatch-exports-individual-status',
+            variant: 'success',
+            title: t('curiosity-toolbar.notifications', {
+              context: ['export', 'completed', 'title'],
+              testId: 'exportNotification-individual-completed'
+            }),
+            description: t('curiosity-toolbar.notifications', {
+              context: ['export', 'completed', 'description'],
+              count: completed.length,
+              fileName: completed?.[0]?.fileName
+            }),
+            dismissable: true
+          })
+        );
+      }
+
+      dispatch(updatedDispatch);
     },
     [addAliasNotification, confirmAppLoaded, dispatch, productId, t]
   );

--- a/src/redux/reducers/appReducer.js
+++ b/src/redux/reducers/appReducer.js
@@ -57,15 +57,23 @@ const appReducer = (state = initialState, action) => {
 
       return state;
     case platformTypes.SET_PLATFORM_EXPORT_STATUS:
+      // Reset pending list on status response
+      let updatedPending = action.pending;
+
+      // Only a selected format updates the pending list
+      if (action.isSelectUpdated === true) {
+        updatedPending = [
+          ...(state?.exports?.[action.id]?.pending || []),
+          ...((Array.isArray(action.pending) && action.pending) || (action.pending && [action.pending]) || [])
+        ];
+      }
+
       return reduxHelpers.setStateProp(
         'exports',
         {
           [action.id]: {
             ...action,
-            pending: [
-              ...(state?.exports?.[action.id]?.pending || []),
-              ...((Array.isArray(action.pending) && action.pending) || (action.pending && [action.pending]) || [])
-            ]
+            pending: updatedPending
           }
         },
         {

--- a/src/redux/reducers/appReducer.js
+++ b/src/redux/reducers/appReducer.js
@@ -61,7 +61,11 @@ const appReducer = (state = initialState, action) => {
         'exports',
         {
           [action.id]: {
-            ...action
+            ...action,
+            pending: [
+              ...(state?.exports?.[action.id]?.pending || []),
+              ...((Array.isArray(action.pending) && action.pending) || (action.pending && [action.pending]) || [])
+            ]
           }
         },
         {

--- a/src/redux/reducers/appReducer.js
+++ b/src/redux/reducers/appReducer.js
@@ -57,23 +57,16 @@ const appReducer = (state = initialState, action) => {
 
       return state;
     case platformTypes.SET_PLATFORM_EXPORT_STATUS:
-      // Reset pending list on status response
-      let updatedPending = action.pending;
-
-      // Only a selected format updates the pending list
-      if (action.isSelectUpdated === true) {
-        updatedPending = [
-          ...(state?.exports?.[action.id]?.pending || []),
-          ...((Array.isArray(action.pending) && action.pending) || (action.pending && [action.pending]) || [])
-        ];
-      }
-
       return reduxHelpers.setStateProp(
         'exports',
         {
           [action.id]: {
             ...action,
-            pending: updatedPending
+            pending: [
+              // Only a selected format updates/reuses the pending list
+              ...((action.isSelectUpdated === true && state?.exports?.[action.id]?.pending) || []),
+              ...((Array.isArray(action.pending) && action.pending) || (action.pending && [action.pending]) || [])
+            ]
           }
         },
         {

--- a/src/services/platform/__tests__/__snapshots__/platformConstants.test.js.snap
+++ b/src/services/platform/__tests__/__snapshots__/platformConstants.test.js.snap
@@ -6,6 +6,7 @@ exports[`Platform Constants should have specific properties: all exported consta
     "SUBSCRIPTIONS": "subscriptions",
   },
   "PLATFORM_API_EXPORT_CONTENT_TYPES": {
+    "CSV": "csv",
     "JSON": "json",
   },
   "PLATFORM_API_EXPORT_FILENAME_PREFIX": "swatch",
@@ -80,6 +81,7 @@ exports[`Platform Constants should have specific properties: all exported consta
       "SUBSCRIPTIONS": "subscriptions",
     },
     "PLATFORM_API_EXPORT_CONTENT_TYPES": {
+      "CSV": "csv",
       "JSON": "json",
     },
     "PLATFORM_API_EXPORT_FILENAME_PREFIX": "swatch",
@@ -155,6 +157,7 @@ exports[`Platform Constants should have specific properties: all exported consta
       "SUBSCRIPTIONS": "subscriptions",
     },
     "PLATFORM_API_EXPORT_CONTENT_TYPES": {
+      "CSV": "csv",
       "JSON": "json",
     },
     "PLATFORM_API_EXPORT_FILENAME_PREFIX": "swatch",
@@ -234,6 +237,7 @@ exports[`Platform Constants should have specific properties: specific constants 
     "SUBSCRIPTIONS": "subscriptions",
   },
   "PLATFORM_API_EXPORT_CONTENT_TYPES": {
+    "CSV": "csv",
     "JSON": "json",
   },
   "PLATFORM_API_EXPORT_FILENAME_PREFIX": "swatch",

--- a/src/services/platform/platformConstants.js
+++ b/src/services/platform/platformConstants.js
@@ -42,7 +42,7 @@ const PLATFORM_API_EXPORT_RESOURCE_TYPES = {
  * @type {{CSV: string, JSON: string}}
  */
 const PLATFORM_API_EXPORT_CONTENT_TYPES = {
-  // CSV: 'csv',
+  CSV: 'csv',
   JSON: 'json'
 };
 


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- feat(toolbarFieldExport): sw-2769 activate csv export

### Notes
- With this update we were attempting to avoid updating state with the immediate "[the user selected this type of export]" because we populate the list from polling status callback.
   
   This lack of a state update created an interim period between the user selecting the CSV, or JSON, from the dropdown/select list, then having all entries disabled, then having the specific entry the user selected update. This is/was awkward!
   
   So now we've attempted to patch and avoid this behavior so the user has more timely interaction feedback, but we may have to revisit it since the required polling behavior is on a 5 sec delay \<insert opinion on polling\> and the conflicting state update vs API response can get weird fast (heh, or at least in the 5 sec window)
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. navigate towards a product
   - select JSON format for export, confirm the JSON selection displays the word `Loading...` and toast confirmations appear
   - select CSV format for export, confirm the CSV selection displays the word `Loading...` and toast confirmations appear

### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. confirm tests come back clean

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-2769
relates #1365 