### PR TITLE
revert(viewReducer): sw-3443 rollback to focused reset

### DIFF
--- a/src/redux/reducers/__tests__/__snapshots__/viewReducer.test.js.snap
+++ b/src/redux/reducers/__tests__/__snapshots__/viewReducer.test.js.snap
@@ -4,10 +4,30 @@ exports[`ViewReducer should handle clearing state with defined types: defined ty
 {
   "result": {
     "graphTallyQuery": {},
-    "inventoryGuestsQuery": {},
-    "inventoryHostsQuery": {},
-    "inventorySubscriptionsQuery": {},
-    "query": {},
+    "inventoryGuestsQuery": {
+      "another_test_id": {
+        "offset": 10,
+      },
+    },
+    "inventoryHostsQuery": {
+      "another_test_id": {
+        "dir": "lorem desc direction",
+        "offset": 90,
+        "sort": "lorem sort",
+      },
+    },
+    "inventorySubscriptionsQuery": {
+      "another_test_id": {
+        "dir": "dolor desc direction",
+        "offset": 40,
+        "sort": "dolor sort",
+      },
+    },
+    "query": {
+      "another_test_id": {
+        "lorem": "ipsum",
+      },
+    },
   },
   "type": "SET_PRODUCT_VARIANT_QUERY_RESET_ALL",
 }

--- a/src/redux/reducers/viewReducer.js
+++ b/src/redux/reducers/viewReducer.js
@@ -36,19 +36,27 @@ const initialState = {
 const viewReducer = (state = initialState, action) => {
   switch (action.type) {
     /*
-     * Note: Hard reset query state/object associated with a variant/productId. Remove this action type if restoring
-     * queries based on product variant is needed, also review toolbar reducer for restoring/removing legend state.
+     * Note: Hard reset causes query state/object updates for ALL variants/productIds that have a filter selected,
+     * instead we focus the update to the specific variant to remove the extra API calls. Remove this entire
+     * action type if restoring queries based on product variant is needed, also review toolbar reducer for
+     * restoring/removing legend state.
      */
     case reduxTypes.app.SET_PRODUCT_VARIANT_QUERY_RESET_ALL:
+      const updateVariantResetQueries = (query = {}, id) => {
+        const updatedQuery = query;
+        delete updatedQuery[id];
+        return updatedQuery;
+      };
+
       return reduxHelpers.setStateProp(
         null,
         {
           ...state,
-          query: {},
-          graphTallyQuery: {},
-          inventoryGuestsQuery: {},
-          inventoryHostsQuery: {},
-          inventorySubscriptionsQuery: {}
+          query: updateVariantResetQueries(state.query, action.variant),
+          graphTallyQuery: updateVariantResetQueries(state.graphTallyQuery, action.variant),
+          inventoryGuestsQuery: updateVariantResetQueries(state.inventoryGuestsQuery, action.variant),
+          inventoryHostsQuery: updateVariantResetQueries(state.inventoryHostsQuery, action.variant),
+          inventorySubscriptionsQuery: updateVariantResetQueries(state.inventorySubscriptionsQuery, action.variant)
         },
         {
           state,


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- revert(viewReducer): sw-3443 rollback to focused reset

### Notes
- little side-tracked today... attempting a hard reset on state borks the intent of #1564 #1565
- restores the solution from #1564 
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. reconfirm that selecting a variant, then filter, waiting 20 secs, selecting a different variant doesn't re-fire the previous variants API calls
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
related #1564 #1565
sw-3443