### PR TITLE
fix(toolbar): sw-3443 productId key refresh

### DIFF
--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -62,7 +62,7 @@ const Toolbar = ({
   useToolbarFieldClearAll: useAliasToolbarFieldClearAll = useToolbarFieldClearAll,
   useToolbarFields: useAliasToolbarFields = useToolbarFields
 }) => {
-  const { productGroup } = useAliasProduct();
+  const { productId } = useAliasProduct();
   const toolbarFieldQueries = useAliasProductToolbarQuery();
   const { currentCategory, options } = useAliasSelectCategoryOptions();
   const clearField = useAliasToolbarFieldClear();
@@ -115,7 +115,7 @@ const Toolbar = ({
   return (
     <PfToolbar
       id="curiosity-toolbar"
-      key={productGroup}
+      key={productId}
       className="curiosity-toolbar pf-m-toggle-group-container ins-c-primary-toolbar"
       collapseListedFiltersBreakpoint="sm"
       clearAllFilters={onClearAll}

--- a/src/redux/reducers/__tests__/__snapshots__/viewReducer.test.js.snap
+++ b/src/redux/reducers/__tests__/__snapshots__/viewReducer.test.js.snap
@@ -4,30 +4,10 @@ exports[`ViewReducer should handle clearing state with defined types: defined ty
 {
   "result": {
     "graphTallyQuery": {},
-    "inventoryGuestsQuery": {
-      "another_test_id": {
-        "offset": 10,
-      },
-    },
-    "inventoryHostsQuery": {
-      "another_test_id": {
-        "dir": "lorem desc direction",
-        "offset": 90,
-        "sort": "lorem sort",
-      },
-    },
-    "inventorySubscriptionsQuery": {
-      "another_test_id": {
-        "dir": "dolor desc direction",
-        "offset": 40,
-        "sort": "dolor sort",
-      },
-    },
-    "query": {
-      "another_test_id": {
-        "lorem": "ipsum",
-      },
-    },
+    "inventoryGuestsQuery": {},
+    "inventoryHostsQuery": {},
+    "inventorySubscriptionsQuery": {},
+    "query": {},
   },
   "type": "SET_PRODUCT_VARIANT_QUERY_RESET_ALL",
 }

--- a/src/redux/reducers/viewReducer.js
+++ b/src/redux/reducers/viewReducer.js
@@ -35,23 +35,20 @@ const initialState = {
  */
 const viewReducer = (state = initialState, action) => {
   switch (action.type) {
-    // Reset query state/object associated with a variant/productId
+    /*
+     * Note: Hard reset query state/object associated with a variant/productId. Remove this action type if restoring
+     * queries based on product variant is needed, also review toolbar reducer for restoring/removing legend state.
+     */
     case reduxTypes.app.SET_PRODUCT_VARIANT_QUERY_RESET_ALL:
-      const updateVariantResetQueries = (query = {}, id) => {
-        const updatedQuery = query;
-        delete updatedQuery[id];
-        return updatedQuery;
-      };
-
       return reduxHelpers.setStateProp(
         null,
         {
           ...state,
-          query: updateVariantResetQueries(state.query, action.variant),
-          graphTallyQuery: updateVariantResetQueries(state.graphTallyQuery, action.variant),
-          inventoryGuestsQuery: updateVariantResetQueries(state.inventoryGuestsQuery, action.variant),
-          inventoryHostsQuery: updateVariantResetQueries(state.inventoryHostsQuery, action.variant),
-          inventorySubscriptionsQuery: updateVariantResetQueries(state.inventorySubscriptionsQuery, action.variant)
+          query: {},
+          graphTallyQuery: {},
+          inventoryGuestsQuery: {},
+          inventoryHostsQuery: {},
+          inventorySubscriptionsQuery: {}
         },
         {
           state,


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(toolbar): sw-3443 productId key refresh
   * toolbar, productId key refresh component, align with toolbarFields
   * viewReducer, simplify focused query reset to hard reset

### Notes
- corrects an intermittent issue where the `Reset filters` link/button on the toolbar doesn't always hide when moving between product variants. The issue shows up on local development run more often than environment. You can attempt to recreate locally by...
   - First, navigating to any product and select a toolbar filter that generates a toolbar token (we used OpenShift Container Annual with SLA "premium")
   - Then navigating to a different product variant (we used RHACS) and you may see the "Reset filters" link/button still displaying
- simplifies the focused query reset with a hard reset since the previous products query is unneeded, currently
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screenshot 2025-04-04 at 3 13 02 PM](https://github.com/user-attachments/assets/e8d3a207-b78c-406c-af60-09cba6bcc552)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-3443