### PR TITLE
build: sw-2778 deprecate, remove, clean preview-beta refs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -40,11 +40,6 @@ jobs:
         uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.COV_TOKEN }}
-      - name: Confirm preview integration
-        if: ${{ success() }}
-        run: npm run build
-        env:
-          BETA: true
-      - name: Confirm stable integration
+      - name: Confirm integration
         if: ${{ success() }}
         run: npm run build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,14 +13,12 @@ Curiosity makes use of
 
 #### Main repository branches and continuous integration
 Curiosity makes use of the branches `main`, `stable`.
-- `main` branch is a representation of development and `stage-beta/preview`.
-   - When a branch push happens the `main` branch is automatically deployed for `https://console.stage.redhat.com/preview`
-- `stable` branch is a representation of 3 environments `stage-stable`, `prod-beta/preview`, and `prod-stable`.
-   - When a branch push happens the `stable` branch is automatically deployed for `https://console.stage.redhat.com/`
-   - To release to `prod-beta/preview` a Git hash is submitted with a GitLab Merge Request within the `app-interface` repository. This will be deployed to `https://console.redhat.com/preview`
-      - It is preferable if ONLY releasing to `prod-beta/preview` that a release candidate tag is created for the latest commit.
-   - To release to `prod-stable` a Git hash is submitted with a GitLab Merge Request within the `app-interface` repository. This will be deployed to `https://console.redhat.com/`
-      - It is preferable if releasing to `prod-stable` that a tag is created for the latest commit. The commit message should use
+- `main` branch is a representation of development, `stage`.
+   - When a branch push happens the `main` branch is automatically deployed for `https://console.stage.redhat.com/`
+- `stable` branch is a representation of a single environment, `prod`.
+   - Commits can be parked on `stable`. We no longer automatically deploy commits on the `stable` branch.
+   - To release to `prod` a Git hash is submitted with a GitLab Merge Request within the `app-interface` repository. This will be deployed to `https://console.redhat.com`
+      - It is preferable if releasing to `prod` that a tag is created for the latest commit. The commit message should use
         the form `chore(release): [version number]`
 
 #### Branch syncing
@@ -131,43 +129,24 @@ clicking the `checks` tab on the related pull request.
 <summary><h3 style="display: inline-block">Releasing code for all environments</h3></summary>
 
 Curiosity releases code to the following environments
-   - stage preview
-   - stage stable
-   - production preview
-   - production stable
+   - stage
+   - production
 
 > After pushing code, or tagging, a repository hook notifies continuous integration and starts the process of
 > environment updates.
 
-#### Release for stage preview
-Merging code into stage preview is simplistic
+#### Release for stage
+Merging code into stage is simplistic
 1. Merge a pull request into `main`
    ```
-   pull-request -> main -> stage preview
+   pull-request -> main -> stage
    ```
-
-#### Release for stage stable
-To merge code into stage stable
-1. Open a pull request from `main` to `stable` and merge using the `rebase` button.
-   ```
-   main -> pull-request -> stable -> stage stable
-   ```
-
-#### Release for production preview
-To merge code into production preview
-1. Tag the most recent commit on `main` as a release candidate using the format `v[x].[x].[x]-rc.[x]`
-   ```
-   stable -> release candidate tag -> `app-interface` merge request -> production preview
-   ```
-   > `rc.0` zero index is a typical starting point for release candidates
-1. Finally, submit a merge request to update the `app-interface` deployment yaml
-   - Copy the tagged Git hash and update the `app-interface` configuration hash within `[app-interface-insights-rhsm]/deploy-clowder.yml`
 
 #### Release for production stable
 To merge code into production stable a maintainer must run the release commit process locally.
 
    ```
-   local main repo, stable branch -> release commit -> push to stable -> release tag -> `app-interface` merge request -> production stable
+   local main repo, stable branch -> create a release commit -> push/merge commit to stable -> release tag on commit -> `app-interface` merge request on commit hash -> production release
    ```
 
 1. Clone the main repository, within the repo confirm you're on the `stable` branch and **SYNCED** with `origin` `stable`
@@ -376,7 +355,7 @@ The dotenv files are structured to cascade each additional dotenv file settings 
 | dotenv parameter                   | definition                                                                                                                                                                     |
 |------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | DEV_PORT                           | A local proxy build modification for running against a custom port                                                                                                             |
