### PR TITLE
fix(pagination): sw-3322 restore default offset from refactor

### DIFF
--- a/src/components/pagination/__tests__/__snapshots__/paginationHelpers.test.js.snap
+++ b/src/components/pagination/__tests__/__snapshots__/paginationHelpers.test.js.snap
@@ -37,6 +37,8 @@ exports[`PaginationHelpers should return a boolean indicating last page: last pa
 exports[`PaginationHelpers should return a page from offset and perPage/limit: page variations 1`] = `
 [
   1,
+  1,
+  1,
   2,
   3,
   4,

--- a/src/components/pagination/__tests__/paginationHelpers.test.js
+++ b/src/components/pagination/__tests__/paginationHelpers.test.js
@@ -24,6 +24,8 @@ describe('PaginationHelpers', () => {
 
   it('should return a page from offset and perPage/limit', () => {
     expect([
+      paginationHelpers.calculatePageFromOffset(undefined, 10),
+      paginationHelpers.calculatePageFromOffset(null, 10),
       paginationHelpers.calculatePageFromOffset(0, 10),
       paginationHelpers.calculatePageFromOffset(10, 10),
       paginationHelpers.calculatePageFromOffset(20, 10),

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -65,7 +65,7 @@ const Pagination = ({
     onSetPage={(event, page, limit) =>
       onPage({ event, perPage: limit, offset: paginationHelpers.calculateOffsetFromPage(page, limit) })
     }
-    onPerPageSelect={(event, limit) => onPerPage({ event, perPage: limit, offset })}
+    onPerPageSelect={(event, limit) => onPerPage({ event, perPage: limit, offset: 0 })}
     page={paginationHelpers.calculatePageFromOffset(offset, perPage)}
     perPage={perPage}
     variant={variant}


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(pagination): sw-3322 restore default offset from refactor

### Notes
- resolves bug introduced in GUI [4.14.1](https://github.com/RedHatInsights/curiosity-frontend/blob/main/CHANGELOG.md#4141-2024-11-05) under #1451 involving refactor/removal of prop-types
- this AFFECTS all inventory displays due to the pagination component being shared across inventory displays
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. navigate towards a product with more than `200` instances entries
   - navigate to at least the 2nd page
   - confirm the query/search param field for offset is set to `0` when selecting `perPage` 
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-3322