### PR TITLE
fix(productViewOnload): sw-95 missing locale string

### DIFF
--- a/public/locales/en-US.json
+++ b/public/locales/en-US.json
@@ -480,6 +480,8 @@
     "error_pageTitle": "Subscriptions Usage",
     "error_title": "{{appName}} is temporarily unavailable",
     "error_title_onload": "$t(curiosity-view.title_{{product}}) display is temporarily unavailable",
+    "pending": "...",
+    "pending_description": "Configuring...",
     "title": "{{appName}}",
     "subtitle": "Monitor your usage based on your subscription terms. <0>Learn more about {{appName}} reporting</0>",
     "description": "Monitor your usage based on your subscription terms.",

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -1118,10 +1118,6 @@ exports[`I18n Component should have locale keys that exist in the default langua
     "key": "curiosity-inventory.table",
   },
   {
-    "file": "src/components/productView/productViewOnload.js",
-    "key": "curiosity-view.pending",
-  },
-  {
     "file": "src/components/toolbar/toolbar.js",
     "key": "curiosity-toolbar.label",
   },


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(productViewOnload): sw-95 missing locale string

### Notes
- missing locale string for the config preload
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-95

<!--

## Summary by Sourcery

Add missing locale string for product view configuration preload in English (US) localization

Bug Fixes:
- Resolved a localization issue by adding a missing locale string for the product view configuration preload

Documentation:
- Updated English (US) locale JSON file to include the missing translation string

-->