### PR TITLE
fix(toolbarFieldBillingAccount): sw-3513 remove locale ref

### DIFF
--- a/public/locales/en-US.json
+++ b/public/locales/en-US.json
@@ -336,7 +336,6 @@
     "clearFilters": "Reset filters",
     "label": "",
     "label_billing_account": "Billing account",
-    "label_billing_account_id": "{{context}}",
     "label_billing_provider": "",
     "label_billing_provider_none": "None",
     "label_billing_provider_aws": "Amazon Web Services",

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -5740,6 +5740,8 @@ A dynamic Billing Account select filter.
 
 ### ToolbarFieldBillingAccount~useToolbarFieldOptions(options) ⇒ <code>Array.&lt;{title: React.ReactNode, value: string, isSelected: boolean}&gt;</code>
 Generate select field options from service.
+Note: Avoid using the translation wrapper for "account" for scenarios where the account
+contains underscores. Underscores interfere with the contextual string lookup.
 
 **Kind**: inner method of [<code>ToolbarFieldBillingAccount</code>](#Toolbar.module_ToolbarFieldBillingAccount)  
 <table>
@@ -5751,8 +5753,6 @@ Generate select field options from service.
   <tbody>
 <tr>
     <td>options</td><td><code>object</code></td><td></td>
-    </tr><tr>
-    <td>[options.t]</td><td><code>translate</code></td><td><code>translate</code></td>
     </tr><tr>
     <td>[options.useProduct]</td><td><code>useProduct</code></td><td><code>useProduct</code></td>
     </tr><tr>

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -349,10 +349,6 @@ exports[`I18n Component should generate a predictable locale key output snapshot
     "file": "src/components/toolbar/toolbarFieldBillingAccount.js",
     "keys": [
       {
-        "key": "curiosity-toolbar.label",
-        "match": "t('curiosity-toolbar.label', { context: ['billing_account_id', account] })",
-      },
-      {
         "key": "",
         "match": "t(\`curiosity-toolbar.placeholder\${(isFilter && '_filter')",
       },
@@ -1127,10 +1123,6 @@ exports[`I18n Component should have locale keys that exist in the default langua
   },
   {
     "file": "src/components/toolbar/toolbar.js",
-    "key": "curiosity-toolbar.label",
-  },
-  {
-    "file": "src/components/toolbar/toolbarFieldBillingAccount.js",
     "key": "curiosity-toolbar.label",
   },
   {

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldBillingAccount.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldBillingAccount.test.js.snap
@@ -4,22 +4,22 @@ exports[`ToolbarFieldBillingAccount Component should generate select options: to
 [
   {
     "isSelected": false,
-    "title": "t(curiosity-toolbar.label_billing_account_id, {"context":"lorem"})",
+    "title": "lorem",
     "value": "lorem",
   },
   {
     "isSelected": false,
-    "title": "t(curiosity-toolbar.label_billing_account_id, {"context":"ipsum"})",
+    "title": "ipsum",
     "value": "ipsum",
   },
   {
     "isSelected": false,
-    "title": "t(curiosity-toolbar.label_billing_account_id, {"context":"dolor"})",
+    "title": "dolor",
     "value": "dolor",
   },
   {
     "isSelected": false,
-    "title": "t(curiosity-toolbar.label_billing_account_id, {"context":"sit"})",
+    "title": "sit",
     "value": "sit",
   },
 ]

--- a/src/components/toolbar/toolbarFieldBillingAccount.js
+++ b/src/components/toolbar/toolbarFieldBillingAccount.js
@@ -17,16 +17,16 @@ import { translate } from '../i18n/i18n';
  */
 /**
  * Generate select field options from service.
+ * Note: Avoid using the translation wrapper for "account" for scenarios where the account
+ * contains underscores. Underscores interfere with the contextual string lookup.
  *
  * @param {object} options
- * @param {translate} [options.t=translate]
  * @param {useProduct} [options.useProduct=useProduct]
  * @param {useProductQuery} [options.useProductQuery=useProductQuery]
  * @param {storeHooks.reactRedux.useSelector} [options.useSelector=storeHooks.reactRedux.useSelector]
  * @returns {Array<{title: React.ReactNode, value: string, isSelected: boolean}>}
  */
 const useToolbarFieldOptions = ({
-  t = translate,
   useProduct: useAliasProduct = useProduct,
   useProductQuery: useAliasProductQuery = useProductQuery,
   useSelector: useAliasSelector = storeHooks.reactRedux.useSelector
@@ -42,11 +42,11 @@ const useToolbarFieldOptions = ({
   return useMemo(
     () =>
       billingAccounts?.map(account => ({
-        title: t('curiosity-toolbar.label', { context: ['billing_account_id', account] }),
+        title: account,
         value: account,
         isSelected: account === defaultAccount
       })) || [],
-    [billingAccounts, defaultAccount, t]
+    [billingAccounts, defaultAccount]
   );
 };
 


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(toolbarFieldBillingAccount): sw-3513 remove locale ref

### Notes
- In scenarios where account identifiers contain underscores they can alter how the translation wrapper determines context. The fix is to avoid using the translation wrapping entirely.
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. navigate to a product display, such as OpenShift AI
   - confirm the billing provider and billing account fields are displaying as intended

### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. navigate to a product display, such as OpenShift AI
   - confirm the billing provider and billing account fields are displaying as intended
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-3513
related to sw-95 #1577
