### PR TITLE
fix(chart): sw-2707 shallow comparison for context

### DIFF
--- a/src/components/chart/chart.js
+++ b/src/components/chart/chart.js
@@ -1,6 +1,7 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { ChartThemeColor } from '@patternfly/react-charts';
+import { useShallowCompareEffect } from 'react-use';
 import { ChartContext } from './chartContext';
 import { ChartElements } from './chartElements';
 import { ChartLegend } from './chartLegend';
@@ -61,7 +62,7 @@ const Chart = ({
   const tooltipRef = useRef(null);
   const { width: chartWidth } = useResizeObserver(containerRef);
 
-  useEffect(() => {
+  useShallowCompareEffect(() => {
     /**
      * Aggregate chart related settings.
      *


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(chart): sw-2707 shallow comparison for context

### Notes
- quick patch, moves from `useEffect` to a shallow comparison related to updating chart context. we'll reevaluate towards using `useMemo` or a simple memoized helper in subsequent updates
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. confirm charts display as intended
   - confirm charts update correctly when filters are selected

### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. confirm charts display as intended
   - confirm charts update correctly when filters are selected

### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. confirm tests come back clean

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-2707