### PR TITLE
test(serviceConfig): reduce mock response interval

### DIFF
--- a/src/services/common/__tests__/serviceConfig.test.js
+++ b/src/services/common/__tests__/serviceConfig.test.js
@@ -34,13 +34,13 @@ describe('ServiceConfig', () => {
     moxios.stubRequest(/\/(test|pollSuccess).*?/, {
       status: 200,
       responseText: 'success',
-      timeout: 1
+      timeout: 0
     });
 
     moxios.stubRequest(/\/(error|pollError).*?/, {
       status: 404,
       responseText: 'error',
-      timeout: 1
+      timeout: 0
     });
   });
 


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- test(serviceConfig): reduce mock response interval

### Notes
- attempt 2 for squashing the test flake
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
related to #1459