### PR TITLE
fix(config): sw-2966 consistent x-axis for all products

### DIFF
--- a/src/config/__tests__/__snapshots__/product.config.test.js.snap
+++ b/src/config/__tests__/__snapshots__/product.config.test.js.snap
@@ -5,7 +5,6 @@ exports[`Product specific configurations should apply graph filters and settings
   {
     "ansible-aap-managed": {
       "xAxisChartLabel": "t(curiosity-graph.label_axisX, {"context":"Daily"})",
-      "xAxisLabelIncrement": 1,
       "yAxisTickFormat": {
         "0.00001345": "0.00001",
         "0.0000269": "0.00003",
@@ -1457,7 +1456,6 @@ exports[`Product specific configurations should apply graph filters and settings
   {
     "rosa": {
       "xAxisChartLabel": "t(curiosity-graph.label_axisX, {"context":"Daily"})",
-      "xAxisLabelIncrement": 1,
       "yAxisTickFormat": {
         "0.00001345": "0.00001",
         "0.0000269": "0.00003",
@@ -1875,7 +1873,6 @@ exports[`Product specific configurations should apply graph filters and settings
             "stringId": "Managed-nodes_ansible-aap-managed",
             "stroke": "#06c",
             "xAxisChartLabel": [Function],
-            "xAxisLabelIncrement": 1,
             "yAxisTickFormat": [Function],
           },
         },
@@ -1957,7 +1954,6 @@ exports[`Product specific configurations should apply graph filters and settings
             "stringId": "Instance-hours_ansible-aap-managed",
             "stroke": "#06c",
             "xAxisChartLabel": [Function],
-            "xAxisLabelIncrement": 1,
             "yAxisTickFormat": [Function],
           },
         },
@@ -2615,7 +2611,6 @@ exports[`Product specific configurations should apply graph filters and settings
             "stringId": "Cores_rosa",
             "stroke": "#06c",
             "xAxisChartLabel": [Function],
-            "xAxisLabelIncrement": 1,
             "yAxisTickFormat": [Function],
           },
         },
@@ -2697,7 +2692,6 @@ exports[`Product specific configurations should apply graph filters and settings
             "stringId": "Instance-hours_rosa",
             "stroke": "#06c",
             "xAxisChartLabel": [Function],
-            "xAxisLabelIncrement": 1,
             "yAxisTickFormat": [Function],
           },
         },

--- a/src/config/product.ansible.js
+++ b/src/config/product.ansible.js
@@ -191,7 +191,6 @@ const config = {
       }
     ],
     isCardTitleDescription: true,
-    xAxisLabelIncrement: 1,
     xAxisChartLabel: () => translate('curiosity-graph.label_axisX', { context: GRANULARITY_TYPES.DAILY }),
     yAxisTickFormat: ({ tick } = {}) => {
       if (tick > 1) {

--- a/src/config/product.rosa.js
+++ b/src/config/product.rosa.js
@@ -191,7 +191,6 @@ const config = {
       }
     ],
     isCardTitleDescription: true,
-    xAxisLabelIncrement: 1,
     xAxisChartLabel: () => translate('curiosity-graph.label_axisX', { context: GRANULARITY_TYPES.DAILY }),
     yAxisTickFormat: ({ tick } = {}) => {
       if (tick > 1) {


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
fix(config): sw-2966 consistent x-axis for all products

### Notes
- This is follow up work. Due to updates in #1480 and #1478 the configuration is now "more correct" . This in turn means all remnants of the old "list-every-day-for-the-x-axis" need to be removed
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. confirm the x-axis ticks now increment the same for all products, ROSA and Ansible displays specifically
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
what it looks like in test/stage/local
![Screenshot 2024-11-13 at 12 03 45 PM](https://github.com/user-attachments/assets/35e80120-7a7f-4bff-af1a-0de13055d3dd)


expected results
![Screenshot 2024-11-13 at 12 04 14 PM](https://github.com/user-attachments/assets/f57f55f2-cedb-41d9-b951-43c61a3e186c)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
related #1426 #1480 and #1478 and sw-2707
sw-2966