### PR TITLE
perf(productView,routerContext): sw-95 product load optimization

### DIFF
--- a/src/components/README.md
+++ b/src/components/README.md
@@ -4192,8 +4192,6 @@ Primary product display component, and config context provider.
 <tr>
     <td>ProductViewContext</td><td><code>module</code></td>
     </tr><tr>
-    <td>ProductViewConfigLoad</td><td><code>module</code></td>
-    </tr><tr>
     <td>ProductViewMissing</td><td><code>module</code></td>
     </tr>  </tbody>
 </table>
@@ -4734,8 +4732,6 @@ A memoized response for the setProductRoute function. Assigned to a property for
 
 ### RouterContext~useSetRouteProduct(options) ⇒ <code>Object</code>
 Initialize and store a product path, parameter, in a "state" update parallel to variant detail.
-We're opting to use "window.location.pathname" directly because its faster.
-and returns a similar structured value as useParam.
 
 **Kind**: inner method of [<code>RouterContext</code>](#Router.module_RouterContext)  
 <table>

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -4192,6 +4192,8 @@ Primary product display component, and config context provider.
 <tr>
     <td>ProductViewContext</td><td><code>module</code></td>
     </tr><tr>
+    <td>ProductViewConfigLoad</td><td><code>module</code></td>
+    </tr><tr>
     <td>ProductViewMissing</td><td><code>module</code></td>
     </tr>  </tbody>
 </table>
@@ -4670,6 +4672,8 @@ On click, update history.
 
 * [RouterContext](#Router.module_RouterContext)
     * [~useNavigate(options)](#Router.module_RouterContext..useNavigate) ⇒ <code>function</code>
+    * [~setRouteProduct(params)](#Router.module_RouterContext..setRouteProduct) ⇒ <code>Object</code>
+        * [.memo](#Router.module_RouterContext..setRouteProduct.memo) : <code>function</code>
     * [~useSetRouteProduct(options)](#Router.module_RouterContext..useSetRouteProduct) ⇒ <code>Object</code>
     * [~useRouteDetail(options)](#Router.module_RouterContext..useRouteDetail) ⇒ <code>Object</code>
 
@@ -4683,19 +4687,49 @@ update. Dispatches the same type leveraged by the initialize hook, useSetRouteDe
 <table>
   <thead>
     <tr>
+      <th>Param</th><th>Type</th><th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+<tr>
+    <td>options</td><td><code>object</code></td><td></td>
+    </tr><tr>
+    <td>[options.useLocation]</td><td><code>useLocation</code></td><td><code>useLocation</code></td>
+    </tr><tr>
+    <td>[options.windowHistory]</td><td><code>*</code></td><td></td>
+    </tr>  </tbody>
+</table>
+
+<a name="Router.module_RouterContext..setRouteProduct"></a>
+
+### RouterContext~setRouteProduct(params) ⇒ <code>Object</code>
+Set a product config based on routing
+
+**Kind**: inner method of [<code>RouterContext</code>](#Router.module_RouterContext)  
+<table>
+  <thead>
+    <tr>
       <th>Param</th><th>Type</th>
     </tr>
   </thead>
   <tbody>
 <tr>
-    <td>options</td><td><code>object</code></td>
+    <td>params</td><td><code>object</code></td>
     </tr><tr>
-    <td>options.useLocation</td><td><code>function</code></td>
+    <td>params.productPath</td><td><code>string</code></td>
     </tr><tr>
-    <td>options.windowHistory</td><td><code>*</code></td>
+    <td>params.disableIsClosestMatch</td><td><code>boolean</code></td>
+    </tr><tr>
+    <td>params.productVariant</td><td><code>object</code></td>
     </tr>  </tbody>
 </table>
 
+<a name="Router.module_RouterContext..setRouteProduct.memo"></a>
+
+#### setRouteProduct.memo : <code>function</code>
+A memoized response for the setProductRoute function. Assigned to a property for testing function.
+
+**Kind**: static property of [<code>setRouteProduct</code>](#Router.module_RouterContext..setRouteProduct)  
 <a name="Router.module_RouterContext..useSetRouteProduct"></a>
 
 ### RouterContext~useSetRouteProduct(options) ⇒ <code>Object</code>
@@ -4707,18 +4741,20 @@ and returns a similar structured value as useParam.
 <table>
   <thead>
     <tr>
-      <th>Param</th><th>Type</th>
+      <th>Param</th><th>Type</th><th>Default</th>
     </tr>
   </thead>
   <tbody>
 <tr>
-    <td>options</td><td><code>object</code></td>
+    <td>options</td><td><code>object</code></td><td></td>
     </tr><tr>
-    <td>options.disableIsClosestMatch</td><td><code>boolean</code></td>
+    <td>[options.disableIsClosestMatch]</td><td><code>boolean</code></td><td></td>
     </tr><tr>
-    <td>options.useLocation</td><td><code>function</code></td>
+    <td>[options.setProduct]</td><td><code>setRouteProduct</code></td><td><code>setRouteProduct</code></td>
     </tr><tr>
-    <td>options.useSelector</td><td><code>function</code></td>
+    <td>[options.useLocation]</td><td><code>useLocation</code></td><td><code>useLocation</code></td>
+    </tr><tr>
+    <td>[options.useSelector]</td><td><code>storeHooks.reactRedux.useSelector</code></td><td><code>storeHooks.reactRedux.useSelector</code></td>
     </tr>  </tbody>
 </table>
 
@@ -4733,18 +4769,18 @@ Consumes useSetRouteProduct to return a display configuration for use in product
 <table>
   <thead>
     <tr>
-      <th>Param</th><th>Type</th>
+      <th>Param</th><th>Type</th><th>Default</th>
     </tr>
   </thead>
   <tbody>
 <tr>
-    <td>options</td><td><code>object</code></td>
+    <td>options</td><td><code>object</code></td><td></td>
     </tr><tr>
-    <td>options.t</td><td><code>function</code></td>
+    <td>[options.t]</td><td><code>translate</code></td><td><code>translate</code></td>
     </tr><tr>
-    <td>options.useChrome</td><td><code>function</code></td>
+    <td>[options.useChrome]</td><td><code>useChrome</code></td><td><code>useChrome</code></td>
     </tr><tr>
-    <td>options.useSetRouteProduct</td><td><code>useSetRouteProduct</code></td>
+    <td>[options.useSetRouteProduct]</td><td><code>useSetRouteProduct</code></td><td><code>useSetRouteProduct</code></td>
     </tr>  </tbody>
 </table>
 

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -315,7 +315,7 @@ exports[`I18n Component should generate a predictable locale key output snapshot
     "keys": [
       {
         "key": "curiosity-view.title",
-        "match": "t(\`curiosity-view.title\`, { appName: helpers.UI_DISPLAY_NAME, context: product?.productGroup })",
+        "match": "t(\`curiosity-view.title\`, { appName: helpers.UI_DISPLAY_NAME, context: productGroup })",
       },
     ],
   },

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -315,7 +315,7 @@ exports[`I18n Component should generate a predictable locale key output snapshot
     "keys": [
       {
         "key": "curiosity-view.title",
-        "match": "t(\`curiosity-view.title\`, { appName: helpers.UI_DISPLAY_NAME, context: productGroup })",
+        "match": "t(\`curiosity-view.title\`, { appName: helpers.UI_DISPLAY_NAME, context: product?.productGroup })",
       },
     ],
   },

--- a/src/components/productView/productView.js
+++ b/src/components/productView/productView.js
@@ -19,7 +19,6 @@ import { ProductViewMissing } from './productViewMissing';
  * @memberof Components
  * @module ProductView
  * @property {module} ProductViewContext
- * @property {module} ProductViewConfigLoad
  * @property {module} ProductViewMissing
  */
 

--- a/src/components/productView/productView.js
+++ b/src/components/productView/productView.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { Button } from '@patternfly/react-core';
 import { routerContext } from '../router';
 import { ProductViewContext } from './productViewContext';
@@ -19,6 +19,7 @@ import { ProductViewMissing } from './productViewMissing';
  * @memberof Components
  * @module ProductView
  * @property {module} ProductViewContext
+ * @property {module} ProductViewConfigLoad
  * @property {module} ProductViewMissing
  */
 
@@ -36,55 +37,51 @@ import { ProductViewMissing } from './productViewMissing';
 const ProductView = ({ t = translate, useRouteDetail: useAliasRouteDetail = routerContext.useRouteDetail }) => {
   const { disableIsClosestMatch, firstMatch, productGroup } = useAliasRouteDetail();
 
-  const renderProduct = useCallback(() => {
-    const updated = config => {
-      const { initialInventoryFilters, initialSubscriptionsInventoryFilters, productId, viewId } = config;
+  const renderProduct = () => {
+    const { initialInventoryFilters, initialSubscriptionsInventoryFilters, productId, viewId } = firstMatch;
 
-      if (!productId || !viewId) {
-        return null;
-      }
+    if (!productId || !viewId) {
+      return null;
+    }
 
-      return (
-        <ProductViewContext.Provider value={config}>
-          <PageMessages>
-            <BannerMessages />
-          </PageMessages>
-          <PageToolbar>
-            <Toolbar />
-          </PageToolbar>
-          <PageSection className="curiosity-page-section__graphs">
-            <GraphCard />
-          </PageSection>
-          <PageSection className="curiosity-page-section__tabs">
-            <InventoryTabs
-              isDisabled={
-                (!initialInventoryFilters && !initialSubscriptionsInventoryFilters) || helpers.UI_DISABLED_TABLE
-              }
-            >
-              {!helpers.UI_DISABLED_TABLE_INSTANCES && initialInventoryFilters && (
-                <InventoryTab
-                  key={`inventory_instances_${productId}`}
-                  title={t('curiosity-inventory.tabInstances', { context: [productId] })}
-                >
-                  <InventoryCardInstances />
-                </InventoryTab>
-              )}
-              {!helpers.UI_DISABLED_TABLE_SUBSCRIPTIONS && initialSubscriptionsInventoryFilters && (
-                <InventoryTab
-                  key={`inventory_subs_${productId}`}
-                  title={t('curiosity-inventory.tabSubscriptions', { context: [productId] })}
-                >
-                  <InventoryCardSubscriptions />
-                </InventoryTab>
-              )}
-            </InventoryTabs>
-          </PageSection>
-        </ProductViewContext.Provider>
-      );
-    };
-
-    return updated(firstMatch);
-  }, [firstMatch, t]);
+    return (
+      <ProductViewContext.Provider value={firstMatch}>
+        <PageMessages>
+          <BannerMessages />
+        </PageMessages>
+        <PageToolbar>
+          <Toolbar />
+        </PageToolbar>
+        <PageSection className="curiosity-page-section__graphs">
+          <GraphCard />
+        </PageSection>
+        <PageSection className="curiosity-page-section__tabs">
+          <InventoryTabs
+            isDisabled={
+              (!initialInventoryFilters && !initialSubscriptionsInventoryFilters) || helpers.UI_DISABLED_TABLE
+            }
+          >
+            {!helpers.UI_DISABLED_TABLE_INSTANCES && initialInventoryFilters && (
+              <InventoryTab
+                key={`inventory_instances_${productId}`}
+                title={t('curiosity-inventory.tabInstances', { context: [productId] })}
+              >
+                <InventoryCardInstances />
+              </InventoryTab>
+            )}
+            {!helpers.UI_DISABLED_TABLE_SUBSCRIPTIONS && initialSubscriptionsInventoryFilters && (
+              <InventoryTab
+                key={`inventory_subs_${productId}`}
+                title={t('curiosity-inventory.tabSubscriptions', { context: [productId] })}
+              >
+                <InventoryCardSubscriptions />
+              </InventoryTab>
+            )}
+          </InventoryTabs>
+        </PageSection>
+      </ProductViewContext.Provider>
+    );
+  };
 
   if (disableIsClosestMatch) {
     return <ProductViewMissing />;

--- a/src/components/productView/productView.js
+++ b/src/components/productView/productView.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Button } from '@patternfly/react-core';
 import { routerContext } from '../router';
 import { ProductViewContext } from './productViewContext';
@@ -24,7 +24,10 @@ import { ProductViewMissing } from './productViewMissing';
  */
 
 /**
- * ToDo: review removing the "useCallback" once the routing updates are in place
+ * Note: Memoize product context. This is related to "Chroming" level app loading, routing and hooks, which can
+ * trigger a reload in environment. Always confirm "Chroming" behavior when modifying memoization on product
+ * context. Use the appropriate environment for testing. Non-networked local run is immune to "app loading"
+ * because it doesn't leverage full "Chroming".
  */
 /**
  * Display products.
@@ -37,7 +40,7 @@ import { ProductViewMissing } from './productViewMissing';
 const ProductView = ({ t = translate, useRouteDetail: useAliasRouteDetail = routerContext.useRouteDetail }) => {
   const { disableIsClosestMatch, firstMatch, productGroup } = useAliasRouteDetail();
 
-  const renderProduct = () => {
+  const renderProduct = useMemo(() => {
     const { initialInventoryFilters, initialSubscriptionsInventoryFilters, productId, viewId } = firstMatch;
 
     if (!productId || !viewId) {
@@ -81,7 +84,7 @@ const ProductView = ({ t = translate, useRouteDetail: useAliasRouteDetail = rout
         </PageSection>
       </ProductViewContext.Provider>
     );
-  };
+  }, [firstMatch, t]);
 
   if (disableIsClosestMatch) {
     return <ProductViewMissing />;
@@ -93,7 +96,7 @@ const ProductView = ({ t = translate, useRouteDetail: useAliasRouteDetail = rout
         <PageHeader productLabel={productGroup}>
           {t('curiosity-view.title', { appName: helpers.UI_DISPLAY_NAME, context: productGroup })}
         </PageHeader>
-        <PageColumns>{renderProduct()}</PageColumns>
+        <PageColumns>{renderProduct}</PageColumns>
         <div className="curiosity-page-section__version">
           <Button
             className="curiosity-page-section__version-link"

--- a/src/components/router/__tests__/__snapshots__/routerContext.test.js.snap
+++ b/src/components/router/__tests__/__snapshots__/routerContext.test.js.snap
@@ -1,38 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RouterContext should apply a hook for useNavigate: navigation push 1`] = `
-[
-  [
-    {},
-    "",
-    "/subscriptions/rhel?lorem=ipsum",
-    undefined,
+exports[`RouterContext should apply a helper with setRouteProduct and return a product configuration match, attempt closest disabled but return exact because of variant selection 1`] = `
+{
+  "detailProps": [
+    "allConfigs",
+    "availableVariants",
+    "firstMatch",
+    "isClosest",
+    "productGroup",
+    "productConfig",
+    "productPath",
+    "productVariant",
+    "disableIsClosestMatch",
   ],
-  [
-    {},
-    "",
-    "/subscriptions/rhel?lorem=ipsum",
-    undefined,
+  "firstMatch": [
+    "aliases",
+    "productGroup",
+    "productId",
+    "productLabel",
+    "productPath",
+    "productDisplay",
+    "viewId",
+    "productVariants",
+    "query",
+    "graphTallyQuery",
+    "inventoryGuestsQuery",
+    "inventoryHostsQuery",
+    "inventorySubscriptionsQuery",
+    "initialGraphFilters",
+    "initialGraphSettings",
+    "initialGuestsFilters",
+    "initialInventoryFilters",
+    "initialInventorySettings",
+    "initialToolbarFilters",
   ],
-  [
-    {},
-    "",
-    "/subscriptions/rhel?lorem=ipsum",
-    undefined,
-  ],
-]
+  "isClosest": false,
+  "productGroup": "rhel",
+  "productPath": "l",
+}
 `;
 
-exports[`RouterContext should apply a hook for useRouteDetail: document title 1`] = `
-[
-  [
-    "t(curiosity-view.title, {"appName":"Subscriptions","context":"rhel"}) - Subscriptions",
-    true,
-  ],
-]
-`;
-
-exports[`RouterContext should apply a hook for useSetRouteProduct: route details, closest 1`] = `
+exports[`RouterContext should apply a helper with setRouteProduct and return a product configuration match, closest 1`] = `
 {
   "detailProps": [
     "allConfigs",
@@ -73,7 +81,48 @@ exports[`RouterContext should apply a hook for useSetRouteProduct: route details
 }
 `;
 
-exports[`RouterContext should apply a hook for useSetRouteProduct: route details, match 1`] = `
+exports[`RouterContext should apply a helper with setRouteProduct and return a product configuration match, closest disabled 1`] = `
+{
+  "detailProps": [
+    "allConfigs",
+    "availableVariants",
+    "firstMatch",
+    "isClosest",
+    "productGroup",
+    "productConfig",
+    "productPath",
+    "productVariant",
+    "disableIsClosestMatch",
+  ],
+  "firstMatch": [
+    "aliases",
+    "productGroup",
+    "productId",
+    "productLabel",
+    "productPath",
+    "productDisplay",
+    "viewId",
+    "productVariants",
+    "query",
+    "graphTallyQuery",
+    "inventoryGuestsQuery",
+    "inventoryHostsQuery",
+    "inventorySubscriptionsQuery",
+    "initialGraphFilters",
+    "initialGraphSettings",
+    "initialGuestsFilters",
+    "initialInventoryFilters",
+    "initialInventorySettings",
+    "initialSubscriptionsInventoryFilters",
+    "initialToolbarFilters",
+  ],
+  "isClosest": true,
+  "productGroup": "rhel",
+  "productPath": "l",
+}
+`;
+
+exports[`RouterContext should apply a helper with setRouteProduct and return a product configuration match, exact 1`] = `
 {
   "detailProps": [
     "allConfigs",
@@ -114,8 +163,53 @@ exports[`RouterContext should apply a hook for useSetRouteProduct: route details
 }
 `;
 
+exports[`RouterContext should apply a hook for the helper setRouteProduct with useSetRouteProduct: hook 1`] = `
+[
+  [
+    {
+      "disableIsClosestMatch": false,
+      "productPath": "rhel",
+      "productVariant": {},
+    },
+  ],
+]
+`;
+
+exports[`RouterContext should apply a hook for useNavigate: navigation push 1`] = `
+[
+  [
+    {},
+    "",
+    "/subscriptions/rhel?lorem=ipsum",
+    undefined,
+  ],
+  [
+    {},
+    "",
+    "/subscriptions/rhel?lorem=ipsum",
+    undefined,
+  ],
+  [
+    {},
+    "",
+    "/subscriptions/rhel?lorem=ipsum",
+    undefined,
+  ],
+]
+`;
+
+exports[`RouterContext should apply a hook for useRouteDetail: document title 1`] = `
+[
+  [
+    "t(curiosity-view.title, {"appName":"Subscriptions","context":"rhel"}) - Subscriptions",
+    true,
+  ],
+]
+`;
+
 exports[`RouterContext should return specific properties: specific properties 1`] = `
 {
+  "setRouteProduct": [Function],
   "useNavigate": [Function],
   "useRouteDetail": [Function],
   "useSetRouteProduct": [Function],

--- a/src/components/router/routerContext.js
+++ b/src/components/router/routerContext.js
@@ -142,18 +142,19 @@ const useRouteDetail = ({
 } = {}) => {
   const product = useAliasSetRouteProduct();
   const { getBundleData = helpers.noop, updateDocumentTitle = helpers.noop } = useAliasChrome();
-  const bundleData = getBundleData();
+  const bundleTitle = getBundleData()?.bundleTitle;
+  const productGroup = product?.productGroup;
 
   useEffect(() => {
     // Set platform document title, remove pre-baked suffix
     updateDocumentTitle(
       `${t(`curiosity-view.title`, {
         appName: helpers.UI_DISPLAY_NAME,
-        context: product?.productGroup
-      })} - ${helpers.UI_DISPLAY_NAME}${(bundleData?.bundleTitle && ` | ${bundleData?.bundleTitle}`) || ''}`,
+        context: productGroup
+      })} - ${helpers.UI_DISPLAY_NAME}${(bundleTitle && ` | ${bundleTitle}`) || ''}`,
       true
     );
-  }, [bundleData?.bundleTitle, product?.productGroup, t, updateDocumentTitle]);
+  }, [bundleTitle, productGroup, t, updateDocumentTitle]);
 
   return product;
 };

--- a/src/components/toolbar/toolbarFieldGroupVariant.js
+++ b/src/components/toolbar/toolbarFieldGroupVariant.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Toolbar as PfToolbar, ToolbarContent, ToolbarItem, ToolbarItemVariant } from '@patternfly/react-core';
 import { reduxTypes, storeHooks } from '../../redux';
 import { useProduct } from '../productView/productViewContext';
@@ -26,17 +26,21 @@ const useToolbarFieldOptions = ({
   useRouteDetail: useAliasRouteDetail = routerContext.useRouteDetail
 } = {}) => {
   const { availableVariants, firstMatch } = useAliasRouteDetail();
-  const options = [];
+  const productId = firstMatch?.productId;
 
-  availableVariants?.forEach(variant => {
-    options.push({
-      title: t('curiosity-toolbar.label', { context: ['groupVariant', variant] }),
-      value: variant,
-      isSelected: variant === firstMatch?.productId
+  return useMemo(() => {
+    const options = [];
+
+    availableVariants?.forEach(variant => {
+      options.push({
+        title: t('curiosity-toolbar.label', { context: ['groupVariant', variant] }),
+        value: variant,
+        isSelected: variant === productId
+      });
     });
-  });
 
-  return options.sort(({ title: titleA }, { title: titleB }) => titleA.localeCompare(titleB));
+    return options.sort(({ title: titleA }, { title: titleB }) => titleA.localeCompare(titleB));
+  }, [availableVariants, productId, t]);
 };
 
 /**


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- perf(productView,routerContext): sw-95 product load optimization
   * productView, move to useMemo
   * routerContext, switch to cached memo matching
   * toolbarFieldGroupVariant, move to useMemo

### Notes
- config loading optimizations exposed while working through sw-95
- retains a level of product context memoization related to how Chroming potentially loads UI code and/or handles routing. avoid unnecessary renders
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. confirm navigation between product variants behaves
   - as intended
   - api calls remain unchanged

### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. confirm navigation between product variants behaves
   - as intended
   - api calls remain unchanged
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-95