### PR TITLE
fix(toolbar): sw-3513 conditional locale display

### DIFF
--- a/src/components/README.md
+++ b/src/components/README.md
@@ -5597,14 +5597,16 @@ Set selected options for chip display.
 <table>
   <thead>
     <tr>
-      <th>Param</th><th>Type</th>
+      <th>Param</th><th>Type</th><th>Default</th>
     </tr>
   </thead>
   <tbody>
 <tr>
-    <td>params</td><td><code>object</code></td>
+    <td>params</td><td><code>object</code></td><td></td>
     </tr><tr>
-    <td>params.value</td><td><code>string</code> | <code>Array.&lt;string&gt;</code></td>
+    <td>params.value</td><td><code>string</code> | <code>Array.&lt;string&gt;</code></td><td></td>
+    </tr><tr>
+    <td>[params.isLocale]</td><td><code>boolean</code></td><td><code>true</code></td>
     </tr>  </tbody>
 </table>
 

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -103,9 +103,10 @@ const Toolbar = ({
    *
    * @param {object} params
    * @param {string|Array<string>} params.value
+   * @param {boolean} [params.isLocale=true]
    * @returns {Array}
    */
-  const setSelectedOptions = ({ value: filterName } = {}) => {
+  const setSelectedOptions = ({ value: filterName, isLocale = true } = {}) => {
     const filterValues =
       (Array.isArray(filterName) && filterName.map(filter => ({ name: filter, value: toolbarFieldQueries[filter] }))) ||
       (typeof toolbarFieldQueries[filterName] === 'string' && [
@@ -115,7 +116,12 @@ const Toolbar = ({
 
     return filterValues
       .filter(({ value }) => typeof value === 'string')
-      .map(({ name, value }) => t('curiosity-toolbar.label', { context: [name, (value === '' && 'none') || value] }));
+      .map(
+        ({ name, value }) =>
+          (isLocale && t('curiosity-toolbar.label', { context: [name, (value === '' && 'none') || value] })) ||
+          (value === '' && 'none') ||
+          value
+      );
   };
 
   return (
@@ -145,7 +151,7 @@ const Toolbar = ({
                 const updatedValue = dynamicValue || filterName;
 
                 if (isClearable !== false) {
-                  chipProps.chips = setSelectedOptions({ value: updatedValue });
+                  chipProps.chips = setSelectedOptions({ value: updatedValue, isLocale: dynamicValue === undefined });
                   chipProps.deleteChip = () => onClearFilter({ value: updatedValue });
                 }
 


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(toolbar): sw-3513 conditional locale display

### Notes
- Applies a conditional check for "dynamic" toolbar chip/label values. The same issue that was happening in the original sw-3513 was also happening at the chip/label level, see examples below
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. navigate towards a product that uses the billing provider filter
   - confirm that after selecting an account id that contains multiple underscores the related toolbar chip/label also displays correctly

### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. navigate towards a product that uses the billing provider filter
   - confirm that after selecting an account id that contains multiple underscores the related toolbar chip/label also displays correctly
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
After
![Screenshot 2025-04-23 at 2 00 43 AM](https://github.com/user-attachments/assets/6a5debf4-6533-4cce-8720-5b67adbc548b)


Before
![Screenshot 2025-04-23 at 1 59 00 AM](https://github.com/user-attachments/assets/0d53c8bd-f449-4f98-b308-570b705e1c74)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-3513
related sw-95 #1581 

<!-- @sourcery-ai summary -->
<!-- @sourcery-ai dismiss -->