### PR TITLE
build(deps): dependabot groups, ignored dep

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,6 @@ updates:
       prod:
         dependency-type: "production"
         update-types:
-          - "minor"
           - "patch"
 
   - package-ecosystem: github-actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
     ignore:
       - dependency-name: "@patternfly/*"
       - dependency-name: "@redhat-cloud-services/frontend*"
+      - dependency-name: "*i18next*"
       - dependency-name: "victory*"
     labels:
       - "build"
@@ -25,14 +26,11 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      patch:
-        dependency-type: "production"
-        update-types:
-          - "patch"
-      minor:
+      prod:
         dependency-type: "production"
         update-types:
           - "minor"
+          - "patch"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- build(deps): dependabot groups, ignored dep

### Notes
- restores the ignore on i18next packages, see #1528  and #1523
- strips `minor` from weekly prod updates. prep for future where `minor` and `major` updates are done monthly instead
   - watching https://github.com/dependabot/dependabot-core/issues/1778

<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing