### PR TITLE
fix(toolbarFieldSelectCategory): sw-3440 set unique test id

### DIFF
--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldSelectCategory.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldSelectCategory.test.js.snap
@@ -289,7 +289,7 @@ exports[`ToolbarFieldSelectCategory Component should handle updating categories 
 exports[`ToolbarFieldSelectCategory Component should render a basic component: basic 1`] = `
 <Select
   aria-label="t(curiosity-toolbar.placeholder, {"context":"filter"})"
-  data-test="toolbarFieldCategory"
+  data-test="toolbarFieldSelectCategory"
   onSelect={[Function]}
   options={
     [

--- a/src/components/toolbar/toolbarFieldSelectCategory.js
+++ b/src/components/toolbar/toolbarFieldSelectCategory.js
@@ -210,7 +210,7 @@ const ToolbarFieldSelectCategory = ({
       selectedOptions={updatedValue}
       placeholder={t('curiosity-toolbar.placeholder', { context: ['filter'] })}
       toggle={{ icon: <FilterIcon /> }}
-      data-test="toolbarFieldCategory"
+      data-test="toolbarFieldSelectCategory"
     />
   );
 };


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(toolbarFieldSelectCategory): sw-3440 set unique test id

### Notes
- currently the test ids for `toolbarFieldSelectCategory` and `toolbarFieldCategory` are the same
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. navigate to the RHEL product view
   - open the developer console and inspect the "select-a-filter", confirm the new test identifier is available

<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-3440