### PR TITLE
build: fix renovate schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,9 @@
   "commitMessagePrefix": "ci:",
   "commitMessageLowerCase": "auto",
   "labels": ["build"],
-  "rebaseWhen": "auto"
+  "rebaseWhen": "auto",
+  "schedule": [
+    "on Tuesday after 3am and before 10am"
+  ],
+  "timezone": "America/New_York"
 }


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- build: fix renovate schedule

### Notes
- fix konflux updates to something more predictable
- borrowed from the [HCS repo](https://github.com/RedHatInsights/hybrid-committed-spend-ui/blob/main/renovate.json)
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing