### PR TITLE
fix(toolbarFieldCategory): sw-3443 reset filter and legend links

### DIFF
--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldGroupVariant.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldGroupVariant.test.js.snap
@@ -39,6 +39,9 @@ exports[`ToolbarFieldGroupVariant Component should handle updating through redux
         "variant": "ipsum",
       },
       {
+        "type": "SET_GRAPH_LEGEND_RESET",
+      },
+      {
         "productGroup": undefined,
         "type": "SET_PRODUCT_VARIANT",
         "variant": "ipsum",
@@ -55,6 +58,9 @@ exports[`ToolbarFieldGroupVariant Component should handle updating through redux
       {
         "type": "SET_PRODUCT_VARIANT_QUERY_RESET_ALL",
         "variant": "dolor sit",
+      },
+      {
+        "type": "SET_GRAPH_LEGEND_RESET",
       },
       {
         "productGroup": "loremIpsum",

--- a/src/components/toolbar/toolbarFieldGroupVariant.js
+++ b/src/components/toolbar/toolbarFieldGroupVariant.js
@@ -61,6 +61,9 @@ const useOnSelect = ({
         variant: value
       },
       {
+        type: reduxTypes.graph.SET_GRAPH_LEGEND_RESET
+      },
+      {
         type: reduxTypes.app.SET_PRODUCT_VARIANT,
         variant: value,
         productGroup

--- a/src/redux/reducers/__tests__/__snapshots__/graphReducer.test.js.snap
+++ b/src/redux/reducers/__tests__/__snapshots__/graphReducer.test.js.snap
@@ -126,3 +126,14 @@ exports[`GraphReducer should handle specific defined types: defined type SET_GRA
   "type": "SET_GRAPH_LEGEND",
 }
 `;
+
+exports[`GraphReducer should handle specific defined types: defined type SET_GRAPH_LEGEND_RESET 1`] = `
+{
+  "result": {
+    "capacity": {},
+    "legend": {},
+    "tally": {},
+  },
+  "type": "SET_GRAPH_LEGEND_RESET",
+}
+`;

--- a/src/redux/reducers/__tests__/graphReducer.test.js
+++ b/src/redux/reducers/__tests__/graphReducer.test.js
@@ -8,7 +8,7 @@ describe('GraphReducer', () => {
   });
 
   it('should handle specific defined types', () => {
-    const specificTypes = [graphTypes.SET_GRAPH_LEGEND];
+    const specificTypes = [graphTypes.SET_GRAPH_LEGEND_RESET, graphTypes.SET_GRAPH_LEGEND];
 
     specificTypes.forEach(value => {
       const dispatched = {

--- a/src/redux/reducers/graphReducer.js
+++ b/src/redux/reducers/graphReducer.js
@@ -30,6 +30,9 @@ const initialState = {
  */
 const graphReducer = (state = initialState, action) => {
   switch (action.type) {
+    // Reset both category/type filtering and graph legend buttons/links
+    case graphTypes.SET_GRAPH_LEGEND_RESET:
+      return { ...state, legend: {} };
     case graphTypes.SET_GRAPH_LEGEND:
       return reduxHelpers.setStateProp(
         'legend',

--- a/src/redux/reducers/viewReducer.js
+++ b/src/redux/reducers/viewReducer.js
@@ -63,6 +63,7 @@ const viewReducer = (state = initialState, action) => {
           reset: false
         }
       );
+    // Reset inventory displays' paging offset, sort direction, sort
     case reduxTypes.query.SET_QUERY_RESET_INVENTORY_LIST:
       const updateResetQueries = (query = {}, id) => {
         const queryIds = productConfig.sortedConfigs().byViewIds[id] || (query[id] && [id]) || [];
@@ -94,6 +95,7 @@ const viewReducer = (state = initialState, action) => {
           reset: false
         }
       );
+    // Reset inventory displays' paging offset
     case reduxTypes.query.SET_QUERY_CLEAR_INVENTORY_LIST:
       const updateClearQueries = (query = {}, id) => {
         const queryIds = productConfig.sortedConfigs().byViewIds[id] || (query[id] && [id]) || [];

--- a/src/redux/types/__tests__/__snapshots__/index.test.js.snap
+++ b/src/redux/types/__tests__/__snapshots__/index.test.js.snap
@@ -25,6 +25,7 @@ exports[`ReduxTypes should have specific type properties: all redux types 1`] = 
     },
     "graph": {
       "SET_GRAPH_LEGEND": "SET_GRAPH_LEGEND",
+      "SET_GRAPH_LEGEND_RESET": "SET_GRAPH_LEGEND_RESET",
     },
     "inventory": {
       "CLEAR_INVENTORY_GUESTS": "CLEAR_INVENTORY_GUESTS",
@@ -70,6 +71,7 @@ exports[`ReduxTypes should have specific type properties: all redux types 1`] = 
   },
   "graphTypes": {
     "SET_GRAPH_LEGEND": "SET_GRAPH_LEGEND",
+    "SET_GRAPH_LEGEND_RESET": "SET_GRAPH_LEGEND_RESET",
   },
   "inventoryTypes": {
     "CLEAR_INVENTORY_GUESTS": "CLEAR_INVENTORY_GUESTS",
@@ -114,6 +116,7 @@ exports[`ReduxTypes should have specific type properties: all redux types 1`] = 
     },
     "graph": {
       "SET_GRAPH_LEGEND": "SET_GRAPH_LEGEND",
+      "SET_GRAPH_LEGEND_RESET": "SET_GRAPH_LEGEND_RESET",
     },
     "inventory": {
       "CLEAR_INVENTORY_GUESTS": "CLEAR_INVENTORY_GUESTS",
@@ -185,6 +188,7 @@ exports[`ReduxTypes should have specific type properties: specific types 1`] = `
   },
   "graph": {
     "SET_GRAPH_LEGEND": "SET_GRAPH_LEGEND",
+    "SET_GRAPH_LEGEND_RESET": "SET_GRAPH_LEGEND_RESET",
   },
   "inventory": {
     "CLEAR_INVENTORY_GUESTS": "CLEAR_INVENTORY_GUESTS",

--- a/src/redux/types/index.js
+++ b/src/redux/types/index.js
@@ -30,10 +30,11 @@ const appTypes = {
 /**
  * Graph action, reducer types.
  *
- * @type {{SET_GRAPH_LEGEND: string}}
+ * @type {{SET_GRAPH_LEGEND_RESET: string, SET_GRAPH_LEGEND: string}}
  */
 const graphTypes = {
-  SET_GRAPH_LEGEND: 'SET_GRAPH_LEGEND'
+  SET_GRAPH_LEGEND: 'SET_GRAPH_LEGEND',
+  SET_GRAPH_LEGEND_RESET: 'SET_GRAPH_LEGEND_RESET'
 };
 
 /**


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(toolbarFieldCategory): sw-3443 reset filter and legend links

### Notes
- subsequent fix related to the category/type filter field not resetting correctly when a user navigates between variants
- this fix, now, also resets when independent legend links/buttons are clicked and a user navigates between variants
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. Select a product variant, like RHEL x86
   - select a RHEL x86 category/type, like "hypervisor" to focus the graph legend
   - change product variants
   - change product variants back to RHEL x86, confirm the graph legend and category/type filter have reset

### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. Select a product variant, like RHEL x86
   - select a RHEL x86 category/type, like "hypervisor" to focus the graph legend
   - change product variants
   - change product variants back to RHEL x86, confirm the graph legend and category/type filter have reset
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-3443