### PR TITLE
refactor(productViewOnloadContext): sw-95 component related hooks

### DIFF
--- a/src/components/README.md
+++ b/src/components/README.md
@@ -127,11 +127,15 @@ recreate the core component.
 <dd><p>Primary product display component, and config context provider.</p>
 </dd>
 <dt><a href="#ProductView.module_ProductViewContext">ProductViewContext</a></dt>
-<dd></dd>
+<dd><p>Product view hooks for configuration and query management.</p>
+</dd>
 <dt><a href="#ProductView.module_ProductViewMissing">ProductViewMissing</a></dt>
 <dd></dd>
 <dt><a href="#ProductView.module_ProductViewOnload">ProductViewOnload</a></dt>
 <dd></dd>
+<dt><a href="#ProductViewOnload.module_ProductViewOnloadContext">ProductViewOnloadContext</a></dt>
+<dd><p>Product view onload hooks. Hooks intended to fire AFTER product query and configuration is set.</p>
+</dd>
 <dt><a href="#Router.module_RouterContext">RouterContext</a></dt>
 <dd></dd>
 <dt><a href="#Router.module_RouterHelpers">RouterHelpers</a></dt>
@@ -4232,6 +4236,8 @@ Display products.
 <a name="ProductView.module_ProductViewContext"></a>
 
 ## ProductViewContext
