### PR TITLE
test(i18nHelpers): sw-2707 replace deprecated react

### DIFF
--- a/src/components/i18n/__tests__/i18nHelpers.test.js
+++ b/src/components/i18n/__tests__/i18nHelpers.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { i18nHelpers, EMPTY_CONTEXT, translate, translateComponent } from '../i18nHelpers';
 
 describe('I18nHelpers', () => {
@@ -9,22 +8,13 @@ describe('I18nHelpers', () => {
 
   it('should attempt to perform translate with a node', () => {
     const ExampleComponent = () => <div>{translate('lorem.ipsum', { hello: 'world' }, [<span id="test" />])}</div>;
-    ExampleComponent.propTypes = {};
-    ExampleComponent.defaultProps = {};
 
     const component = renderComponent(<ExampleComponent />);
     expect(component).toMatchSnapshot('translated node');
   });
 
   it('should attempt to perform a component translate', () => {
-    const ExampleComponent = ({ t }) => <div>{t('lorem.ipsum', 'hello world')}</div>;
-    ExampleComponent.propTypes = {
-      t: PropTypes.func
-    };
-
-    ExampleComponent.defaultProps = {
-      t: translate
-    };
+    const ExampleComponent = ({ t = translate }) => <div>{t('lorem.ipsum', 'hello world')}</div>;
 
     const TranslatedComponent = translateComponent(ExampleComponent);
     const component = renderComponent(<TranslatedComponent />);


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- test(i18nHelpers): sw-2707 replace deprecated react

### Notes
- replace default props
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-2707