### PR TITLE
fix(select): sw-3468 consistent multiple, single return value

### DIFF
--- a/src/components/form/__tests__/__snapshots__/select.test.js.snap
+++ b/src/components/form/__tests__/__snapshots__/select.test.js.snap
@@ -618,6 +618,29 @@ exports[`Select should return an emulated onselect/onchange event, single: defau
 ]
 `;
 
+exports[`helpers formatEvent should modify the event object for select by exposing selected, selectedIndex, select type, and value, dropdown 1`] = `
+{
+  "checked": undefined,
+  "currentTarget": {},
+  "id": undefined,
+  "keyCode": undefined,
+  "name": undefined,
+  "persist": [Function],
+  "selected": {
+    "index": "mock",
+    "isSelected": true,
+    "title": "lorem",
+    "value": "lorem",
+  },
+  "selectedIndex": [
+    "mock",
+  ],
+  "target": {},
+  "type": "select-one",
+  "value": "lorem",
+}
+`;
+
 exports[`helpers formatEvent should modify the event object for select by exposing selected, selectedIndex, select type, and value, multiple 1`] = `
 {
   "checked": undefined,

--- a/src/components/form/__tests__/select.test.js
+++ b/src/components/form/__tests__/select.test.js
@@ -212,6 +212,14 @@ describe('helpers', () => {
     {
       options: [
         { title: 'lorem', value: 'lorem', index: 'mock', isSelected: true },
+        { title: 'ipsum', value: 'ipsum', index: 'mock', isSelected: false }
+      ],
+      variant: SelectVariant.dropdown,
+      description: 'dropdown'
+    },
+    {
+      options: [
+        { title: 'lorem', value: 'lorem', index: 'mock', isSelected: true },
         { title: 'ipsum', value: 'ipsum', index: 'mock', isSelected: true }
       ],
       variant: SelectVariant.checkbox,

--- a/src/components/form/select.js
+++ b/src/components/form/select.js
@@ -216,8 +216,8 @@ updateSelectedProp.memo = helpers.memo(updateSelectedProp, { cacheLimit: 25 });
 const formatEvent = ({ event, options, variant = SelectVariant.single } = {}) => {
   const mockUpdatedOptions = helpers.memoClone(options);
   const mockSelected =
-    (variant === SelectVariant.single && mockUpdatedOptions.find(({ isSelected }) => isSelected === true)) ||
-    mockUpdatedOptions.filter(({ isSelected }) => isSelected === true);
+    (variant === SelectVariant.checkbox && mockUpdatedOptions.filter(({ isSelected }) => isSelected === true)) ||
+    mockUpdatedOptions.find(({ isSelected }) => isSelected === true);
 
   const mockSelectedIndex = mockUpdatedOptions
     .filter(({ isSelected }) => isSelected === true)
@@ -227,7 +227,7 @@ const formatEvent = ({ event, options, variant = SelectVariant.single } = {}) =>
     ...createMockEvent(event),
     selected: mockSelected,
     selectedIndex: mockSelectedIndex,
-    type: `select-${((variant === SelectVariant.single || variant === SelectVariant.dropdown) && 'one') || 'multiple'}`,
+    type: `select-${(variant === SelectVariant.checkbox && 'multiple') || 'one'}`,
     value: (Array.isArray(mockSelected) && mockSelected.map(({ value: mockValue }) => mockValue)) || mockSelected.value
   };
 };


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(select): sw-3468 consistent multiple, single return value

### Notes
- this issue only affects staging, see #1562 
- corrects an issue where the dropdown variant was returning a list instead of a single value
- adds missing unit test that would have caught the issue
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. confirm the export `dropdown` now correctly submits the value for export, `json` and/or `csv`

### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. confirm the export `dropdown` now correctly submits the value for export, `json` and/or `csv`
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
related to #1562, sw-3339
sw-3468