### PR TITLE
fix(config): sw-2966 remove single day x-axis increments

### DIFF
--- a/src/config/__tests__/__snapshots__/product.config.test.js.snap
+++ b/src/config/__tests__/__snapshots__/product.config.test.js.snap
@@ -6,7 +6,6 @@ exports[`Product specific configurations should apply graph filters and settings
     "ansible-aap-managed": {
       "xAxisChartLabel": "t(curiosity-graph.label_axisX, {"context":"Daily"})",
       "xAxisLabelIncrement": 1,
-      "xAxisTickFormatAvailable": true,
       "yAxisTickFormat": {
         "0.00001345": "0.00001",
         "0.0000269": "0.00003",
@@ -1459,7 +1458,6 @@ exports[`Product specific configurations should apply graph filters and settings
     "rosa": {
       "xAxisChartLabel": "t(curiosity-graph.label_axisX, {"context":"Daily"})",
       "xAxisLabelIncrement": 1,
-      "xAxisTickFormatAvailable": true,
       "yAxisTickFormat": {
         "0.00001345": "0.00001",
         "0.0000269": "0.00003",
@@ -1878,7 +1876,6 @@ exports[`Product specific configurations should apply graph filters and settings
             "stroke": "#06c",
             "xAxisChartLabel": [Function],
             "xAxisLabelIncrement": 1,
-            "xAxisTickFormat": [Function],
             "yAxisTickFormat": [Function],
           },
         },
@@ -1961,7 +1958,6 @@ exports[`Product specific configurations should apply graph filters and settings
             "stroke": "#06c",
             "xAxisChartLabel": [Function],
             "xAxisLabelIncrement": 1,
-            "xAxisTickFormat": [Function],
             "yAxisTickFormat": [Function],
           },
         },
@@ -2620,7 +2616,6 @@ exports[`Product specific configurations should apply graph filters and settings
             "stroke": "#06c",
             "xAxisChartLabel": [Function],
             "xAxisLabelIncrement": 1,
-            "xAxisTickFormat": [Function],
             "yAxisTickFormat": [Function],
           },
         },
@@ -2703,7 +2698,6 @@ exports[`Product specific configurations should apply graph filters and settings
             "stroke": "#06c",
             "xAxisChartLabel": [Function],
             "xAxisLabelIncrement": 1,
-            "xAxisTickFormat": [Function],
             "yAxisTickFormat": [Function],
           },
         },

--- a/src/config/product.ansible.js
+++ b/src/config/product.ansible.js
@@ -193,7 +193,6 @@ const config = {
     isCardTitleDescription: true,
     xAxisLabelIncrement: 1,
     xAxisChartLabel: () => translate('curiosity-graph.label_axisX', { context: GRANULARITY_TYPES.DAILY }),
-    xAxisTickFormat: ({ tick }) => Number.parseInt(tick, 10) + 1 || tick,
     yAxisTickFormat: ({ tick } = {}) => {
       if (tick > 1) {
         return helpers

--- a/src/config/product.rosa.js
+++ b/src/config/product.rosa.js
@@ -193,7 +193,6 @@ const config = {
     isCardTitleDescription: true,
     xAxisLabelIncrement: 1,
     xAxisChartLabel: () => translate('curiosity-graph.label_axisX', { context: GRANULARITY_TYPES.DAILY }),
-    xAxisTickFormat: ({ tick }) => Number.parseInt(tick, 10) + 1 || tick,
     yAxisTickFormat: ({ tick } = {}) => {
       if (tick > 1) {
         return helpers


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(config): sw-2966 remove single day x-axis increments

### Notes
- minor configuration tweak for x-axis
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. confirm the ROSA and Ansible graph displays no longer shows single day number format only ticks, see below examples
<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. next...
-->

### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. confirm tests come back clean

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
### previous
![Screenshot 2024-09-25 at 3 50 19 PM](https://github.com/user-attachments/assets/2de04daf-ccb1-46dd-9899-14d5bf7f5b79)
### updated
![Screenshot 2024-09-25 at 3 52 09 PM](https://github.com/user-attachments/assets/4ed9e051-5031-4b80-a8a3-ceccefa55d0b)

![Screenshot 2024-09-25 at 15-49-15 Standalone Curiosity](https://github.com/user-attachments/assets/ce2a4f24-9715-46cb-bfc6-d44dc7f6dfa2)
![Screenshot 2024-09-25 at 15-48-57 Standalone Curiosity](https://github.com/user-attachments/assets/dfd41652-7fb8-41d3-811c-529b20a5428c)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
