### PR TITLE
build(deps): sw-2981 bump group with 2 updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@patternfly/react-styles": "5.3.1",
         "@patternfly/react-table": "5.3.4",
         "@patternfly/react-tokens": "5.3.1",
-        "@redhat-cloud-services/frontend-components": "4.2.14",
+        "@redhat-cloud-services/frontend-components": "4.2.15",
         "@redhat-cloud-services/frontend-components-notifications": "4.1.0",
         "@redhat-cloud-services/frontend-components-utilities": "4.0.17",
         "axios": "^1.7.7",
@@ -50,7 +50,7 @@
       "devDependencies": {
         "@babel/core": "7.25.2",
         "@babel/eslint-parser": "7.25.1",
-        "@redhat-cloud-services/frontend-components-config": "6.2.6",
+        "@redhat-cloud-services/frontend-components-config": "6.2.9",
         "@redhat-cloud-services/tsc-transform-imports": "^1.0.16",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.5.0",
@@ -4092,6 +4092,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-5.0.1.tgz",
       "integrity": "sha512-+azUBN6FgcDmlcWMzG0bthcRUJC1u12wf9xa2aJGFbC/uTiOXwjrkcQ7LW/PyK5Em7wDhwaUdapaeOgh8I6Kjg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "lodash": "^4.17.21",
         "semver": "^7.3.7",
@@ -4137,6 +4138,7 @@
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4370,16 +4372,16 @@
       "dev": true
     },
     "node_modules/@redhat-cloud-services/frontend-components": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-4.2.14.tgz",
-      "integrity": "sha512-q3RgMJiJ4Zk4Qim0sKbCzn9IJtQT9oJWetu11FbHwYZV2w25mORM22QA9LS1jOsaywJJJc4J453CPVRBQhrkGw==",
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-4.2.15.tgz",
+      "integrity": "sha512-52bu9XFZCosQ7QUzLiA4NNYWWas14Gir3/OBgxWlKQ8UayMfiBP9nuwvelDfC/jU8jLdYVbAznkNzbxQdhTKiw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/react-component-groups": "^5.0.0",
         "@redhat-cloud-services/frontend-components-utilities": "^4.0.0",
         "@redhat-cloud-services/types": "^1.0.9",
-        "@scalprum/core": "^0.7.0",
-        "@scalprum/react-core": "^0.8.0",
+        "@scalprum/core": "^0.8.1",
+        "@scalprum/react-core": "^0.9.1",
         "classnames": "^2.2.5",
         "sanitize-html": "^2.12.1"
       },
@@ -4397,9 +4399,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-config": {
-      "version": "6.2.6",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-6.2.6.tgz",
-      "integrity": "sha512-MbsGc1MHA4CPMryHvs2bGAeLoiKUuiW6Bsr076ANkGAlueCZguAZMotDlPC3vML5cyJ2wNrQ7fPnbCW9ElXqvQ==",
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-6.2.9.tgz",
+      "integrity": "sha512-tJHyse/6y53lehKUx8tY1kIAezuj2yV1Gmgl6Ye9vfnm9DfcsFYObz9nQOdp/pmeNNrUO3u3fpzYSPxoamKqHg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4800,21 +4802,23 @@
       "dev": true
     },
     "node_modules/@scalprum/core": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.7.0.tgz",
-      "integrity": "sha512-zvrPXexI+bxHGFY/teuwPI5yjnOuiq8uT+RDsrm3gnpr1AqZQVUiGdskl1ON/ci5lSs1kNadmXceF1BTKlicwg==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.8.1.tgz",
+      "integrity": "sha512-bRbquESsjUvgu3QHA9aDIK5uTu7XoXjzqoxAmDmytnedzg8LFk/iNKs/bx4lSP2rufxx8iFkdVVvN3sM1W6a4A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@openshift/dynamic-plugin-sdk": "^5.0.1",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@scalprum/react-core": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.8.0.tgz",
-      "integrity": "sha512-ADqL6GdjT0ihVfTtIqu8vvYgwUb3IiUGXj9md1+h6tL8yshbq+FAezwuD9jhX7qcjfgL1Sl3g/faO2/SE9jPvw==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.9.3.tgz",
+      "integrity": "sha512-AnBoFLZl+qYB9XnAJBHYZJTHHRFWCW6iYAojGkiqtD4luyiEMmd6SaCv2s8xs/b6l/KKkG2FU272sIYqb/FkAQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@openshift/dynamic-plugin-sdk": "^5.0.1",
-        "@scalprum/core": "^0.7.0",
+        "@scalprum/core": "^0.8.1",
         "lodash": "^4.17.0"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@patternfly/react-styles": "5.3.1",
     "@patternfly/react-table": "5.3.4",
     "@patternfly/react-tokens": "5.3.1",
-    "@redhat-cloud-services/frontend-components": "4.2.14",
+    "@redhat-cloud-services/frontend-components": "4.2.15",
     "@redhat-cloud-services/frontend-components-notifications": "4.1.0",
     "@redhat-cloud-services/frontend-components-utilities": "4.0.17",
     "axios": "^1.7.7",
@@ -117,7 +117,7 @@
   "devDependencies": {
     "@babel/core": "7.25.2",
     "@babel/eslint-parser": "7.25.1",
-    "@redhat-cloud-services/frontend-components-config": "6.2.6",
+    "@redhat-cloud-services/frontend-components-config": "6.2.9",
     "@redhat-cloud-services/tsc-transform-imports": "^1.0.16",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.5.0",


### PR DESCRIPTION

## What's included
<!-- Summary of changes/additions -->
- build(deps): sw-2981 bump group with 2 updates
   * @redhat-cloud-services/frontend-components from 4.2.14 to 4.2.15
   * @redhat-cloud-services/frontend-components-config from 6.2.6 to 6.2.9

### Notes
- bumps platform level packages as part of issue sw-2981 review
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. next...
-->

### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. confirm tests come back clean

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-2981
ongoing