### PR TITLE
refactor(inventoryCards,tabs): sw-2707 remove deprecated react

### DIFF
--- a/src/components/README.md
+++ b/src/components/README.md
@@ -2911,13 +2911,16 @@ Base inventory table card.
 
 
 * [InventoryCard](#Components.module_InventoryCard)
-    * [~InventoryCard(props)](#Components.module_InventoryCard..InventoryCard) ⇒ <code>React.ReactNode</code>
-        * [.propTypes](#Components.module_InventoryCard..InventoryCard.propTypes) : <code>Object</code>
-        * [.defaultProps](#Components.module_InventoryCard..InventoryCard.defaultProps) : <code>Object</code>
+    * [~InventoryCard(props)](#Components.module_InventoryCard..InventoryCard) ⇒ <code>JSX.Element</code>
+    * [~useGetInventory](#Components.module_InventoryCard..useGetInventory) ⇒ <code>Object</code>
+    * [~useInventoryCardActions](#Components.module_InventoryCard..useInventoryCardActions) ⇒ <code>React.ReactNode</code>
+    * [~useParseFiltersSettings](#Components.module_InventoryCard..useParseFiltersSettings) ⇒ <code>Object</code>
+    * [~useOnPage](#Components.module_InventoryCard..useOnPage) ⇒ <code>function</code>
+    * [~useOnColumnSort](#Components.module_InventoryCard..useOnColumnSort) ⇒ <code>function</code>
 
 <a name="Components.module_InventoryCard..InventoryCard"></a>
 
-### InventoryCard~InventoryCard(props) ⇒ <code>React.ReactNode</code>
+### InventoryCard~InventoryCard(props) ⇒ <code>JSX.Element</code>
 Set up inventory cards. Expand filters with base settings.
 
 **Kind**: inner method of [<code>InventoryCard</code>](#Components.module_InventoryCard)  
@@ -2925,46 +2928,49 @@ Set up inventory cards. Expand filters with base settings.
 <table>
   <thead>
     <tr>
-      <th>Param</th><th>Type</th>
+      <th>Param</th><th>Type</th><th>Default</th>
     </tr>
   </thead>
   <tbody>
 <tr>
-    <td>props</td><td><code>object</code></td>
+    <td>props</td><td><code>object</code></td><td></td>
     </tr><tr>
-    <td>props.isDisabled</td><td><code>boolean</code></td>
+    <td>[props.isDisabled]</td><td><code>boolean</code></td><td><code>false</code></td>
     </tr><tr>
-    <td>props.t</td><td><code>function</code></td>
+    <td>[props.t]</td><td><code>translate</code></td><td><code>translate</code></td>
     </tr><tr>
-    <td>props.useGetInventory</td><td><code>function</code></td>
+    <td>props.useGetInventory</td><td><code>useGetInventory</code></td><td></td>
     </tr><tr>
-    <td>props.useInventoryCardActions</td><td><code>function</code></td>
+    <td>props.useInventoryCardActions</td><td><code>useInventoryCardActions</code></td><td></td>
     </tr><tr>
-    <td>props.useParseFiltersSettings</td><td><code>function</code></td>
+    <td>props.useParseFiltersSettings</td><td><code>useParseFiltersSettings</code></td><td></td>
     </tr><tr>
-    <td>props.useOnPage</td><td><code>function</code></td>
+    <td>props.useOnPage</td><td><code>useOnPage</code></td><td></td>
     </tr><tr>
-    <td>props.useOnColumnSort</td><td><code>function</code></td>
+    <td>props.useOnColumnSort</td><td><code>useOnColumnSort</code></td><td></td>
     </tr>  </tbody>
 </table>
 
+<a name="Components.module_InventoryCard..useGetInventory"></a>
 
-* [~InventoryCard(props)](#Components.module_InventoryCard..InventoryCard) ⇒ <code>React.ReactNode</code>
-    * [.propTypes](#Components.module_InventoryCard..InventoryCard.propTypes) : <code>Object</code>
-    * [.defaultProps](#Components.module_InventoryCard..InventoryCard.defaultProps) : <code>Object</code>
+### InventoryCard~useGetInventory ⇒ <code>Object</code>
+**Kind**: inner typedef of [<code>InventoryCard</code>](#Components.module_InventoryCard)  
+<a name="Components.module_InventoryCard..useInventoryCardActions"></a>
 
-<a name="Components.module_InventoryCard..InventoryCard.propTypes"></a>
+### InventoryCard~useInventoryCardActions ⇒ <code>React.ReactNode</code>
+**Kind**: inner typedef of [<code>InventoryCard</code>](#Components.module_InventoryCard)  
+<a name="Components.module_InventoryCard..useParseFiltersSettings"></a>
 
-#### InventoryCard.propTypes : <code>Object</code>
-Prop types.
+### InventoryCard~useParseFiltersSettings ⇒ <code>Object</code>
+**Kind**: inner typedef of [<code>InventoryCard</code>](#Components.module_InventoryCard)  
+<a name="Components.module_InventoryCard..useOnPage"></a>
 
-**Kind**: static property of [<code>InventoryCard</code>](#Components.module_InventoryCard..InventoryCard)  
-<a name="Components.module_InventoryCard..InventoryCard.defaultProps"></a>
+### InventoryCard~useOnPage ⇒ <code>function</code>
+**Kind**: inner typedef of [<code>InventoryCard</code>](#Components.module_InventoryCard)  
+<a name="Components.module_InventoryCard..useOnColumnSort"></a>
 
-#### InventoryCard.defaultProps : <code>Object</code>
-Default props.
-
-**Kind**: static property of [<code>InventoryCard</code>](#Components.module_InventoryCard..InventoryCard)  
+### InventoryCard~useOnColumnSort ⇒ <code>function</code>
+**Kind**: inner typedef of [<code>InventoryCard</code>](#Components.module_InventoryCard)  
 <a name="InventoryCard.module_InventoryCardHelpers"></a>
 
 ## InventoryCardHelpers
@@ -3048,60 +3054,36 @@ Parse an inventory API response against available filters, query parameters, and
     </tr>  </tbody>
 </table>
 
-
-* [InventoryCardInstances](#Components.module_InventoryCardInstances)
-    * [~InventoryCardInstances(props)](#Components.module_InventoryCardInstances..InventoryCardInstances) ⇒ <code>React.ReactNode</code>
-        * [.propTypes](#Components.module_InventoryCardInstances..InventoryCardInstances.propTypes) : <code>Object</code>
-        * [.defaultProps](#Components.module_InventoryCardInstances..InventoryCardInstances.defaultProps) : <code>Object</code>
-
 <a name="Components.module_InventoryCardInstances..InventoryCardInstances"></a>
 
-### InventoryCardInstances~InventoryCardInstances(props) ⇒ <code>React.ReactNode</code>
+### InventoryCardInstances~InventoryCardInstances(props) ⇒ <code>JSX.Element</code>
 An instances' system inventory component.
 
 **Kind**: inner method of [<code>InventoryCardInstances</code>](#Components.module_InventoryCardInstances)  
-**Emits**: [<code>onColumnSort</code>](#event_onColumnSort), [<code>onPage</code>](#event_onPage)  
 <table>
   <thead>
     <tr>
-      <th>Param</th><th>Type</th>
+      <th>Param</th><th>Type</th><th>Default</th>
     </tr>
   </thead>
   <tbody>
 <tr>
-    <td>props</td><td><code>object</code></td>
+    <td>props</td><td><code>object</code></td><td></td>
     </tr><tr>
-    <td>props.isDisabled</td><td><code>boolean</code></td>
+    <td>[props.isDisabled]</td><td><code>boolean</code></td><td><code>helpers.UI_DISABLED_TABLE_INSTANCES</code></td>
     </tr><tr>
-    <td>props.useGetInventory</td><td><code>function</code></td>
+    <td>[props.useGetInventory]</td><td><code>useGetInstancesInventory</code></td><td><code>useGetInstancesInventory</code></td>
     </tr><tr>
-    <td>props.useOnPage</td><td><code>function</code></td>
+    <td>[props.useInventoryCardActions]</td><td><code>useInventoryCardActionsInstances</code></td><td><code>useInventoryCardActionsInstances</code></td>
     </tr><tr>
-    <td>props.useOnColumnSort</td><td><code>function</code></td>
+    <td>[props.useOnPage]</td><td><code>useOnPageInstances</code></td><td><code>useOnPageInstances</code></td>
     </tr><tr>
-    <td>props.useProductInventoryConfig</td><td><code>function</code></td>
+    <td>[props.useOnColumnSort]</td><td><code>useOnColumnSortInstances</code></td><td><code>useOnColumnSortInstances</code></td>
     </tr><tr>
-    <td>props.useProductInventoryQuery</td><td><code>function</code></td>
+    <td>[props.useParseFiltersSettings]</td><td><code>useParseInstancesFiltersSettings</code></td><td><code>useParseInstancesFiltersSettings</code></td>
     </tr>  </tbody>
 </table>
 
-
-* [~InventoryCardInstances(props)](#Components.module_InventoryCardInstances..InventoryCardInstances) ⇒ <code>React.ReactNode</code>
-    * [.propTypes](#Components.module_InventoryCardInstances..InventoryCardInstances.propTypes) : <code>Object</code>
-    * [.defaultProps](#Components.module_InventoryCardInstances..InventoryCardInstances.defaultProps) : <code>Object</code>
-
-<a name="Components.module_InventoryCardInstances..InventoryCardInstances.propTypes"></a>
-
-#### InventoryCardInstances.propTypes : <code>Object</code>
-Prop types.
-
-**Kind**: static property of [<code>InventoryCardInstances</code>](#Components.module_InventoryCardInstances..InventoryCardInstances)  
-<a name="Components.module_InventoryCardInstances..InventoryCardInstances.defaultProps"></a>
-
-#### InventoryCardInstances.defaultProps : <code>Object</code>
-Default props.
-
-**Kind**: static property of [<code>InventoryCardInstances</code>](#Components.module_InventoryCardInstances..InventoryCardInstances)  
 <a name="InventoryCardInstances.module_InventoryCardInstancesContext"></a>
 
 ## InventoryCardInstancesContext
@@ -3332,60 +3314,36 @@ On event update state for inventory.
     </tr>  </tbody>
 </table>
 
-
-* [InventoryCardSubscriptions](#Components.module_InventoryCardSubscriptions)
-    * [~InventoryCardSubscriptions(props)](#Components.module_InventoryCardSubscriptions..InventoryCardSubscriptions) ⇒ <code>React.ReactNode</code>
-        * [.propTypes](#Components.module_InventoryCardSubscriptions..InventoryCardSubscriptions.propTypes) : <code>Object</code>
-        * [.defaultProps](#Components.module_InventoryCardSubscriptions..InventoryCardSubscriptions.defaultProps) : <code>Object</code>
-
 <a name="Components.module_InventoryCardSubscriptions..InventoryCardSubscriptions"></a>
 
-### InventoryCardSubscriptions~InventoryCardSubscriptions(props) ⇒ <code>React.ReactNode</code>
+### InventoryCardSubscriptions~InventoryCardSubscriptions(props) ⇒ <code>JSX.Element</code>
 A subscriptions' system inventory component.
 
 **Kind**: inner method of [<code>InventoryCardSubscriptions</code>](#Components.module_InventoryCardSubscriptions)  
-**Emits**: [<code>onColumnSort</code>](#event_onColumnSort), [<code>onPage</code>](#event_onPage)  
 <table>
   <thead>
     <tr>
-      <th>Param</th><th>Type</th>
+      <th>Param</th><th>Type</th><th>Default</th>
     </tr>
   </thead>
   <tbody>
 <tr>
-    <td>props</td><td><code>object</code></td>
+    <td>props</td><td><code>object</code></td><td></td>
     </tr><tr>
-    <td>props.isDisabled</td><td><code>boolean</code></td>
+    <td>[props.isDisabled]</td><td><code>boolean</code></td><td><code>helpers.UI_DISABLED_TABLE_SUBSCRIPTIONS</code></td>
     </tr><tr>
-    <td>props.useGetInventory</td><td><code>function</code></td>
+    <td>[props.useGetInventory]</td><td><code>useGetSubscriptionsInventory</code></td><td><code>useGetSubscriptionsInventory</code></td>
     </tr><tr>
-    <td>props.useOnPage</td><td><code>function</code></td>
+    <td>[props.useInventoryCardActions]</td><td><code>useInventoryCardActionsSubscriptions</code></td><td><code>useInventoryCardActionsSubscriptions</code></td>
     </tr><tr>
-    <td>props.useOnColumnSort</td><td><code>function</code></td>
+    <td>[props.useOnPage]</td><td><code>useOnPageSubscriptions</code></td><td><code>useOnPageSubscriptions</code></td>
     </tr><tr>
-    <td>props.useProductInventoryConfig</td><td><code>function</code></td>
+    <td>[props.useOnColumnSort]</td><td><code>useOnColumnSortSubscriptions</code></td><td><code>useOnColumnSortSubscriptions</code></td>
     </tr><tr>
-    <td>props.useProductInventoryQuery</td><td><code>function</code></td>
+    <td>[props.useParseFiltersSettings]</td><td><code>useParseSubscriptionsFiltersSettings</code></td><td><code>useParseSubscriptionsFiltersSettings</code></td>
     </tr>  </tbody>
 </table>
 
-
-* [~InventoryCardSubscriptions(props)](#Components.module_InventoryCardSubscriptions..InventoryCardSubscriptions) ⇒ <code>React.ReactNode</code>
-    * [.propTypes](#Components.module_InventoryCardSubscriptions..InventoryCardSubscriptions.propTypes) : <code>Object</code>
-    * [.defaultProps](#Components.module_InventoryCardSubscriptions..InventoryCardSubscriptions.defaultProps) : <code>Object</code>
-
-<a name="Components.module_InventoryCardSubscriptions..InventoryCardSubscriptions.propTypes"></a>
-
-#### InventoryCardSubscriptions.propTypes : <code>Object</code>
-Prop types.
-
-**Kind**: static property of [<code>InventoryCardSubscriptions</code>](#Components.module_InventoryCardSubscriptions..InventoryCardSubscriptions)  
-<a name="Components.module_InventoryCardSubscriptions..InventoryCardSubscriptions.defaultProps"></a>
-
-#### InventoryCardSubscriptions.defaultProps : <code>Object</code>
-Default props.
-
-**Kind**: static property of [<code>InventoryCardSubscriptions</code>](#Components.module_InventoryCardSubscriptions..InventoryCardSubscriptions)  
 <a name="InventoryCardSubscriptions.module_InventoryCardSubscriptionsContext"></a>
 
 ## InventoryCardSubscriptionsContext
@@ -3616,15 +3574,9 @@ Guests inventory table wrapper.
     </tr>  </tbody>
 </table>
 
-
-* [InventoryGuests](#Components.module_InventoryGuests)
-    * [~InventoryGuests(props)](#Components.module_InventoryGuests..InventoryGuests) ⇒ <code>React.ReactNode</code>
-        * [.propTypes](#Components.module_InventoryGuests..InventoryGuests.propTypes) : <code>Object</code>
-        * [.defaultProps](#Components.module_InventoryGuests..InventoryGuests.defaultProps) : <code>Object</code>
-
 <a name="Components.module_InventoryGuests..InventoryGuests"></a>
 
-### InventoryGuests~InventoryGuests(props) ⇒ <code>React.ReactNode</code>
+### InventoryGuests~InventoryGuests(props) ⇒ <code>JSX.Element</code>
 A system inventory guests component.
 
 **Kind**: inner method of [<code>InventoryGuests</code>](#Components.module_InventoryGuests)  
@@ -3632,44 +3584,27 @@ A system inventory guests component.
 <table>
   <thead>
     <tr>
-      <th>Param</th><th>Type</th>
+      <th>Param</th><th>Type</th><th>Default</th>
     </tr>
   </thead>
   <tbody>
 <tr>
-    <td>props</td><td><code>object</code></td>
+    <td>props</td><td><code>object</code></td><td></td>
     </tr><tr>
-    <td>props.defaultPerPage</td><td><code>number</code></td>
+    <td>[props.defaultPerPage]</td><td><code>number</code></td><td><code>5</code></td>
     </tr><tr>
-    <td>props.id</td><td><code>string</code></td>
+    <td>props.id</td><td><code>string</code></td><td></td>
     </tr><tr>
-    <td>props.numberOfGuests</td><td><code>number</code></td>
+    <td>props.numberOfGuests</td><td><code>number</code></td><td></td>
     </tr><tr>
-    <td>props.useGetInventory</td><td><code>function</code></td>
+    <td>[props.useGetInventory]</td><td><code>useGetGuestsInventory</code></td><td><code>useGetGuestsInventory</code></td>
     </tr><tr>
-    <td>props.useOnScroll</td><td><code>function</code></td>
+    <td>[props.useOnScroll]</td><td><code>useOnScroll</code></td><td><code>useOnScroll</code></td>
     </tr><tr>
-    <td>props.t</td><td><code>function</code></td>
+    <td>[props.t]</td><td><code>translate</code></td><td><code>translate</code></td>
     </tr>  </tbody>
 </table>
 
-
-* [~InventoryGuests(props)](#Components.module_InventoryGuests..InventoryGuests) ⇒ <code>React.ReactNode</code>
-    * [.propTypes](#Components.module_InventoryGuests..InventoryGuests.propTypes) : <code>Object</code>
-    * [.defaultProps](#Components.module_InventoryGuests..InventoryGuests.defaultProps) : <code>Object</code>
-
-<a name="Components.module_InventoryGuests..InventoryGuests.propTypes"></a>
-
-#### InventoryGuests.propTypes : <code>Object</code>
-Prop types.
-
-**Kind**: static property of [<code>InventoryGuests</code>](#Components.module_InventoryGuests..InventoryGuests)  
-<a name="Components.module_InventoryGuests..InventoryGuests.defaultProps"></a>
-
-#### InventoryGuests.defaultProps : <code>Object</code>
-Default props.
-
-**Kind**: static property of [<code>InventoryGuests</code>](#Components.module_InventoryGuests..InventoryGuests)  
 <a name="InventoryGuests.module_InventoryGuestsContext"></a>
 
 ## InventoryGuestsContext
@@ -3815,53 +3750,34 @@ On scroll, dispatch type.
 <a name="InventoryTabs.module_InventoryTab"></a>
 
 ## InventoryTab
-
-* [InventoryTab](#InventoryTabs.module_InventoryTab)
-    * [~InventoryTab(props)](#InventoryTabs.module_InventoryTab..InventoryTab) ⇒ <code>React.ReactNode</code>
-        * [.propTypes](#InventoryTabs.module_InventoryTab..InventoryTab.propTypes) : <code>Object</code>
-        * [.defaultProps](#InventoryTabs.module_InventoryTab..InventoryTab.defaultProps) : <code>Object</code>
-
 <a name="InventoryTabs.module_InventoryTab..InventoryTab"></a>
 
 ### InventoryTab~InventoryTab(props) ⇒ <code>React.ReactNode</code>
-A tab pass-through component for passing props to InventoryTabs.
+A tab pass-through component for passing props to the parent InventoryTabs.
+There are two props, "active" and "title", that don't appear to be used in the immediate component. Instead, those
+props are consumed at the parent level.
 
 **Kind**: inner method of [<code>InventoryTab</code>](#InventoryTabs.module_InventoryTab)  
 <table>
   <thead>
     <tr>
-      <th>Param</th><th>Type</th>
+      <th>Param</th><th>Type</th><th>Default</th><th>Description</th>
     </tr>
   </thead>
   <tbody>
 <tr>
-    <td>props</td><td><code>object</code></td>
+    <td>props</td><td><code>object</code></td><td></td><td></td>
     </tr><tr>
-    <td>props.active</td><td><code>boolean</code></td>
+    <td>[props.active]</td><td><code>boolean</code></td><td><code>false</code></td><td><p>The active tab to display</p>
+</td>
     </tr><tr>
-    <td>props.children</td><td><code>React.ReactNode</code></td>
+    <td>props.children</td><td><code>React.ReactNode</code></td><td></td><td></td>
     </tr><tr>
-    <td>props.title</td><td><code>string</code></td>
+    <td>props.title</td><td><code>string</code></td><td></td><td><p>Tab title/copy to display</p>
+</td>
     </tr>  </tbody>
 </table>
 
-
-* [~InventoryTab(props)](#InventoryTabs.module_InventoryTab..InventoryTab) ⇒ <code>React.ReactNode</code>
-    * [.propTypes](#InventoryTabs.module_InventoryTab..InventoryTab.propTypes) : <code>Object</code>
-    * [.defaultProps](#InventoryTabs.module_InventoryTab..InventoryTab.defaultProps) : <code>Object</code>
-
-<a name="InventoryTabs.module_InventoryTab..InventoryTab.propTypes"></a>
-
-#### InventoryTab.propTypes : <code>Object</code>
-Prop types.
-
-**Kind**: static property of [<code>InventoryTab</code>](#InventoryTabs.module_InventoryTab..InventoryTab)  
-<a name="InventoryTabs.module_InventoryTab..InventoryTab.defaultProps"></a>
-
-#### InventoryTab.defaultProps : <code>Object</code>
-Default props.
-
-**Kind**: static property of [<code>InventoryTab</code>](#InventoryTabs.module_InventoryTab..InventoryTab)  
 <a name="Components.module_InventoryTabs"></a>
 
 ## InventoryTabs
@@ -3885,9 +3801,7 @@ An inventory tabs display with state. Consume Tabs.
 
 * [InventoryTabs](#Components.module_InventoryTabs)
     * [~useOnTab(options)](#Components.module_InventoryTabs..useOnTab) ⇒ <code>function</code>
-    * [~InventoryTabs(props)](#Components.module_InventoryTabs..InventoryTabs) ⇒ <code>React.ReactNode</code> \| <code>null</code>
-        * [.propTypes](#Components.module_InventoryTabs..InventoryTabs.propTypes) : <code>Object</code>
-        * [.defaultProps](#Components.module_InventoryTabs..InventoryTabs.defaultProps) : <code>Object</code>
+    * [~InventoryTabs(props)](#Components.module_InventoryTabs..InventoryTabs) ⇒ <code>JSX.Element</code> \| <code>null</code>
 
 <a name="Components.module_InventoryTabs..useOnTab"></a>
 
@@ -3898,22 +3812,22 @@ Update tab state.
 <table>
   <thead>
     <tr>
-      <th>Param</th><th>Type</th>
+      <th>Param</th><th>Type</th><th>Default</th>
     </tr>
   </thead>
   <tbody>
 <tr>
-    <td>options</td><td><code>object</code></td>
+    <td>options</td><td><code>object</code></td><td></td>
     </tr><tr>
-    <td>options.useDispatch</td><td><code>function</code></td>
+    <td>[options.useDispatch]</td><td><code>storeHooks.reactRedux.useDispatch</code></td><td><code>storeHooks.reactRedux.useDispatch</code></td>
     </tr><tr>
-    <td>options.useProduct</td><td><code>function</code></td>
+    <td>[options.useProduct]</td><td><code>useProduct</code></td><td><code>useProduct</code></td>
     </tr>  </tbody>
 </table>
 
 <a name="Components.module_InventoryTabs..InventoryTabs"></a>
 
-### InventoryTabs~InventoryTabs(props) ⇒ <code>React.ReactNode</code> \| <code>null</code>
+### InventoryTabs~InventoryTabs(props) ⇒ <code>JSX.Element</code> \| <code>null</code>
 An inventory tabs component.
 Render inventory tabs using Inventory tab passed props only.
 
@@ -3922,48 +3836,31 @@ Render inventory tabs using Inventory tab passed props only.
 <table>
   <thead>
     <tr>
-      <th>Param</th><th>Type</th>
+      <th>Param</th><th>Type</th><th>Default</th>
     </tr>
   </thead>
   <tbody>
 <tr>
-    <td>props</td><td><code>object</code></td>
+    <td>props</td><td><code>object</code></td><td></td>
     </tr><tr>
-    <td>props.activeTab</td><td><code>number</code></td>
+    <td>[props.activeTab]</td><td><code>number</code></td><td><code>0</code></td>
     </tr><tr>
-    <td>props.children</td><td><code>React.ReactNode</code></td>
+    <td>props.children</td><td><code>React.ReactNode</code></td><td></td>
     </tr><tr>
-    <td>props.defaultActiveTab</td><td><code>number</code></td>
+    <td>[props.defaultActiveTab]</td><td><code>number</code></td><td><code>0</code></td>
     </tr><tr>
-    <td>props.isDisabled</td><td><code>boolean</code></td>
+    <td>[props.isDisabled]</td><td><code>boolean</code></td><td><code>helpers.UI_DISABLED_TABLE</code></td>
     </tr><tr>
-    <td>props.t</td><td><code>function</code></td>
+    <td>[props.t]</td><td><code>translate</code></td><td><code>translate</code></td>
     </tr><tr>
-    <td>props.useOnTab</td><td><code>function</code></td>
+    <td>[props.useOnTab]</td><td><code>useOnTab</code></td><td><code>useOnTab</code></td>
     </tr><tr>
-    <td>props.useProduct</td><td><code>function</code></td>
+    <td>[props.useProduct]</td><td><code>useProduct</code></td><td><code>useProduct</code></td>
     </tr><tr>
-    <td>props.useSelector</td><td><code>function</code></td>
+    <td>[props.useSelector]</td><td><code>storeHooks.reactRedux.useSelector</code></td><td><code>storeHooks.reactRedux.useSelector</code></td>
     </tr>  </tbody>
 </table>
 
-
-* [~InventoryTabs(props)](#Components.module_InventoryTabs..InventoryTabs) ⇒ <code>React.ReactNode</code> \| <code>null</code>
-    * [.propTypes](#Components.module_InventoryTabs..InventoryTabs.propTypes) : <code>Object</code>
-    * [.defaultProps](#Components.module_InventoryTabs..InventoryTabs.defaultProps) : <code>Object</code>
-
-<a name="Components.module_InventoryTabs..InventoryTabs.propTypes"></a>
-
-#### InventoryTabs.propTypes : <code>Object</code>
-Prop types.
-
-**Kind**: static property of [<code>InventoryTabs</code>](#Components.module_InventoryTabs..InventoryTabs)  
-<a name="Components.module_InventoryTabs..InventoryTabs.defaultProps"></a>
-
-#### InventoryTabs.defaultProps : <code>Object</code>
-Default props.
-
-**Kind**: static property of [<code>InventoryTabs</code>](#Components.module_InventoryTabs..InventoryTabs)  
 <a name="Components.module_Loader"></a>
 
 ## Loader

--- a/src/components/inventoryCard/inventoryCard.js
+++ b/src/components/inventoryCard/inventoryCard.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { TableVariant } from '@patternfly/react-table';
 import {
   Bullseye,
@@ -34,23 +33,58 @@ import { helpers } from '../../common';
  */
 
 /**
+ * @callback useGetInventory
+ * @returns {{
+ *     error: boolean,
+ *     message: string,
+ *     pending: boolean,
+ *     dataSetColumnHeaders: Array,
+ *     dataSetRows: Array,
+ *     resultsColumnCountAndWidths: { count: number, widths: Array },
+ *     resultsCount,
+ *     resultsOffset,
+ *     resultsPerPage
+ *   }}
+ */
+
+/**
+ * @callback useInventoryCardActions
+ * @returns {React.ReactNode}
+ */
+
+/**
+ * @callback useParseFiltersSettings
+ * @returns {{ filters: Array }}
+ */
+
+/**
+ * @callback useOnPage
+ * @returns {Function}
+ */
+
+/**
+ * @callback useOnColumnSort
+ * @returns {Function}
+ */
+
+/**
  * Set up inventory cards. Expand filters with base settings.
  *
  * @param {object} props
- * @param {boolean} props.isDisabled
- * @param {Function} props.t
- * @param {Function} props.useGetInventory
- * @param {Function} props.useInventoryCardActions
- * @param {Function} props.useParseFiltersSettings
- * @param {Function} props.useOnPage
- * @param {Function} props.useOnColumnSort
+ * @param {boolean} [props.isDisabled=false]
+ * @param {translate} [props.t=translate]
+ * @param {useGetInventory} props.useGetInventory
+ * @param {useInventoryCardActions} props.useInventoryCardActions
+ * @param {useParseFiltersSettings} props.useParseFiltersSettings
+ * @param {useOnPage} props.useOnPage
+ * @param {useOnColumnSort} props.useOnColumnSort
  * @fires onColumnSort
  * @fires onPage
- * @returns {React.ReactNode}
+ * @returns {JSX.Element}
  */
 const InventoryCard = ({
-  isDisabled,
-  t,
+  isDisabled = false,
+  t = translate,
   useGetInventory: useAliasGetInventory,
   useInventoryCardActions: useAliasInventoryCardActions,
   useOnPage: useAliasOnPage,
@@ -194,32 +228,6 @@ const InventoryCard = ({
       </MinHeight>
     </Card>
   );
-};
-
-/**
- * Prop types.
- *
- * @type {{useOnPage: Function, useParseFiltersSettings: Function, t: Function, useInventoryCardActions: Function,
- *     isDisabled: boolean, useGetInventory: Function, useOnColumnSort: Function}}
- */
-InventoryCard.propTypes = {
-  isDisabled: PropTypes.bool,
-  t: PropTypes.func,
-  useGetInventory: PropTypes.func.isRequired,
-  useInventoryCardActions: PropTypes.func.isRequired,
-  useOnPage: PropTypes.func.isRequired,
-  useOnColumnSort: PropTypes.func.isRequired,
-  useParseFiltersSettings: PropTypes.func.isRequired
-};
-
-/**
- * Default props.
- *
- * @type {{t: translate, isDisabled: boolean}}
- */
-InventoryCard.defaultProps = {
-  isDisabled: false,
-  t: translate
 };
 
 export { InventoryCard as default, InventoryCard };

--- a/src/components/inventoryCardInstances/__tests__/__snapshots__/inventoryCardInstances.test.js.snap
+++ b/src/components/inventoryCardInstances/__tests__/__snapshots__/inventoryCardInstances.test.js.snap
@@ -3,13 +3,10 @@
 exports[`InventoryCardInstances Component should render a basic component: basic 1`] = `
 <InventoryCard
   isDisabled={false}
-  t={[Function]}
   useGetInventory={[Function]}
   useInventoryCardActions={[Function]}
   useOnColumnSort={[Function]}
   useOnPage={[Function]}
   useParseFiltersSettings={[Function]}
-  useProductInventoryConfig={[Function]}
-  useProductInventoryQuery={[Function]}
 />
 `;

--- a/src/components/inventoryCardInstances/inventoryCardInstances.js
+++ b/src/components/inventoryCardInstances/inventoryCardInstances.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import {
   useGetInstancesInventory,
   useInventoryCardActionsInstances,
@@ -9,7 +8,6 @@ import {
 } from './inventoryCardInstancesContext';
 import { InventoryCard } from '../inventoryCard/inventoryCard';
 import { helpers } from '../../common';
-import { translate } from '../i18n/i18nHelpers';
 
 /**
  * @memberof Components
@@ -21,48 +19,30 @@ import { translate } from '../i18n/i18nHelpers';
  * An instances' system inventory component.
  *
  * @param {object} props
- * @param {boolean} props.isDisabled
- * @param {Function} props.useGetInventory
- * @param {Function} props.useOnPage
- * @param {Function} props.useOnColumnSort
- * @param {Function} props.useProductInventoryConfig
- * @param {Function} props.useProductInventoryQuery
- * @fires onColumnSort
- * @fires onPage
- * @returns {React.ReactNode}
+ * @param {boolean} [props.isDisabled=helpers.UI_DISABLED_TABLE_INSTANCES]
+ * @param {useGetInstancesInventory} [props.useGetInventory=useGetInstancesInventory]
+ * @param {useInventoryCardActionsInstances} [props.useInventoryCardActions=useInventoryCardActionsInstances]
+ * @param {useOnPageInstances} [props.useOnPage=useOnPageInstances]
+ * @param {useOnColumnSortInstances} [props.useOnColumnSort=useOnColumnSortInstances]
+ * @param {useParseInstancesFiltersSettings} [props.useParseFiltersSettings=useParseInstancesFiltersSettings]
+ * @returns {JSX.Element}
  */
-const InventoryCardInstances = ({ ...props }) => <InventoryCard {...props} />;
-
-/**
- * Prop types.
- *
- * @type {{useOnPage: Function, useParseFiltersSettings: Function, t: Function, useInventoryCardActions: Function,
- *     isDisabled: boolean, useGetInventory: Function, useOnColumnSort: Function}}
- */
-InventoryCardInstances.propTypes = {
-  isDisabled: PropTypes.bool,
-  t: PropTypes.func,
-  useGetInventory: PropTypes.func,
-  useInventoryCardActions: PropTypes.func,
-  useOnPage: PropTypes.func,
-  useOnColumnSort: PropTypes.func,
-  useParseFiltersSettings: PropTypes.func
-};
-
-/**
- * Default props.
- *
- * @type {{useOnPage: Function, useParseFiltersSettings: Function, t: translate, useInventoryCardActions: Function,
- *     isDisabled: boolean, useGetInventory: Function, useOnColumnSort: Function}}
- */
-InventoryCardInstances.defaultProps = {
-  isDisabled: helpers.UI_DISABLED_TABLE_INSTANCES,
-  t: translate,
-  useGetInventory: useGetInstancesInventory,
-  useInventoryCardActions: useInventoryCardActionsInstances,
-  useOnPage: useOnPageInstances,
-  useOnColumnSort: useOnColumnSortInstances,
-  useParseFiltersSettings: useParseInstancesFiltersSettings
-};
+const InventoryCardInstances = ({
+  isDisabled = helpers.UI_DISABLED_TABLE_INSTANCES,
+  useGetInventory = useGetInstancesInventory,
+  useInventoryCardActions = useInventoryCardActionsInstances,
+  useOnPage = useOnPageInstances,
+  useOnColumnSort = useOnColumnSortInstances,
+  useParseFiltersSettings = useParseInstancesFiltersSettings
+}) => (
+  <InventoryCard
+    isDisabled={isDisabled}
+    useGetInventory={useGetInventory}
+    useInventoryCardActions={useInventoryCardActions}
+    useOnPage={useOnPage}
+    useOnColumnSort={useOnColumnSort}
+    useParseFiltersSettings={useParseFiltersSettings}
+  />
+);
 
 export { InventoryCardInstances as default, InventoryCardInstances };

--- a/src/components/inventoryCardSubscriptions/__tests__/__snapshots__/inventoryCardSubscriptions.test.js.snap
+++ b/src/components/inventoryCardSubscriptions/__tests__/__snapshots__/inventoryCardSubscriptions.test.js.snap
@@ -3,13 +3,10 @@
 exports[`InventoryCardSubscriptions Component should render a basic component: basic 1`] = `
 <InventoryCard
   isDisabled={false}
-  t={[Function]}
   useGetInventory={[Function]}
   useInventoryCardActions={[Function]}
   useOnColumnSort={[Function]}
   useOnPage={[Function]}
   useParseFiltersSettings={[Function]}
-  useProductInventoryConfig={[Function]}
-  useProductInventoryQuery={[Function]}
 />
 `;

--- a/src/components/inventoryCardSubscriptions/inventoryCardSubscriptions.js
+++ b/src/components/inventoryCardSubscriptions/inventoryCardSubscriptions.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import {
   useGetSubscriptionsInventory,
   useInventoryCardActionsSubscriptions,
@@ -9,7 +8,6 @@ import {
 } from './inventoryCardSubscriptionsContext';
 import { InventoryCard } from '../inventoryCard/inventoryCard';
 import { helpers } from '../../common';
-import { translate } from '../i18n/i18nHelpers';
 
 /**
  * @memberof Components
@@ -21,48 +19,30 @@ import { translate } from '../i18n/i18nHelpers';
  * A subscriptions' system inventory component.
  *
  * @param {object} props
- * @param {boolean} props.isDisabled
- * @param {Function} props.useGetInventory
- * @param {Function} props.useOnPage
- * @param {Function} props.useOnColumnSort
- * @param {Function} props.useProductInventoryConfig
- * @param {Function} props.useProductInventoryQuery
- * @fires onColumnSort
- * @fires onPage
- * @returns {React.ReactNode}
+ * @param {boolean} [props.isDisabled=helpers.UI_DISABLED_TABLE_SUBSCRIPTIONS]
+ * @param {useGetSubscriptionsInventory} [props.useGetInventory=useGetSubscriptionsInventory]
+ * @param {useInventoryCardActionsSubscriptions} [props.useInventoryCardActions=useInventoryCardActionsSubscriptions]
+ * @param {useOnPageSubscriptions} [props.useOnPage=useOnPageSubscriptions]
+ * @param {useOnColumnSortSubscriptions} [props.useOnColumnSort=useOnColumnSortSubscriptions]
+ * @param {useParseSubscriptionsFiltersSettings} [props.useParseFiltersSettings=useParseSubscriptionsFiltersSettings]
+ * @returns {JSX.Element}
  */
-const InventoryCardSubscriptions = ({ ...props }) => <InventoryCard {...props} />;
-
-/**
- * Prop types.
- *
- * @type {{useOnPage: Function, useParseFiltersSettings: Function, t: Function, useInventoryCardActions: Function,
- *     isDisabled: boolean, useGetInventory: Function, useOnColumnSort: Function}}
- */
-InventoryCardSubscriptions.propTypes = {
-  isDisabled: PropTypes.bool,
-  t: PropTypes.func,
-  useGetInventory: PropTypes.func,
-  useInventoryCardActions: PropTypes.func,
-  useOnPage: PropTypes.func,
-  useOnColumnSort: PropTypes.func,
-  useParseFiltersSettings: PropTypes.func
-};
-
-/**
- * Default props.
- *
- * @type {{useOnPage: Function, useParseFiltersSettings: Function, t: translate, useInventoryCardActions: Function,
- *     isDisabled: boolean, useGetInventory: Function, useOnColumnSort: Function}}
- */
-InventoryCardSubscriptions.defaultProps = {
-  isDisabled: helpers.UI_DISABLED_TABLE_SUBSCRIPTIONS,
-  t: translate,
-  useGetInventory: useGetSubscriptionsInventory,
-  useInventoryCardActions: useInventoryCardActionsSubscriptions,
-  useOnPage: useOnPageSubscriptions,
-  useOnColumnSort: useOnColumnSortSubscriptions,
-  useParseFiltersSettings: useParseSubscriptionsFiltersSettings
-};
+const InventoryCardSubscriptions = ({
+  isDisabled = helpers.UI_DISABLED_TABLE_SUBSCRIPTIONS,
+  useGetInventory = useGetSubscriptionsInventory,
+  useInventoryCardActions = useInventoryCardActionsSubscriptions,
+  useOnPage = useOnPageSubscriptions,
+  useOnColumnSort = useOnColumnSortSubscriptions,
+  useParseFiltersSettings = useParseSubscriptionsFiltersSettings
+}) => (
+  <InventoryCard
+    isDisabled={isDisabled}
+    useGetInventory={useGetInventory}
+    useInventoryCardActions={useInventoryCardActions}
+    useOnPage={useOnPage}
+    useOnColumnSort={useOnColumnSort}
+    useParseFiltersSettings={useParseFiltersSettings}
+  />
+);
 
 export { InventoryCardSubscriptions as default, InventoryCardSubscriptions };

--- a/src/components/inventoryGuests/inventoryGuests.js
+++ b/src/components/inventoryGuests/inventoryGuests.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Loader } from '../loader/loader';
 import { Table, TableVariant } from '../table/table';
 import { useGetGuestsInventory, useOnScroll } from './inventoryGuestsContext'; // eslint-disable-line
@@ -18,22 +17,22 @@ import { translate } from '../i18n/i18n';
  * A system inventory guests component.
  *
  * @param {object} props
- * @param {number} props.defaultPerPage
+ * @param {number} [props.defaultPerPage=5]
  * @param {string} props.id
  * @param {number} props.numberOfGuests
- * @param {Function} props.useGetInventory
- * @param {Function} props.useOnScroll
- * @param {Function} props.t
+ * @param {useGetGuestsInventory} [props.useGetInventory=useGetGuestsInventory]
+ * @param {useOnScroll} [props.useOnScroll=useOnScroll]
+ * @param {translate} [props.t=translate]
  * @fires onScroll
- * @returns {React.ReactNode}
+ * @returns {JSX.Element}
  */
 const InventoryGuests = ({
-  defaultPerPage,
+  defaultPerPage = 5,
   id,
   numberOfGuests,
-  t,
-  useGetInventory: useAliasGetInventory,
-  useOnScroll: useAliasOnScroll
+  t = translate,
+  useGetInventory: useAliasGetInventory = useGetGuestsInventory,
+  useOnScroll: useAliasOnScroll = useOnScroll
 }) => {
   const {
     error,
@@ -89,33 +88,6 @@ const InventoryGuests = ({
       </div>
     </div>
   );
-};
-
-/**
- * Prop types.
- *
- * @type {{numberOfGuests: number, id: string, t: Function, useOnScroll: Function, useGetInventory: Function,
- *     defaultPerPage: number}}
- */
-InventoryGuests.propTypes = {
-  defaultPerPage: PropTypes.number,
-  id: PropTypes.string.isRequired,
-  numberOfGuests: PropTypes.number.isRequired,
-  t: PropTypes.func,
-  useGetInventory: PropTypes.func,
-  useOnScroll: PropTypes.func
-};
-
-/**
- * Default props.
- *
- * @type {{t: translate, useOnScroll: Function, useGetInventory: Function, defaultPerPage: number}}
- */
-InventoryGuests.defaultProps = {
-  t: translate,
-  defaultPerPage: 5,
-  useGetInventory: useGetGuestsInventory,
-  useOnScroll
 };
 
 export { InventoryGuests as default, InventoryGuests };

--- a/src/components/inventoryTabs/inventoryTab.js
+++ b/src/components/inventoryTabs/inventoryTab.js
@@ -1,4 +1,5 @@
-import PropTypes from 'prop-types';
+// eslint-disable-next-line no-unused-vars
+import React from 'react';
 
 /**
  * @memberof InventoryTabs
@@ -6,35 +7,17 @@ import PropTypes from 'prop-types';
  */
 
 /**
- * A tab pass-through component for passing props to InventoryTabs.
+ * A tab pass-through component for passing props to the parent InventoryTabs.
+ * There are two props, "active" and "title", that don't appear to be used in the immediate component. Instead, those
+ * props are consumed at the parent level.
  *
  * @param {object} props
- * @param {boolean} props.active
+ * @param {boolean} [props.active=false] The active tab to display
  * @param {React.ReactNode} props.children
- * @param {string} props.title
+ * @param {string} props.title Tab title/copy to display
  * @returns {React.ReactNode}
  */
 // eslint-disable-next-line no-unused-vars
-const InventoryTab = ({ active, children, title }) => children;
-
-/**
- * Prop types.
- *
- * @type {{children: React.ReactNode, className: string}}
- */
-InventoryTab.propTypes = {
-  children: PropTypes.node.isRequired,
-  active: PropTypes.bool,
-  title: PropTypes.node.isRequired
-};
-
-/**
- * Default props.
- *
- * @type {{className: string}}
- */
-InventoryTab.defaultProps = {
-  active: false
-};
+const InventoryTab = ({ active = false, children, title }) => children;
 
 export { InventoryTab as default, InventoryTab };

--- a/src/components/inventoryTabs/inventoryTabs.js
+++ b/src/components/inventoryTabs/inventoryTabs.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Title } from '@patternfly/react-core';
 import { reduxTypes, storeHooks } from '../../redux';
 import { useProduct } from '../productView/productViewContext';
@@ -21,8 +20,8 @@ import { InventoryTab } from './inventoryTab';
  * Update tab state.
  *
  * @param {object} options
- * @param {Function} options.useDispatch
- * @param {Function} options.useProduct
+ * @param {storeHooks.reactRedux.useDispatch} [options.useDispatch=storeHooks.reactRedux.useDispatch]
+ * @param {useProduct} [options.useProduct=useProduct]
  * @returns {Function}
  */
 const useOnTab = ({
@@ -46,27 +45,27 @@ const useOnTab = ({
  * An inventory tabs component.
  * Render inventory tabs using Inventory tab passed props only.
  *
- * @fires onTab
  * @param {object} props
- * @param {number} props.activeTab
+ * @param {number} [props.activeTab=0]
  * @param {React.ReactNode} props.children
- * @param {number} props.defaultActiveTab
- * @param {boolean} props.isDisabled
- * @param {Function} props.t
- * @param {Function} props.useOnTab
- * @param {Function} props.useProduct
- * @param {Function} props.useSelector
- * @returns {React.ReactNode|null}
+ * @param {number} [props.defaultActiveTab=0]
+ * @param {boolean} [props.isDisabled=helpers.UI_DISABLED_TABLE]
+ * @param {translate} [props.t=translate]
+ * @param {useOnTab} [props.useOnTab=useOnTab]
+ * @param {useProduct} [props.useProduct=useProduct]
+ * @param {storeHooks.reactRedux.useSelector} [props.useSelector=storeHooks.reactRedux.useSelector]
+ * @fires onTab
+ * @returns {JSX.Element|null}
  */
 const InventoryTabs = ({
-  activeTab,
+  activeTab = 0,
   children,
-  defaultActiveTab,
-  isDisabled,
-  t,
-  useOnTab: useAliasOnTab,
-  useProduct: useAliasProduct,
-  useSelector: useAliasSelector
+  defaultActiveTab = 0,
+  isDisabled = helpers.UI_DISABLED_TABLE,
+  t = translate,
+  useOnTab: useAliasOnTab = useOnTab,
+  useProduct: useAliasProduct = useProduct,
+  useSelector: useAliasSelector = storeHooks.reactRedux.useSelector
 }) => {
   const { productId } = useAliasProduct();
   const updatedActiveTab = useAliasSelector(({ inventory }) => inventory.tabs?.[productId], activeTab);
@@ -94,39 +93,6 @@ const InventoryTabs = ({
       <Tabs activeTab={updatedActiveTab} defaultActiveTab={defaultActiveTab} onTab={onTab} tabs={updatedChildren} />
     </React.Fragment>
   );
-};
-
-/**
- * Prop types.
- *
- * @type {{useOnTab: Function, useProduct: Function, t: Function, children: React.ReactNode,
- *     useSelector: Function, defaultActiveTab: number, isDisabled: boolean, activeTab: number}}
- */
-InventoryTabs.propTypes = {
-  activeTab: PropTypes.number,
-  children: PropTypes.node.isRequired,
-  defaultActiveTab: PropTypes.number,
-  isDisabled: PropTypes.bool,
-  t: PropTypes.func,
-  useOnTab: PropTypes.func,
-  useProduct: PropTypes.func,
-  useSelector: PropTypes.func
-};
-
-/**
- * Default props.
- *
- * @type {{useOnTab: Function, useProduct: Function, t: translate, useSelector: Function,
- *     defaultActiveTab: number, isDisabled: boolean, activeTab: number}}
- */
-InventoryTabs.defaultProps = {
-  activeTab: 0,
-  defaultActiveTab: 0,
-  isDisabled: helpers.UI_DISABLED_TABLE,
-  t: translate,
-  useOnTab,
-  useProduct,
-  useSelector: storeHooks.reactRedux.useSelector
 };
 
 export { InventoryTabs as default, InventoryTabs, InventoryTab, useOnTab };

--- a/src/components/productView/__tests__/__snapshots__/productView.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productView.test.js.snap
@@ -57,41 +57,17 @@ exports[`ProductView Component should allow custom inventory displays via config
         className="curiosity-page-section__tabs"
       >
         <InventoryTabs
-          activeTab={0}
-          defaultActiveTab={0}
           isDisabled={false}
-          t={[Function]}
-          useOnTab={[Function]}
-          useProduct={[Function]}
-          useSelector={[Function]}
         >
           <InventoryTab
-            active={false}
             title="t(curiosity-inventory.tabInstances, {"context":"lorem"})"
           >
-            <InventoryCardInstances
-              isDisabled={false}
-              t={[Function]}
-              useGetInventory={[Function]}
-              useInventoryCardActions={[Function]}
-              useOnColumnSort={[Function]}
-              useOnPage={[Function]}
-              useParseFiltersSettings={[Function]}
-            />
+            <InventoryCardInstances />
           </InventoryTab>
           <InventoryTab
-            active={false}
             title="t(curiosity-inventory.tabSubscriptions, {"context":"lorem"})"
           >
-            <InventoryCardSubscriptions
-              isDisabled={false}
-              t={[Function]}
-              useGetInventory={[Function]}
-              useInventoryCardActions={[Function]}
-              useOnColumnSort={[Function]}
-              useOnPage={[Function]}
-              useParseFiltersSettings={[Function]}
-            />
+            <InventoryCardSubscriptions />
           </InventoryTab>
         </InventoryTabs>
       </PageSection>
@@ -171,27 +147,12 @@ exports[`ProductView Component should allow custom inventory displays via config
         className="curiosity-page-section__tabs"
       >
         <InventoryTabs
-          activeTab={0}
-          defaultActiveTab={0}
           isDisabled={false}
-          t={[Function]}
-          useOnTab={[Function]}
-          useProduct={[Function]}
-          useSelector={[Function]}
         >
           <InventoryTab
-            active={false}
             title="t(curiosity-inventory.tabSubscriptions, {"context":"lorem"})"
           >
-            <InventoryCardSubscriptions
-              isDisabled={false}
-              t={[Function]}
-              useGetInventory={[Function]}
-              useInventoryCardActions={[Function]}
-              useOnColumnSort={[Function]}
-              useOnPage={[Function]}
-              useParseFiltersSettings={[Function]}
-            />
+            <InventoryCardSubscriptions />
           </InventoryTab>
         </InventoryTabs>
       </PageSection>
@@ -271,27 +232,12 @@ exports[`ProductView Component should allow custom inventory displays via config
         className="curiosity-page-section__tabs"
       >
         <InventoryTabs
-          activeTab={0}
-          defaultActiveTab={0}
           isDisabled={false}
-          t={[Function]}
-          useOnTab={[Function]}
-          useProduct={[Function]}
-          useSelector={[Function]}
         >
           <InventoryTab
-            active={false}
             title="t(curiosity-inventory.tabInstances, {"context":"lorem"})"
           >
-            <InventoryCardInstances
-              isDisabled={false}
-              t={[Function]}
-              useGetInventory={[Function]}
-              useInventoryCardActions={[Function]}
-              useOnColumnSort={[Function]}
-              useOnPage={[Function]}
-              useParseFiltersSettings={[Function]}
-            />
+            <InventoryCardInstances />
           </InventoryTab>
         </InventoryTabs>
       </PageSection>
@@ -370,13 +316,7 @@ exports[`ProductView Component should allow custom product views via productDisp
         className="curiosity-page-section__tabs"
       >
         <InventoryTabs
-          activeTab={0}
-          defaultActiveTab={0}
           isDisabled={true}
-          t={[Function]}
-          useOnTab={[Function]}
-          useProduct={[Function]}
-          useSelector={[Function]}
         />
       </PageSection>
     </Context.Provider>
@@ -454,13 +394,7 @@ exports[`ProductView Component should allow custom product views via productDisp
         className="curiosity-page-section__tabs"
       >
         <InventoryTabs
-          activeTab={0}
-          defaultActiveTab={0}
           isDisabled={true}
-          t={[Function]}
-          useOnTab={[Function]}
-          useProduct={[Function]}
-          useSelector={[Function]}
         />
       </PageSection>
     </Context.Provider>
@@ -538,13 +472,7 @@ exports[`ProductView Component should allow custom product views via productDisp
         className="curiosity-page-section__tabs"
       >
         <InventoryTabs
-          activeTab={0}
-          defaultActiveTab={0}
           isDisabled={true}
-          t={[Function]}
-          useOnTab={[Function]}
-          useProduct={[Function]}
-          useSelector={[Function]}
         />
       </PageSection>
     </Context.Provider>
@@ -622,13 +550,7 @@ exports[`ProductView Component should allow custom product views via productDisp
         className="curiosity-page-section__tabs"
       >
         <InventoryTabs
-          activeTab={0}
-          defaultActiveTab={0}
           isDisabled={true}
-          t={[Function]}
-          useOnTab={[Function]}
-          useProduct={[Function]}
-          useSelector={[Function]}
         />
       </PageSection>
     </Context.Provider>
@@ -706,13 +628,7 @@ exports[`ProductView Component should allow custom product views via productDisp
         className="curiosity-page-section__tabs"
       >
         <InventoryTabs
-          activeTab={0}
-          defaultActiveTab={0}
           isDisabled={true}
-          t={[Function]}
-          useOnTab={[Function]}
-          useProduct={[Function]}
-          useSelector={[Function]}
         />
       </PageSection>
     </Context.Provider>
@@ -789,13 +705,7 @@ exports[`ProductView Component should render a basic component: basic 1`] = `
         className="curiosity-page-section__tabs"
       >
         <InventoryTabs
-          activeTab={0}
-          defaultActiveTab={0}
           isDisabled={true}
-          t={[Function]}
-          useOnTab={[Function]}
-          useProduct={[Function]}
-          useSelector={[Function]}
         />
       </PageSection>
     </Context.Provider>


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- refactor(inventoryCards,tabs): sw-2707 remove deprecated react

### Notes
- remove inventoryCards' default props and types. affects
   - inventoryCard
   - inventoryCardInstances
   - inventoryCardSubscriptions
   - inventoryGuests

<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. next...
-->

### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. confirm tests come back clean

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-2707