### PR TITLE
fix: RHINENG-15664 inventory link

### DIFF
--- a/src/config/__tests__/__snapshots__/product.config.test.js.snap
+++ b/src/config/__tests__/__snapshots__/product.config.test.js.snap
@@ -3109,7 +3109,7 @@ exports[`Product specific configurations should apply variations in inventory fi
             {
               "content": <Button
                 component="a"
-                href="/insights/inventory/lorem inventory id/"
+                href="/insights/inventory/lorem inventory id"
                 isInline={true}
                 variant="link"
               >
@@ -3326,7 +3326,7 @@ exports[`Product specific configurations should apply variations in inventory fi
             {
               "content": <Button
                 component="a"
-                href="/insights/inventory/lorem inventory id/"
+                href="/insights/inventory/lorem inventory id"
                 isInline={true}
                 variant="link"
               >
@@ -3473,7 +3473,7 @@ exports[`Product specific configurations should apply variations in inventory fi
             {
               "content": <Button
                 component="a"
-                href="/insights/inventory/lorem inventory id/"
+                href="/insights/inventory/lorem inventory id"
                 isInline={true}
                 variant="link"
               >
@@ -4184,7 +4184,7 @@ exports[`Product specific configurations should apply variations in inventory fi
               "content": <React.Fragment>
                 <Button
                   component="a"
-                  href="/insights/inventory/XXXX-XXXX-XXXXX-XXXXX/"
+                  href="/insights/inventory/XXXX-XXXX-XXXXX-XXXXX"
                   isInline={true}
                   variant="link"
                 >
@@ -4624,7 +4624,7 @@ exports[`Product specific configurations should apply variations in inventory fi
             {
               "content": <Button
                 component="a"
-                href="/insights/inventory/XXXX-XXXX-XXXXX-XXXXX/"
+                href="/insights/inventory/XXXX-XXXX-XXXXX-XXXXX"
                 isInline={true}
                 variant="link"
               >
@@ -5064,7 +5064,7 @@ exports[`Product specific configurations should apply variations in inventory fi
             {
               "content": <Button
                 component="a"
-                href="/insights/inventory/XXXX-XXXX-XXXXX-XXXXX/"
+                href="/insights/inventory/XXXX-XXXX-XXXXX-XXXXX"
                 isInline={true}
                 variant="link"
               >

--- a/src/config/product.ansible.js
+++ b/src/config/product.ansible.js
@@ -225,7 +225,7 @@ const config = {
               isInline
               component="a"
               variant="link"
-              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}/`}
+              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}`}
             >
               {updatedDisplayName}
             </Button>

--- a/src/config/product.openshiftContainer.js
+++ b/src/config/product.openshiftContainer.js
@@ -153,7 +153,7 @@ const config = {
               isInline
               component="a"
               variant="link"
-              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}/`}
+              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}`}
             >
               {updatedDisplayName}
             </Button>
@@ -198,7 +198,7 @@ const config = {
               isInline
               component="a"
               variant="link"
-              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}/`}
+              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}`}
             >
               {updatedDisplayName}
             </Button>

--- a/src/config/product.openshiftDedicated.js
+++ b/src/config/product.openshiftDedicated.js
@@ -207,7 +207,7 @@ const config = {
               isInline
               component="a"
               variant="link"
-              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}/`}
+              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}`}
             >
               {updatedDisplayName}
             </Button>

--- a/src/config/product.openshiftMetrics.js
+++ b/src/config/product.openshiftMetrics.js
@@ -198,7 +198,7 @@ const config = {
               isInline
               component="a"
               variant="link"
-              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}/`}
+              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}`}
             >
               {updatedDisplayName}
             </Button>

--- a/src/config/product.rhel.js
+++ b/src/config/product.rhel.js
@@ -184,7 +184,7 @@ const config = {
               isInline
               component="a"
               variant="link"
-              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}/`}
+              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}`}
             >
               {updatedDisplayName}
             </Button>
@@ -222,7 +222,7 @@ const config = {
               isInline
               component="a"
               variant="link"
-              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}/`}
+              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}`}
             >
               {updatedDisplayName}
             </Button>

--- a/src/config/product.rhelElsPayg.js
+++ b/src/config/product.rhelElsPayg.js
@@ -202,7 +202,7 @@ const config = {
               isInline
               component="a"
               variant="link"
-              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${instanceId}/`}
+              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${instanceId}`}
             >
               {updatedDisplayName}
             </Button>

--- a/src/config/product.rhods.js
+++ b/src/config/product.rhods.js
@@ -201,7 +201,7 @@ const config = {
               isInline
               component="a"
               variant="link"
-              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}/`}
+              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}`}
             >
               {updatedDisplayName}
             </Button>

--- a/src/config/product.rosa.js
+++ b/src/config/product.rosa.js
@@ -225,7 +225,7 @@ const config = {
               isInline
               component="a"
               variant="link"
-              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}/`}
+              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}`}
             >
               {updatedDisplayName}
             </Button>

--- a/src/config/product.satellite.js
+++ b/src/config/product.satellite.js
@@ -162,7 +162,7 @@ const config = {
               isInline
               component="a"
               variant="link"
-              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}/`}
+              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}`}
             >
               {updatedDisplayName}
             </Button>
@@ -200,7 +200,7 @@ const config = {
               isInline
               component="a"
               variant="link"
-              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}/`}
+              href={`${helpers.UI_DEPLOY_PATH_LINK_PREFIX}/insights/inventory/${inventoryId}`}
             >
               {updatedDisplayName}
             </Button>


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
Removed trailing slash from inventory links
<!-- ### Notes -->
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
1. Go to Subscriptions Usage > RHEL > Current instances tab
2. Inventory link shouldn't have a trailing slash
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
![image](https://github.com/user-attachments/assets/275cf6bf-4644-4631-9daa-9d57c463dba8)


## Updates issue/story
[RHINENG-15664](https://issues.redhat.com/browse/RHINENG-15664)
