### PR TITLE
fix(rhsmTransformers): sw-95 allow id overlap per provider

### DIFF
--- a/public/locales/en-US.json
+++ b/public/locales/en-US.json
@@ -338,7 +338,7 @@
     "label_billing_account": "Billing account",
     "label_billing_account_id": "{{value}}",
     "label_billing_account_id_none": "Empty account id",
-    "label_billing_provider": "",
+    "label_billing_provider": "{{value}}",
     "label_billing_provider_none": "$t(curiosity-toolbar.label_none)",
     "label_billing_provider_aws": "Amazon Web Services",
     "label_billing_provider_azure": "Microsoft Azure",

--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldBillingProvider.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldBillingProvider.test.js.snap
@@ -4,7 +4,7 @@ exports[`ToolbarFieldBillingProvider Component should generate select options: t
 [
   {
     "isSelected": true,
-    "title": "t(curiosity-toolbar.label_billing_provider, {"context":"mock billing provider"})",
+    "title": "t(curiosity-toolbar.label_billing_provider, {"context":"mock billing provider","value":"mock billing provider"})",
     "value": "mock billing provider",
   },
 ]

--- a/src/components/toolbar/toolbarFieldBillingProvider.js
+++ b/src/components/toolbar/toolbarFieldBillingProvider.js
@@ -39,7 +39,10 @@ const useToolbarFieldOptions = ({
   return useMemo(
     () =>
       billingProviders?.map(provider => ({
-        title: t('curiosity-toolbar.label', { context: ['billing_provider', (provider === '' && 'none') || provider] }),
+        title: t('curiosity-toolbar.label', {
+          context: ['billing_provider', (provider === '' && 'none') || provider],
+          value: provider
+        }),
         value: provider,
         isSelected: provider === updatedBillingProvider
       })) || [],

--- a/src/services/rhsm/__tests__/__snapshots__/rhsmTransformers.test.js.snap
+++ b/src/services/rhsm/__tests__/__snapshots__/rhsmTransformers.test.js.snap
@@ -913,6 +913,7 @@ exports[`RHSM Transformers should attempt to parse multiple billing account id r
 {
   "accountsByProvider": {
     "mockProvider": [
+      "12345",
       "678910",
     ],
     "otherMockProvider": [
@@ -924,9 +925,9 @@ exports[`RHSM Transformers should attempt to parse multiple billing account id r
     "mockProvider",
     "otherMockProvider",
   ],
-  "defaultAccount": "678910",
+  "defaultAccount": "12345",
   "defaultAccountByProvider": {
-    "mockProvider": "678910",
+    "mockProvider": "12345",
     "otherMockProvider": "12345",
   },
   "defaultProvider": "mockProvider",

--- a/src/services/rhsm/rhsmTransformers.js
+++ b/src/services/rhsm/rhsmTransformers.js
@@ -41,30 +41,20 @@ const rhsmBillingAccounts = (response = []) => {
       )
     )
     .flat()
-    .filter(Boolean);
-
-  // Note: Apply last entry. This will overwrite duplicates if they exist in the first response.
-  const dupCache = {};
-  successResponse.forEach(obj => {
-    if (obj.id) {
-      dupCache[obj.id] = obj;
-    }
-  });
-
-  const accounts = Object.values(dupCache);
-
-  const billingProviders = [...new Set(accounts.map(({ provider }) => provider))].sort();
+    .filter(res => typeof res?.provider === 'string' && typeof res?.id === 'string');
 
   const accountsByProvider = {};
   const defaultAccountByProvider = {};
 
-  accounts.forEach(({ id, provider }) => {
+  successResponse.forEach(({ id, provider }) => {
     accountsByProvider[provider] ??= [];
     accountsByProvider[provider].push(id);
   });
 
+  const billingProviders = [...Object.keys(accountsByProvider)].sort();
+
   Object.keys(accountsByProvider).forEach(key => {
-    accountsByProvider[key].sort();
+    accountsByProvider[key] = [...new Set(accountsByProvider[key])].sort();
     defaultAccountByProvider[key] = accountsByProvider[key]?.[0];
   });
 


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
fix(rhsmTransformers): sw-95 allow id overlap per provider

### Notes
- discovered during testing... "unique providers" are currently being filtered when account ids happened to overlap. 
   - original logic assumed "ids are unique across provider"
   - this update assumes we can't always guarantee the account ids being returned by provider are unique
- multiple providers can now have the same account ids, ie. AWS could have the same account identifier as Azure and they would be unique to the provider. This wouldn't necessarily happen in the wild but the UI code now makes an allowance for wonky identifiers
- for final clarity... `the UI does NOT make up any providers or account identifiers, it only returns what the billing account id instances and subscriptions API responses give it`
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. navigate towards a product variant that uses billing providers/accounts, we leveraged RHEL ELS
   - confirm that the billing account ID responses contain overlapping non-unique identifiers by provider
   - confirm the UI now responds with displaying unique providers and unique accounts by provider
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screenshot 2025-04-23 at 10 59 11 PM](https://github.com/user-attachments/assets/707edfba-8a78-459b-aa3d-00f2c9808133)
![Screenshot 2025-04-23 at 10 58 51 PM](https://github.com/user-attachments/assets/5d8513d2-2390-4b1e-979b-b4b563e0ca09)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-95