### PR TITLE
ci(tekton): sw-3395 new shared Dockerfile for container build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "build-tools"]
+	path = build-tools
+	url = https://github.com/RedHatInsights/insights-frontend-builder-common.git

--- a/.tekton/curiosity-frontend-pull-request.yaml
+++ b/.tekton/curiosity-frontend-pull-request.yaml
@@ -26,7 +26,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: dockerfile
-    value: ./Dockerfile
+    value: build-tools/Dockerfile
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -206,66 +206,6 @@ spec:
         workspace: git-auth
       - name: netrc
         workspace: netrc
-    - name: parse-build-deploy-script
-      params:
-        - name: path-context
-          value: $(params.path-context)
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: https://github.com/RedHatInsights/konflux-consoledot-frontend-build
-          - name: revision
-            value: a6838b71b88dc1e84f11764c9734e4880096585d  # replace with the latest commit from https://github.com/RedHatInsights/konflux-consoledot-frontend-build/commits
-          - name: pathInRepo
-            value: tasks/parse-build-deploy-script/parse-build-deploy-script.yaml
-      workspaces:
-        - name: source
-          workspace: workspace
-      runAfter:
-        - clone-repository
-    - name: create-frontend-dockerfile
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: https://github.com/RedHatInsights/konflux-consoledot-frontend-build
-          - name: revision
-            value: a6838b71b88dc1e84f11764c9734e4880096585d  # replace with the latest commit from https://github.com/RedHatInsights/konflux-consoledot-frontend-build/commits
-          - name: pathInRepo
-            value: tasks/create-frontend-dockerfile/create-frontend-dockerfile.yaml
-      workspaces:
-        - name: source
-          workspace: workspace
-      params:
-        - name: path-context
-          value: $(params.path-context)
-        - name: component
-          value: $(tasks.parse-build-deploy-script.results.component)
-        - name: image
-          value: $(tasks.parse-build-deploy-script.results.image)
-        - name: node-build-version
-          value: $(tasks.parse-build-deploy-script.results.node-build-version)
-        - name: quay-expire-time
-          value: $(tasks.parse-build-deploy-script.results.quay-expire-time)
-        - name: npm-build-script
-          value: $(tasks.parse-build-deploy-script.results.npm-build-script)
-        - name: yarn-build-script
-          value: $(tasks.parse-build-deploy-script.results.yarn-build-script)
-        - name: route-path
-          value: $(tasks.parse-build-deploy-script.results.route-path)
-        - name: beta-route-path
-          value: $(tasks.parse-build-deploy-script.results.beta-route-path)
-        - name: preview-route-path
-          value: $(tasks.parse-build-deploy-script.results.preview-route-path)
-        - name: ci-root
-          value: $(tasks.parse-build-deploy-script.results.ci-root)
-        - name: server-name
-          value: $(tasks.parse-build-deploy-script.results.server-name)
-        - name: dist-folder
-          value: $(tasks.parse-build-deploy-script.results.dist-folder)
-      runAfter:
-        - parse-build-deploy-script
     - name: build-container
       params:
       - name: IMAGE
@@ -289,7 +229,6 @@ spec:
         value: $(params.build-args-file)
       runAfter:
       - prefetch-dependencies
-      - create-frontend-dockerfile
       taskRef:
         params:
         - name: name

--- a/.tekton/curiosity-frontend-push.yaml
+++ b/.tekton/curiosity-frontend-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: output-image
     value: quay.io/redhat-user-workloads/rh-subs-watch-tenant/curiosity-frontend/curiosity-frontend:{{revision}}
   - name: dockerfile
-    value: ./Dockerfile
+    value: build-tools/Dockerfile
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -203,66 +203,6 @@ spec:
         workspace: git-auth
       - name: netrc
         workspace: netrc
-    - name: parse-build-deploy-script
-      params:
-        - name: path-context
-          value: $(params.path-context)
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: https://github.com/RedHatInsights/konflux-consoledot-frontend-build
-          - name: revision
-            value: a6838b71b88dc1e84f11764c9734e4880096585d  # replace with the latest commit from https://github.com/RedHatInsights/konflux-consoledot-frontend-build/commits
-          - name: pathInRepo
-            value: tasks/parse-build-deploy-script/parse-build-deploy-script.yaml
-      workspaces:
-        - name: source
-          workspace: workspace
-      runAfter:
-        - clone-repository
-    - name: create-frontend-dockerfile
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: https://github.com/RedHatInsights/konflux-consoledot-frontend-build
-          - name: revision
-            value: a6838b71b88dc1e84f11764c9734e4880096585d  # replace with the latest commit from https://github.com/RedHatInsights/konflux-consoledot-frontend-build/commits
-          - name: pathInRepo
-            value: tasks/create-frontend-dockerfile/create-frontend-dockerfile.yaml
-      workspaces:
-        - name: source
-          workspace: workspace
-      params:
-        - name: path-context
-          value: $(params.path-context)
-        - name: component
-          value: $(tasks.parse-build-deploy-script.results.component)
-        - name: image
-          value: $(tasks.parse-build-deploy-script.results.image)
-        - name: node-build-version
-          value: $(tasks.parse-build-deploy-script.results.node-build-version)
-        - name: quay-expire-time
-          value: $(tasks.parse-build-deploy-script.results.quay-expire-time)
-        - name: npm-build-script
-          value: $(tasks.parse-build-deploy-script.results.npm-build-script)
-        - name: yarn-build-script
-          value: $(tasks.parse-build-deploy-script.results.yarn-build-script)
-        - name: route-path
-          value: $(tasks.parse-build-deploy-script.results.route-path)
-        - name: beta-route-path
-          value: $(tasks.parse-build-deploy-script.results.beta-route-path)
-        - name: preview-route-path
-          value: $(tasks.parse-build-deploy-script.results.preview-route-path)
-        - name: ci-root
-          value: $(tasks.parse-build-deploy-script.results.ci-root)
-        - name: server-name
-          value: $(tasks.parse-build-deploy-script.results.server-name)
-        - name: dist-folder
-          value: $(tasks.parse-build-deploy-script.results.dist-folder)
-      runAfter:
-        - parse-build-deploy-script
     - name: build-container
       params:
       - name: IMAGE
@@ -286,7 +226,6 @@ spec:
         value: $(params.build-args-file)
       runAfter:
       - prefetch-dependencies
-      - create-frontend-dockerfile
       taskRef:
         params:
         - name: name


### PR DESCRIPTION
## What's included
Migrate frontend curiosity build to use the new shared common Dockerfile [SWATCH-3395](https://issues.redhat.com/browse/SWATCH-3395)

### Notes

1. submodule for [insights-frontend-builder-common](https://github.com/RedHatInsights/insights-frontend-builder-common.git) 
2. Remove obsolete tasks and reference to these tasks from pull request and push Tekton pipelines:
a. Create-frontend-dockerfile
b. Parse-build-deploy-script
3. Update the Dockerfile path: "build-tools/Dockerfile"

The changes will only affect the tekton container build.