### PR TITLE
fix(toolbar): sw-2856 hide residual reset filters link

### DIFF
--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -8,7 +8,7 @@ import {
   ToolbarToggleGroup
 } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons';
-import { useProductToolbarQuery } from '../productView/productViewContext';
+import { useProductToolbarQuery, useProduct } from '../productView/productViewContext';
 import { useToolbarFieldClear, useToolbarFieldClearAll, useToolbarFields } from './toolbarContext';
 import { ToolbarFilter } from './toolbarFilter';
 import { ToolbarFieldGroupVariant } from './toolbarFieldGroupVariant';
@@ -61,6 +61,7 @@ const Toolbar = ({
   useToolbarFieldClearAll: useAliasToolbarFieldClearAll,
   useToolbarFields: useAliasToolbarFields
 }) => {
+  const { productGroup } = useProduct();
   const toolbarFieldQueries = useAliasProductToolbarQuery();
   const { currentCategory, options } = useAliasSelectCategoryOptions();
   const clearField = useAliasToolbarFieldClear();
@@ -113,6 +114,7 @@ const Toolbar = ({
   return (
     <PfToolbar
       id="curiosity-toolbar"
+      key={productGroup}
       className="curiosity-toolbar pf-m-toggle-group-container ins-c-primary-toolbar"
       collapseListedFiltersBreakpoint="sm"
       clearAllFilters={onClearAll}


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
fix(toolbar): sw-2856 hide residual reset filters link

### Notes
- Minor display bug around hiding the "reset filters" chips/token link when switching products via the left nav
- Unclear how long this has been an issue
- Fixed by simply applying a cache busting key using the internal `productGroup` on the react components
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. Select the RHEL product display
   - Select the toolbar filter "Type", then choose any option and let the page load
   - From the left navigation select OpenShift
   - Observe the toolbar link "Reset filters" DOES NOT display without any "chips/tokens" in front of it

<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-2856