### PR TITLE
chore: skip dependabot commit linting

### DIFF
--- a/scripts/actions.commit.js
+++ b/scripts/actions.commit.js
@@ -131,9 +131,12 @@ const messagesList = (
 
       const descriptionValid = (description && 'valid') || 'INVALID: description (missing description)';
 
+      const isDependabotCommit = message.includes('dependabot');
+
       const lengthValid =
-        (messageLength <= maxMessageLength && 'valid') ||
-        `INVALID: message length (${messageLength} > ${maxMessageLength})`;
+        messageLength <= maxMessageLength || isDependabotCommit
+          ? 'valid'
+          : `INVALID: message length (${messageLength} > ${maxMessageLength})`;
 
       return {
         hash,


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
...
Skip linting for commit message length on dependabot PRs
<!-- ### Notes -->
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
Skip commit message length for dependabot commit messages.
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