-| DEV_BRANCH                         | A local proxy build modification for running against a custom environment branch. Available options include `stage-beta`, `stage-stable`, `prod-beta`, `prod-stable`           |
+| DEV_BRANCH                         | A local proxy build modification for running against a custom environment branch. Available options include `stage*`, `prod*`                                                  |
 | GENERATE_SOURCEMAP                 | A static boolean that disables local run source map generation only. May speed up local development re-compiles. May eventually be moved into `.env.development`.              | 
 | REACT_APP_DEBUG_DEFAULT_DATETIME   | A static string associated with overriding the assumed UI/application date in the form of `YYYY-MM-DD`                                                                         |
 | REACT_APP_DEBUG_MIDDLEWARE         | A static boolean that activates the console state debugging messages associated with Redux.                                                                                    |
@@ -388,15 +367,15 @@ The dotenv files are structured to cascade each additional dotenv file settings 
 
 > Technically all dotenv parameters come across as strings when imported through `process.env`. It is important to cast them accordingly if "type" is required.
 
-| dotenv parameter                                  | definition                                                                                                                                                     |
-|---------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| REACT_APP_UI_VERSION                              | A dynamically build populated package.json version reference                                                                                                   |
-| REACT_APP_UI_NAME                                 | A static string populated reference similar to the consoledot application name                                                                                 |
+ | dotenv parameter                                  | definition                                                                                                                                                     |
+ |---------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+ | REACT_APP_UI_VERSION                              | A dynamically build populated package.json version reference                                                                                                   |
+ | REACT_APP_UI_NAME                                 | A static string populated reference similar to the consoledot application name                                                                                 |
  | REACT_APP_UI_DISPLAY_NAME                         | A static string populated reference to the display version of the application name                                                                             |
  | REACT_APP_UI_DISPLAY_CONFIG_NAME                  | A static string populated reference to the configuration version of the application name                                                                       |
  | REACT_APP_UI_DISPLAY_START_NAME                   | A static string populated reference to the "sentence start" application name                                                                                   |
- | REACT_APP_UI_DEPLOY_PATH_PREFIX                   | A dynamically build populated beta/preview environment path reference                                                                                          |                                                               
- | REACT_APP_UI_DEPLOY_PATH_LINK_PREFIX              | A dynamically build populated beta/preview environment path reference that may or may not be equivalent to `REACT_APP_UI_DEPLOY_PATH_PREFIX`                   |
+ | ~~REACT_APP_UI_DEPLOY_PATH_PREFIX~~               | A legacy parameter. Originally, a dynamically build populated beta/preview environment path reference                                                                                          |                                                               
+ | ~~REACT_APP_UI_DEPLOY_PATH_LINK_PREFIX~~          | A legacy parameter. Originally, a dynamically build populated beta/preview environment path reference that may or may not be equivalent to `REACT_APP_UI_DEPLOY_PATH_PREFIX`                   |
  | PUBLIC_URL                                        | A dynamically prefix populated reference to where the application lives on consoledot                                                                          |                                                                                                           
  | REACT_APP_UI_LINK_CONTACT_US                      | A static contact us link for populating a link reference NOT directly controlled by the application and subject to randomly changing.                          |
  | REACT_APP_UI_LINK_LEARN_MORE                      | A static learn more link for populating a link reference NOT directly controlled by the application and subject to randomly changing.                          |

--- a/scripts/pre.sh
+++ b/scripts/pre.sh
@@ -11,7 +11,7 @@ deployPaths()
   DEPLOY_PATH_PREFIX=""
   DEPLOY_STAGE="Stable"
 
-  # Note: allow Container build
+  # Note: Deprecated beta-preview prefixes. Temporarily left because they provide an alternative for prefixing paths.
   if [[ $CONTAINER_BUILD_ENV == "true" ]]; then
     DEPLOY_STAGE="Preview"
     DEPLOY_PATH_PREFIX=/beta

