### PR TITLE
refactor(textInput): sw-2707, class to func, deprecated react

### DIFF
--- a/src/components/README.md
+++ b/src/components/README.md
@@ -1705,51 +1705,53 @@ Text input with state.
 
 
 * [TextInput](#Form.module_TextInput)
-    * [~TextInput](#Form.module_TextInput..TextInput) ⇐ <code>React.Component</code>
-        * _instance_
-            * [.render()](#Form.module_TextInput..TextInput+render) ⇒ <code>React.ReactNode</code>
-        * _static_
-            * [.propTypes](#Form.module_TextInput..TextInput.propTypes) : <code>Object</code>
-            * [.defaultProps](#Form.module_TextInput..TextInput.defaultProps) : <code>Object</code>
+    * [~TextInput(props)](#Form.module_TextInput..TextInput) ⇒ <code>JSX.Element</code>
     * ["onKeyUp" (event)](#event_onKeyUp)
     * ["onMouseUp" (event)](#event_onMouseUp)
     * ["onChange" (event, value)](#event_onChange)
 
 <a name="Form.module_TextInput..TextInput"></a>
 
-### TextInput~TextInput ⇐ <code>React.Component</code>
+### TextInput~TextInput(props) ⇒ <code>JSX.Element</code>
 A wrapper for Patternfly TextInput. Provides restructured event data,
 and an onClear event for the search type.
 
-**Kind**: inner class of [<code>TextInput</code>](#Form.module_TextInput)  
-**Extends**: <code>React.Component</code>  
+**Kind**: inner method of [<code>TextInput</code>](#Form.module_TextInput)  
 **Emits**: [<code>onKeyUp</code>](#event_onKeyUp), [<code>onMouseUp</code>](#event_onMouseUp), [<code>onChange</code>](#event_onChange)  
+<table>
+  <thead>
+    <tr>
+      <th>Param</th><th>Type</th><th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+<tr>
+    <td>props</td><td><code>object</code></td><td></td>
+    </tr><tr>
+    <td>[props.className]</td><td><code>string</code></td><td><code>&quot;&#x27;&#x27;&quot;</code></td>
+    </tr><tr>
+    <td>[props.id]</td><td><code>string</code></td><td></td>
+    </tr><tr>
+    <td>[props.isDisabled]</td><td><code>boolean</code></td><td><code>false</code></td>
+    </tr><tr>
+    <td>[props.isReadOnly]</td><td><code>boolean</code></td><td><code>false</code></td>
+    </tr><tr>
+    <td>[props.name]</td><td><code>string</code></td><td><code>&quot;helpers.generateId()&quot;</code></td>
+    </tr><tr>
+    <td>[props.onChange]</td><td><code>function</code></td><td><code>helpers.noop</code></td>
+    </tr><tr>
+    <td>[props.onClear]</td><td><code>function</code></td><td><code>helpers.noop</code></td>
+    </tr><tr>
+    <td>[props.onKeyUp]</td><td><code>function</code></td><td><code>helpers.noop</code></td>
+    </tr><tr>
+    <td>[props.onMouseUp]</td><td><code>function</code></td><td><code>helpers.noop</code></td>
+    </tr><tr>
+    <td>[props.type]</td><td><code>string</code></td><td><code>&quot;&#x27;text&#x27;&quot;</code></td>
+    </tr><tr>
+    <td>[props.value]</td><td><code>string</code></td><td><code>&quot;&#x27;&#x27;&quot;</code></td>
+    </tr>  </tbody>
+</table>
 
-* [~TextInput](#Form.module_TextInput..TextInput) ⇐ <code>React.Component</code>
-    * _instance_
-        * [.render()](#Form.module_TextInput..TextInput+render) ⇒ <code>React.ReactNode</code>
-    * _static_
-        * [.propTypes](#Form.module_TextInput..TextInput.propTypes) : <code>Object</code>
-        * [.defaultProps](#Form.module_TextInput..TextInput.defaultProps) : <code>Object</code>
-
-<a name="Form.module_TextInput..TextInput+render"></a>
-
-#### textInput.render() ⇒ <code>React.ReactNode</code>
-Render a text input.
-
-**Kind**: instance method of [<code>TextInput</code>](#Form.module_TextInput..TextInput)  
-<a name="Form.module_TextInput..TextInput.propTypes"></a>
-
-#### TextInput.propTypes : <code>Object</code>
-Prop types.
-
-**Kind**: static property of [<code>TextInput</code>](#Form.module_TextInput..TextInput)  
-<a name="Form.module_TextInput..TextInput.defaultProps"></a>
-
-#### TextInput.defaultProps : <code>Object</code>
-Default props.
-
-**Kind**: static property of [<code>TextInput</code>](#Form.module_TextInput..TextInput)  
 <a name="event_onKeyUp"></a>
 
 ### "onKeyUp" (event)

--- a/src/components/form/__tests__/__snapshots__/textInput.test.js.snap
+++ b/src/components/form/__tests__/__snapshots__/textInput.test.js.snap
@@ -4,12 +4,7 @@ exports[`TextInput Component should handle readOnly, disabled: active 1`] = `
 <textinput
   props="{
   "isReadOnly": false,
-  "className": "",
-  "id": null,
   "isDisabled": false,
-  "name": null,
-  "type": "text",
-  "value": "",
   "children": []
 }"
 >
@@ -34,12 +29,7 @@ exports[`TextInput Component should handle readOnly, disabled: disabled 1`] = `
 <textinput
   props="{
   "isReadOnly": false,
-  "className": "",
-  "id": null,
   "isDisabled": true,
-  "name": null,
-  "type": "text",
-  "value": "",
   "children": []
 }"
 >
@@ -65,12 +55,6 @@ exports[`TextInput Component should handle readOnly, disabled: readOnly 1`] = `
 <textinput
   props="{
   "isReadOnly": true,
-  "className": "",
-  "id": null,
-  "isDisabled": false,
-  "name": null,
-  "type": "text",
-  "value": "",
   "children": []
 }"
 >
@@ -95,13 +79,6 @@ exports[`TextInput Component should handle readOnly, disabled: readOnly 1`] = `
 exports[`TextInput Component should render a basic component: basic component 1`] = `
 <textinput
   props="{
-  "className": "",
-  "id": null,
-  "isDisabled": false,
-  "isReadOnly": false,
-  "name": null,
-  "type": "text",
-  "value": "",
   "children": []
 }"
 >

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldDisplayName.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldDisplayName.test.js.snap
@@ -65,17 +65,10 @@ exports[`ToolbarFieldDisplayName Component should render a basic component: basi
       className="curiosity-input__display-name"
       customIcon={<SearchIcon />}
       data-test="toolbarFieldDisplayName"
-      id={null}
-      isDisabled={false}
-      isReadOnly={false}
       maxLength={255}
-      name={null}
-      onChange={[Function]}
       onClear={[Function]}
       onKeyUp={[Function]}
-      onMouseUp={[Function]}
       placeholder="t(curiosity-toolbar.placeholder_filter, {"context":"displayName"})"
-      type="text"
       value="lorem ipsum"
     />
   </InputGroupItem>


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- refactor(textInput): sw-2707, class to func, deprecated react

### Notes
- move from component class to function
- remove proptypes and replace default props
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. confirm the "display name" field still works as intended and submits queries accordingly
<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. next...
-->

### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. confirm tests come back clean

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-2707