### PR TITLE
fix(config): sw-2956 display ints for ansible inventory

### DIFF
--- a/src/config/product.ansible.js
+++ b/src/config/product.ansible.js
@@ -281,7 +281,7 @@ const config = {
       cell: ({ [RHSM_API_PATH_METRIC_TYPES.MANAGED_NODES]: total } = {}) =>
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
-          total: (total && Number.parseFloat(total).toFixed(2)) || undefined,
+          total,
           testId: (
             <span data-test={`instances-cell-${RHSM_API_PATH_METRIC_TYPES.MANAGED_NODES}`} data-value={`${total}`} />
           )
@@ -295,7 +295,7 @@ const config = {
       cell: ({ [RHSM_API_PATH_METRIC_TYPES.INSTANCE_HOURS]: total } = {}) =>
         translate('curiosity-inventory.measurement', {
           context: (total && 'value') || undefined,
-          total: (total && Number.parseFloat(total).toFixed(2)) || undefined,
+          total,
           testId: (
             <span data-test={`instances-cell-${RHSM_API_PATH_METRIC_TYPES.INSTANCE_HOURS}`} data-value={`${total}`} />
           )

--- a/src/services/rhsm/rhsmServices.js
+++ b/src/services/rhsm/rhsmServices.js
@@ -1935,7 +1935,7 @@ const getInstancesInventoryGuests = (id, params = {}, options = {}) => {
  *           "subscription_manager_id": "BBBBB-5b00-42fa-BBBBB-75801d45cc6d",
  *           "display_name": "lorem.example.com",
  *           "measurements": [
- *              4000,
+ *              0,
  *              50,
  *              10000.0000345678,
  *              3000,


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(config): sw-2956 display ints for ansible inventory

### Notes
- replaces the float config with int directly from API
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. navigate towards the ansible display
   - confirm the inventory display shows ints instead of floats
<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screenshot 2024-09-24 at 1 54 07 PM](https://github.com/user-attachments/assets/20b8a7da-6906-473b-b610-2f32d02106ef)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-2956
related sw-2932