+Product view hooks for configuration and query management.
+
 
 * [ProductViewContext](#ProductView.module_ProductViewContext)
     * [~DEFAULT_CONTEXT](#ProductView.module_ProductViewContext..DEFAULT_CONTEXT) : <code>React.Context.&lt;{}&gt;</code>
@@ -4253,7 +4259,6 @@ Display products.
     * [~useProductInventorySubscriptionsConfig(options)](#ProductView.module_ProductViewContext..useProductInventorySubscriptionsConfig) ⇒ <code>Object</code>
     * [~useProductToolbarConfig(options)](#ProductView.module_ProductViewContext..useProductToolbarConfig) ⇒ <code>Object</code>
     * [~useProductExportQuery(options)](#ProductView.module_ProductViewContext..useProductExportQuery) ⇒ <code>Object</code>
-    * [~useProductOnload(options)](#ProductView.module_ProductViewContext..useProductOnload) ⇒ <code>Object</code>
 
 <a name="ProductView.module_ProductViewContext..DEFAULT_CONTEXT"></a>
 
@@ -4677,34 +4682,6 @@ Return an export query for subscriptions.
     </tr>  </tbody>
 </table>
 
-<a name="ProductView.module_ProductViewContext..useProductOnload"></a>
-
-### ProductViewContext~useProductOnload(options) ⇒ <code>Object</code>
-Onload product conditionally dispatch services.
-
-**Kind**: inner method of [<code>ProductViewContext</code>](#ProductView.module_ProductViewContext)  
-<table>
-  <thead>
-    <tr>
-      <th>Param</th><th>Type</th><th>Default</th>
-    </tr>
-  </thead>
-  <tbody>
-<tr>
-    <td>options</td><td><code>object</code></td><td></td>
-    </tr><tr>
-    <td>[options.getBillingAccounts]</td><td><code>reduxActions.rhsm.getBillingAccounts</code></td><td><code>reduxActions.rhsm.getBillingAccounts</code></td>
-    </tr><tr>
-    <td>[options.useDispatch]</td><td><code>storeHooks.reactRedux.useDispatch</code></td><td><code>storeHooks.reactRedux.useDispatch</code></td>
-    </tr><tr>
-    <td>[options.useProductViewContext]</td><td><code>useProductViewContext</code></td><td><code>useProductViewContext</code></td>
-    </tr><tr>
-    <td>[options.useProductBillingAccountsQuery]</td><td><code>useProductBillingAccountsQuery</code></td><td><code>useProductBillingAccountsQuery</code></td>
-    </tr><tr>
-    <td>[options.useSelectorsResponse]</td><td><code>storeHooks.reactRedux.useSelectorsResponse</code></td><td><code>useSelectorsResponse</code></td>
-    </tr>  </tbody>
-</table>
-
 <a name="ProductView.module_ProductViewMissing"></a>
 
 ## ProductViewMissing
@@ -4761,6 +4738,20 @@ On click, update history.
 <a name="ProductView.module_ProductViewOnload"></a>
 
 ## ProductViewOnload
+**Properties**
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th><th>Type</th>
+    </tr>
+  </thead>
+  <tbody>
+<tr>
+    <td>ProductViewOnloadContext</td><td><code>module</code></td>
+    </tr>  </tbody>
+</table>
+
 <a name="ProductView.module_ProductViewOnload..ProductViewOnload"></a>
 
 ### ProductViewOnload~ProductViewOnload(props) ⇒ <code>JSX.Element</code>
@@ -4782,6 +4773,39 @@ Product conditional configuration loading.
     <td>[props.t]</td><td><code>translate</code></td><td><code>translate</code></td>
     </tr><tr>
     <td>[props.useProductOnload]</td><td><code>useProductOnload</code></td><td><code>useProductOnload</code></td>
+    </tr>  </tbody>
+</table>
+
+<a name="ProductViewOnload.module_ProductViewOnloadContext"></a>
+
+## ProductViewOnloadContext
+Product view onload hooks. Hooks intended to fire AFTER product query and configuration is set.
+
+<a name="ProductViewOnload.module_ProductViewOnloadContext..useProductOnload"></a>
+
+### ProductViewOnloadContext~useProductOnload(options) ⇒ <code>Object</code>
+Onload product apply conditional state dispatch services.
+
+**Kind**: inner method of [<code>ProductViewOnloadContext</code>](#ProductViewOnload.module_ProductViewOnloadContext)  
+<table>
+  <thead>
+    <tr>
+      <th>Param</th><th>Type</th><th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+<tr>
+    <td>options</td><td><code>object</code></td><td></td>
+    </tr><tr>
+    <td>[options.getBillingAccounts]</td><td><code>reduxActions.rhsm.getBillingAccounts</code></td><td><code>reduxActions.rhsm.getBillingAccounts</code></td>
+    </tr><tr>
+    <td>[options.useDispatch]</td><td><code>storeHooks.reactRedux.useDispatch</code></td><td><code>storeHooks.reactRedux.useDispatch</code></td>
+    </tr><tr>
+    <td>[options.useProductViewContext]</td><td><code>useProductViewContext</code></td><td><code>useProductViewContext</code></td>
+    </tr><tr>
+    <td>[options.useProductBillingAccountsQuery]</td><td><code>useProductBillingAccountsQuery</code></td><td><code>useProductBillingAccountsQuery</code></td>
+    </tr><tr>
+    <td>[options.useSelectorsResponse]</td><td><code>storeHooks.reactRedux.useSelectorsResponse</code></td><td><code>useSelectorsResponse</code></td>
     </tr>  </tbody>
 </table>
 

--- a/src/components/productView/__tests__/__snapshots__/productViewContext.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productViewContext.test.js.snap
@@ -6,51 +6,6 @@ exports[`ProductViewContext should apply a hook factory for retrieving api queri
 }
 `;
 
-exports[`ProductViewContext should apply a hook for product configuration onload: dispatch 1`] = `
-[
-  [
-    "lorem",
-    {
-      "org_id": undefined,
-    },
-  ],
-]
-`;
-
-exports[`ProductViewContext should apply a hook for product configuration onload: product onload, basic 1`] = `
-{
-  "cancelled": false,
-  "data": [],
-  "error": false,
-  "fulfilled": false,
-  "isReady": true,
-  "message": null,
-  "pending": false,
-  "productId": "lorem",
-  "responses": {
-    "id": {},
-    "list": [],
-  },
-}
-`;
-
-exports[`ProductViewContext should apply a hook for product configuration onload: product onload, onload 1`] = `
-{
-  "cancelled": false,
-  "data": [],
-  "error": false,
-  "fulfilled": false,
-  "isReady": false,
-  "message": null,
-  "pending": false,
-  "productId": "lorem",
-  "responses": {
-    "id": {},
-    "list": [],
-  },
-}
-`;
-
 exports[`ProductViewContext should apply a hook for retrieving configuration based queries: query factory 1`] = `
 {
   "billing_account_id": "mockAccount",
@@ -244,7 +199,7 @@ exports[`ProductViewContext should return specific properties: specific properti
   "useProduct": [Function],
   "useProductContext": [Function],
   "useProductExportQuery": [Function],
-  "useProductOnload": [Function],
+  "useProductViewContext": [Function],
   "useQuery": [Function],
   "useQueryConditional": [Function],
   "useQueryFactory": [Function],

--- a/src/components/productView/__tests__/__snapshots__/productViewOnloadContext.test.js.snap
+++ b/src/components/productView/__tests__/__snapshots__/productViewOnloadContext.test.js.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProductViewOnloadContext should apply a hook for product configuration onload: dispatch 1`] = `
+[
+  [
+    "lorem",
+    {
+      "org_id": undefined,
+    },
+  ],
+]
+`;
+
+exports[`ProductViewOnloadContext should apply a hook for product configuration onload: product onload, basic 1`] = `
+{
+  "cancelled": false,
+  "data": [],
+  "error": false,
+  "fulfilled": false,
+  "isReady": true,
+  "message": null,
+  "pending": false,
+  "productId": "lorem",
+  "responses": {
+    "id": {},
+    "list": [],
+  },
+}
+`;
+
+exports[`ProductViewOnloadContext should apply a hook for product configuration onload: product onload, onload 1`] = `
+{
+  "cancelled": false,
+  "data": [],
+  "error": false,
+  "fulfilled": false,
+  "isReady": false,
+  "message": null,
+  "pending": false,
+  "productId": "lorem",
+  "responses": {
+    "id": {},
+    "list": [],
+  },
+}
+`;
+
+exports[`ProductViewOnloadContext should return specific properties: specific properties 1`] = `
+{
+  "useProductOnload": [Function],
+}
+`;

--- a/src/components/productView/__tests__/productViewContext.test.js
+++ b/src/components/productView/__tests__/productViewContext.test.js
@@ -12,7 +12,6 @@ import {
   useProductToolbarQuery,
   useProductContext,
   useProduct,
-  useProductOnload,
   useProductGraphConfig,
   useProductInventoryGuestsConfig,
   useProductInventoryHostsConfig,
@@ -193,31 +192,5 @@ describe('ProductViewContext', () => {
       useHook({ useProductViewContext: () => mockContextValue, useProductContext: () => mockContextValue })
     );
     expect(result).toMatchSnapshot();
-  });
-
-  it('should apply a hook for product configuration onload', async () => {
-    const mockApiCall = jest.fn();
-    const mockDispatch = jest.fn();
-    const mockContextValue = {
-      productId: 'lorem'
-    };
-
-    const { result: basic } = await renderHook(() =>
-      useProductOnload({ useProductViewContext: () => mockContextValue })
-    );
-    expect(basic).toMatchSnapshot('product onload, basic');
-
-    const { result: onload } = await renderHook(() =>
-      useProductOnload({
-        getBillingAccounts: mockApiCall,
-        useDispatch: () => mockDispatch,
-        useProductViewContext: () => ({
-          ...mockContextValue,
-          onloadProduct: [rhsmConstants.RHSM_API_QUERY_SET_TYPES.BILLING_ACCOUNT_ID]
-        })
-      })
-    );
-    expect(onload).toMatchSnapshot('product onload, onload');
-    expect(mockApiCall.mock.calls).toMatchSnapshot('dispatch');
   });
 });

--- a/src/components/productView/__tests__/productViewOnloadContext.test.js
+++ b/src/components/productView/__tests__/productViewOnloadContext.test.js
@@ -1,0 +1,34 @@
+import { context, useProductOnload } from '../productViewOnloadContext';
+import { rhsmConstants } from '../../../services/rhsm/rhsmConstants';
+
+describe('ProductViewOnloadContext', () => {
+  it('should return specific properties', () => {
+    expect(context).toMatchSnapshot('specific properties');
+  });
+
+  it('should apply a hook for product configuration onload', async () => {
+    const mockApiCall = jest.fn();
+    const mockDispatch = jest.fn();
+    const mockContextValue = {
+      productId: 'lorem'
+    };
+
+    const { result: basic } = await renderHook(() =>
+      useProductOnload({ useProductViewContext: () => mockContextValue })
+    );
+    expect(basic).toMatchSnapshot('product onload, basic');
+
+    const { result: onload } = await renderHook(() =>
+      useProductOnload({
+        getBillingAccounts: mockApiCall,
+        useDispatch: () => mockDispatch,
+        useProductViewContext: () => ({
+          ...mockContextValue,
+          onloadProduct: [rhsmConstants.RHSM_API_QUERY_SET_TYPES.BILLING_ACCOUNT_ID]
+        })
+      })
+    );
+    expect(onload).toMatchSnapshot('product onload, onload');
+    expect(mockApiCall.mock.calls).toMatchSnapshot('dispatch');
+  });
+});

--- a/src/components/productView/productViewContext.js
+++ b/src/components/productView/productViewContext.js
@@ -1,11 +1,13 @@
-import React, { useContext, useEffect, useMemo } from 'react';
+import React, { useContext, useMemo } from 'react';
 import { useSession } from '../authentication/authenticationContext';
-import { reduxActions, reduxHelpers, storeHooks } from '../../redux';
+import { reduxHelpers, storeHooks } from '../../redux';
 import { rhsmConstants } from '../../services/rhsm/rhsmConstants';
 import { platformConstants } from '../../services/platform/platformConstants';
 import { helpers } from '../../common/helpers';
 
 /**
+ * Product view hooks for configuration and query management.
+ *
  * @memberof ProductView
  * @module ProductViewContext
  */
@@ -398,55 +400,11 @@ const useProductExportQuery = ({
   );
 };
 
-/**
- * Onload product conditionally dispatch services.
- *
- * @param {object} options
- * @param {reduxActions.rhsm.getBillingAccounts} [options.getBillingAccounts=reduxActions.rhsm.getBillingAccounts]
- * @param {storeHooks.reactRedux.useDispatch} [options.useDispatch=storeHooks.reactRedux.useDispatch]
- * @param {useProductViewContext} [options.useProductViewContext=useProductViewContext]
- * @param {useProductBillingAccountsQuery} [options.useProductBillingAccountsQuery=useProductBillingAccountsQuery]
- * @param {storeHooks.reactRedux.useSelectorsResponse} [options.useSelectorsResponse=useSelectorsResponse]
- * @returns {{data: object, productId: string, pending: boolean, isReady: boolean, fulfilled: boolean,
- *     responses: object}}
- */
-const useProductOnload = ({
-  getBillingAccounts = reduxActions.rhsm.getBillingAccounts,
-  useDispatch: useAliasDispatch = storeHooks.reactRedux.useDispatch,
-  useProductViewContext: useAliasProductViewContext = useProductViewContext,
-  useProductBillingAccountsQuery: useAliasProductBillingAccountsQuery = useProductBillingAccountsQuery,
-  useSelectorsResponse: useAliasSelectorsResponse = storeHooks.reactRedux.useSelectorsResponse
-} = {}) => {
-  const { onloadProduct, productId } = useAliasProductViewContext();
-  const billingAccountsQuery = useAliasProductBillingAccountsQuery();
-  const dispatch = useAliasDispatch();
-  const isBillingAccountRequired =
-    onloadProduct?.find(value => value === rhsmConstants.RHSM_API_QUERY_SET_TYPES.BILLING_ACCOUNT_ID) !== undefined;
-
-  const selectors = [];
-  if (isBillingAccountRequired) {
-    selectors.push({ id: 'billing', selector: ({ app }) => app.billingAccounts?.[productId] });
-  }
-  const response = useAliasSelectorsResponse(selectors);
-
-  useEffect(() => {
-    if (isBillingAccountRequired) {
-      dispatch(getBillingAccounts(productId, billingAccountsQuery));
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isBillingAccountRequired, productId]);
-
-  return {
-    ...response,
-    isReady: !onloadProduct?.length || response?.fulfilled || false,
-    productId
-  };
-};
-
 const context = {
   ProductViewContext,
   DEFAULT_CONTEXT,
   useProductContext,
+  useProductViewContext,
   useQuery: useProductQuery,
   useQueryFactory: useProductQueryFactory,
   useQueryConditional: useProductQueryConditional,
@@ -456,7 +414,6 @@ const context = {
   useInventoryHostsQuery: useProductInventoryHostsQuery,
   useInventorySubscriptionsQuery: useProductInventorySubscriptionsQuery,
   useProduct,
-  useProductOnload,
   useProductExportQuery,
   useGraphConfig: useProductGraphConfig,
   useInventoryGuestsConfig: useProductInventoryGuestsConfig,
@@ -472,6 +429,7 @@ export {
   ProductViewContext,
   DEFAULT_CONTEXT,
   useProductContext,
+  useProductViewContext,
   useProductQuery,
   useProductQueryFactory,
   useProductQueryConditional,
@@ -481,7 +439,6 @@ export {
   useProductInventoryHostsQuery,
   useProductInventorySubscriptionsQuery,
   useProduct,
-  useProductOnload,
   useProductExportQuery,
   useProductGraphConfig,
   useProductInventoryGuestsConfig,

--- a/src/components/productView/productViewOnload.js
+++ b/src/components/productView/productViewOnload.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Card, CardBody } from '@patternfly/react-core';
 import { BinocularsIcon } from '@patternfly/react-icons';
-import { useProductOnload } from './productViewContext';
+import { useProductOnload } from './productViewOnloadContext';
 import { ErrorMessage } from '../errorMessage/errorMessage';
 import { MessageView } from '../messageView/messageView';
 import { translate } from '../i18n/i18n';
@@ -9,6 +9,7 @@ import { translate } from '../i18n/i18n';
 /**
  * @memberof ProductView
  * @module ProductViewOnload
+ * @property {module} ProductViewOnloadContext
  */
 
 /**

--- a/src/components/productView/productViewOnloadContext.js
+++ b/src/components/productView/productViewOnloadContext.js
@@ -1,0 +1,62 @@
+import { useEffect } from 'react';
+import { useProductBillingAccountsQuery, useProductViewContext } from './productViewContext';
+import { reduxActions, storeHooks } from '../../redux';
+import { rhsmConstants } from '../../services/rhsm/rhsmConstants';
+
+/**
+ * Product view onload hooks. Hooks intended to fire AFTER product query and configuration is set.
+ *
+ * @memberof ProductViewOnload
+ * @module ProductViewOnloadContext
+ */
+
+/**
+ * Onload product apply conditional state dispatch services.
+ *
+ * @param {object} options
+ * @param {reduxActions.rhsm.getBillingAccounts} [options.getBillingAccounts=reduxActions.rhsm.getBillingAccounts]
+ * @param {storeHooks.reactRedux.useDispatch} [options.useDispatch=storeHooks.reactRedux.useDispatch]
+ * @param {useProductViewContext} [options.useProductViewContext=useProductViewContext]
+ * @param {useProductBillingAccountsQuery} [options.useProductBillingAccountsQuery=useProductBillingAccountsQuery]
+ * @param {storeHooks.reactRedux.useSelectorsResponse} [options.useSelectorsResponse=useSelectorsResponse]
+ * @returns {{data: object, productId: string, pending: boolean, isReady: boolean, fulfilled: boolean,
+ *     responses: object}}
+ */
+const useProductOnload = ({
+  getBillingAccounts = reduxActions.rhsm.getBillingAccounts,
+  useDispatch: useAliasDispatch = storeHooks.reactRedux.useDispatch,
+  useProductViewContext: useAliasProductViewContext = useProductViewContext,
+  useProductBillingAccountsQuery: useAliasProductBillingAccountsQuery = useProductBillingAccountsQuery,
+  useSelectorsResponse: useAliasSelectorsResponse = storeHooks.reactRedux.useSelectorsResponse
+} = {}) => {
+  const { onloadProduct, productId } = useAliasProductViewContext();
+  const billingAccountsQuery = useAliasProductBillingAccountsQuery();
+  const dispatch = useAliasDispatch();
+  const isBillingAccountRequired =
+    onloadProduct?.find(value => value === rhsmConstants.RHSM_API_QUERY_SET_TYPES.BILLING_ACCOUNT_ID) !== undefined;
+
+  const selectors = [];
+  if (isBillingAccountRequired) {
+    selectors.push({ id: 'billing', selector: ({ app }) => app.billingAccounts?.[productId] });
+  }
+  const response = useAliasSelectorsResponse(selectors);
+
+  useEffect(() => {
+    if (isBillingAccountRequired) {
+      dispatch(getBillingAccounts(productId, billingAccountsQuery));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isBillingAccountRequired, productId]);
+
+  return {
+    ...response,
+    isReady: !onloadProduct?.length || response?.fulfilled || false,
+    productId
+  };
+};
+
+const context = {
+  useProductOnload
+};
+
+export { context as default, context, useProductOnload };

--- a/tests/__snapshots__/dist.test.js.snap
+++ b/tests/__snapshots__/dist.test.js.snap
@@ -777,8 +777,8 @@ exports[`Build distribution should have a predictable ephemeral navigation based
 exports[`Build distribution should match a specific file output 1`] = `
 [
   "",
+  "./dist/css/2031*css",
   "./dist/css/3372*css",
-  "./dist/css/7889*css",
   "./dist/fed-mods.json",
   "./dist/fonts/graph2x.png",
   "./dist/fonts/graph4x.png",
@@ -796,6 +796,7 @@ exports[`Build distribution should match a specific file output 1`] = `
   "./dist/js/167*js",
   "./dist/js/2007*js",
   "./dist/js/203*js",
+  "./dist/js/2031*js",
   "./dist/js/2047*js",
   "./dist/js/2471*js",
   "./dist/js/279*js",
@@ -862,7 +863,6 @@ exports[`Build distribution should match a specific file output 1`] = `
   "./dist/js/7474*js",
   "./dist/js/7675*js",
   "./dist/js/7691*js",
-  "./dist/js/7889*js",
   "./dist/js/7964*js",
   "./dist/js/8005*js",
   "./dist/js/8376*js",


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- refactor(productViewOnloadContext): sw-95 component related onload hooks
   * productViewContext, remove useProductOnload hook
   * productViewOnloadContext, new file, apply useProductOnload

### Notes
- group onload hooks slightly better (we just moved code around)
- related to upcoming banner messaging indicating there might be a "usage" issue, #1587 
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. next...
-->

### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. confirm tests come back clean

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-95