--- a/src/common/README.md
+++ b/src/common/README.md
@@ -311,8 +311,8 @@ Download the debug log file.
     * [~CONFIG_EXPORT_FILE_TYPE](#Helpers.module_General..CONFIG_EXPORT_FILE_TYPE) : <code>string</code>
     * [~CONFIG_EXPORT_FILENAME](#Helpers.module_General..CONFIG_EXPORT_FILENAME) : <code>string</code>
     * [~CONFIG_EXPORT_SERVICE_NAME_PREFIX](#Helpers.module_General..CONFIG_EXPORT_SERVICE_NAME_PREFIX) : <code>string</code>
-    * [~UI_DEPLOY_PATH_PREFIX](#Helpers.module_General..UI_DEPLOY_PATH_PREFIX) : <code>string</code>
-    * [~UI_DEPLOY_PATH_LINK_PREFIX](#Helpers.module_General..UI_DEPLOY_PATH_LINK_PREFIX) : <code>string</code>
+    * <del>[~UI_DEPLOY_PATH_PREFIX](#Helpers.module_General..UI_DEPLOY_PATH_PREFIX) : <code>string</code></del>
+    * <del>[~UI_DEPLOY_PATH_LINK_PREFIX](#Helpers.module_General..UI_DEPLOY_PATH_LINK_PREFIX) : <code>string</code></del>
     * [~UI_DISABLED](#Helpers.module_General..UI_DISABLED) : <code>boolean</code>
     * [~UI_DISABLED_GRAPH](#Helpers.module_General..UI_DISABLED_GRAPH) : <code>boolean</code>
     * [~UI_DISABLED_NOTIFICATIONS](#Helpers.module_General..UI_DISABLED_NOTIFICATIONS) : <code>boolean</code>
@@ -461,7 +461,9 @@ CONFIG export "post" download name prefix, for consistency.
 **Kind**: inner constant of [<code>General</code>](#Helpers.module_General)  
 <a name="Helpers.module_General..UI_DEPLOY_PATH_PREFIX"></a>
 
-### General~UI\_DEPLOY\_PATH\_PREFIX : <code>string</code>
+### <del>General~UI\_DEPLOY\_PATH\_PREFIX : <code>string</code></del>
+***Deprecated***
+
 Apply a path prefix for routing.
 Typically associated with applying a "beta" path prefix. See dotenv config files for updating.
 See build scripts for generated prefix.
@@ -469,7 +471,9 @@ See build scripts for generated prefix.
 **Kind**: inner constant of [<code>General</code>](#Helpers.module_General)  
 <a name="Helpers.module_General..UI_DEPLOY_PATH_LINK_PREFIX"></a>
 
-### General~UI\_DEPLOY\_PATH\_LINK\_PREFIX : <code>string</code>
+### <del>General~UI\_DEPLOY\_PATH\_LINK\_PREFIX : <code>string</code></del>
+***Deprecated***
+
 Patch for compensating for platform updates where a mismatch between "beta" and "preview" for redirects means
 that the same prefix can no longer be used for both additional remote resources and links.
 See build scripts for generated prefix.

--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -278,19 +278,17 @@ const CONFIG_EXPORT_SERVICE_NAME_PREFIX = process.env.REACT_APP_CONFIG_EXPORT_SE
  * Typically associated with applying a "beta" path prefix. See dotenv config files for updating.
  * See build scripts for generated prefix.
  *
+ * @deprecated
  * @type {string}
  */
 const UI_DEPLOY_PATH_PREFIX = process.env.REACT_APP_UI_DEPLOY_PATH_PREFIX;
 
 /**
- * FixMe: Replace, or alias towards UI_DEPLOY_PATH_PREFIX, this dotenv parameter if/when "beta" and "preview" are
- * normalized.
- */
-/**
  * Patch for compensating for platform updates where a mismatch between "beta" and "preview" for redirects means
  * that the same prefix can no longer be used for both additional remote resources and links.
  * See build scripts for generated prefix.
  *
+ * @deprecated
  * @type {string}
  */
 const UI_DEPLOY_PATH_LINK_PREFIX = process.env.REACT_APP_UI_DEPLOY_PATH_LINK_PREFIX;


### PR DESCRIPTION

## What's included
<!-- Summary of changes/additions -->
- build: sw-2778 deprecate, remove, clean preview-beta refs

### Notes
- Primarily
   * integration, gh actions, remove beta-preview checks
   * contributing, readme, release update, deprecate params
   * pre script, deprecated annotations
   * src/helpers, deprecate dotenv path prefix params
- We're temporarily leaving in the dotenv params since their use expands beyond `preview`-`beta`. We just happened to utilize them for that at the start of the project. Everything has been labeled `deprecated` (for future clean up)

<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. next...
-->
-
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. confirm tests come back clean

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-2778