### PR TITLE
feat(config): sw-95 activate dynamic provider, accounts

### DIFF
--- a/src/config/product.ansible.js
+++ b/src/config/product.ansible.js
@@ -58,8 +58,8 @@ const productLabel = RHSM_API_PATH_PRODUCT_TYPES.ANSIBLE;
  * Product configuration
  *
  * @type {{productLabel: string, productPath: string, aliases: string[], productId: string,
- *     inventorySubscriptionsQuery: object, query: object, initialSubscriptionsInventoryFilters: Array,
- *     initialInventorySettings: object, viewId: string, initialToolbarFilters: Array, productGroup: string,
+ *     inventorySubscriptionsQuery: object, query: object, onloadProduct: Array, initialSubscriptionsInventoryFilters:
+ *     Array, initialInventorySettings: object, viewId: string, initialToolbarFilters: Array, productGroup: string,
  *     graphTallyQuery: object, inventoryHostsQuery: object, productDisplay: string, initialGraphFilters: Array,
  *     initialGuestsFilters: Array, inventoryGuestsQuery: object, initialGraphSettings: object,
  *     initialInventoryFilters: Array}}
@@ -72,6 +72,7 @@ const config = {
   productPath: productGroup.toLowerCase(),
   productDisplay: DISPLAY_TYPES.CAPACITY,
   viewId: `view${productGroup}-${productId}`,
+  onloadProduct: [RHSM_API_QUERY_SET_TYPES.BILLING_ACCOUNT_ID],
   query: {
     [RHSM_API_QUERY_SET_TYPES.START_DATE]: dateHelpers.getRangedMonthDateTime('current').value.startDate.toISOString(),
     [RHSM_API_QUERY_SET_TYPES.END_DATE]: dateHelpers.getRangedMonthDateTime('current').value.endDate.toISOString()
@@ -351,6 +352,9 @@ const config = {
     }
   ],
   initialToolbarFilters: [
+    {
+      id: RHSM_API_QUERY_SET_TYPES.BILLING_PROVIDER
+    },
     {
       id: 'rangedMonthly',
       isSecondary: true,

--- a/src/config/product.openshiftDedicated.js
+++ b/src/config/product.openshiftDedicated.js
@@ -55,10 +55,10 @@ const productLabel = RHSM_API_PATH_PRODUCT_TYPES.OPENSHIFT_DEDICATED_METRICS;
  * Product configuration
  *
  * @type {{productLabel: string, productPath: string, aliases: string[], productId: string, query: object,
- *     initialInventorySettings: object, viewId: string, initialToolbarFilters: Array, productGroup: string,
- *     graphTallyQuery: object, inventoryHostsQuery: object, productDisplay: string, initialGraphFilters: Array,
- *     initialGuestsFilters: Array, inventoryGuestsQuery: object, initialGraphSettings: object,
- *     initialInventoryFilters: Array}}
+ *     onloadProduct: Array, initialInventorySettings: object, viewId: string, initialToolbarFilters: Array,
+ *     productGroup: string, graphTallyQuery: object, inventoryHostsQuery: object, productDisplay: string,
+ *     initialGraphFilters: Array, initialGuestsFilters: Array, inventoryGuestsQuery: object, initialGraphSettings:
+ *     object, initialInventoryFilters: Array}}
  */
 const config = {
   aliases: ['openshift-dedicated', 'dedicated'],
@@ -68,6 +68,7 @@ const config = {
   productPath: productGroup.toLowerCase(),
   productDisplay: DISPLAY_TYPES.HOURLY,
   viewId: `view${productGroup}-${productId}`,
+  onloadProduct: [RHSM_API_QUERY_SET_TYPES.BILLING_ACCOUNT_ID],
   query: {
     [RHSM_API_QUERY_SET_TYPES.START_DATE]: dateHelpers.getRangedMonthDateTime('current').value.startDate.toISOString(),
     [RHSM_API_QUERY_SET_TYPES.END_DATE]: dateHelpers.getRangedMonthDateTime('current').value.endDate.toISOString()
@@ -318,6 +319,9 @@ const config = {
     } = {}) => (numberOfGuests > 0 && id && { id, numberOfGuests }) || undefined
   },
   initialToolbarFilters: [
+    {
+      id: RHSM_API_QUERY_SET_TYPES.BILLING_PROVIDER
+    },
     {
       id: 'rangedMonthly',
       isSecondary: true,

--- a/src/config/product.openshiftMetrics.js
+++ b/src/config/product.openshiftMetrics.js
@@ -55,10 +55,10 @@ const productLabel = RHSM_API_PATH_PRODUCT_TYPES.OPENSHIFT_METRICS;
  * Product configuration
  *
  * @type {{productLabel: string, productPath: string, aliases: string[], productId: string, query: object,
- *     initialInventorySettings: object, viewId: string, initialToolbarFilters: Array, productGroup: string,
- *     graphTallyQuery: object, inventoryHostsQuery: object, productDisplay: string, initialGraphFilters: Array,
- *     initialGuestsFilters: Array, inventoryGuestsQuery: object, initialGraphSettings: object,
- *     initialInventoryFilters: Array}}
+ *     onloadProduct: Array, initialInventorySettings: object, viewId: string, initialToolbarFilters: Array,
+ *     productGroup: string, graphTallyQuery: object, inventoryHostsQuery: object, productDisplay: string,
+ *     initialGraphFilters: Array, initialGuestsFilters: Array, inventoryGuestsQuery: object, initialGraphSettings:
+ *     object, initialInventoryFilters: Array}}
  */
 const config = {
   aliases: [RHSM_API_PATH_PRODUCT_TYPES.OPENSHIFT_METRICS, 'metrics'],
@@ -68,6 +68,7 @@ const config = {
   productPath: productGroup.toLowerCase(),
   productDisplay: DISPLAY_TYPES.HOURLY,
   viewId: `view${productGroup}-${productId}`,
+  onloadProduct: [RHSM_API_QUERY_SET_TYPES.BILLING_ACCOUNT_ID],
   query: {
     [RHSM_API_QUERY_SET_TYPES.START_DATE]: dateHelpers.getRangedMonthDateTime('current').value.startDate.toISOString(),
     [RHSM_API_QUERY_SET_TYPES.END_DATE]: dateHelpers.getRangedMonthDateTime('current').value.endDate.toISOString()
@@ -295,6 +296,9 @@ const config = {
     } = {}) => (numberOfGuests > 0 && id && { id, numberOfGuests }) || undefined
   },
   initialToolbarFilters: [
+    {
+      id: RHSM_API_QUERY_SET_TYPES.BILLING_PROVIDER
+    },
     {
       id: 'rangedMonthly',
       isSecondary: true,

--- a/src/config/product.rosa.js
+++ b/src/config/product.rosa.js
@@ -58,8 +58,8 @@ const productLabel = RHSM_API_PATH_PRODUCT_TYPES.ROSA;
  * Product configuration
  *
  * @type {{productLabel: string, productPath: string, aliases: string[], productId: string,
- *     inventorySubscriptionsQuery: object, query: object, initialSubscriptionsInventoryFilters: Array,
- *     initialInventorySettings: object, viewId: string, initialToolbarFilters: Array, productGroup: string,
+ *     inventorySubscriptionsQuery: object, query: object, onloadProduct: Array, initialSubscriptionsInventoryFilters:
+ *     Array, initialInventorySettings: object, viewId: string, initialToolbarFilters: Array, productGroup: string,
  *     graphTallyQuery: object, inventoryHostsQuery: object, productDisplay: string, initialGraphFilters: Array,
  *     initialGuestsFilters: Array, inventoryGuestsQuery: object, initialGraphSettings: object,
  *     initialInventoryFilters: Array}}
@@ -72,6 +72,7 @@ const config = {
   productPath: productGroup.toLowerCase(),
   productDisplay: DISPLAY_TYPES.CAPACITY,
   viewId: `view${productGroup}-${productId}`,
+  onloadProduct: [RHSM_API_QUERY_SET_TYPES.BILLING_ACCOUNT_ID],
   query: {
     [RHSM_API_QUERY_SET_TYPES.START_DATE]: dateHelpers.getRangedMonthDateTime('current').value.startDate.toISOString(),
     [RHSM_API_QUERY_SET_TYPES.END_DATE]: dateHelpers.getRangedMonthDateTime('current').value.endDate.toISOString()
@@ -352,6 +353,9 @@ const config = {
     }
   ],
   initialToolbarFilters: [
+    {
+      id: RHSM_API_QUERY_SET_TYPES.BILLING_PROVIDER
+    },
     {
       id: 'rangedMonthly',
       isSecondary: true,


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- feat(config): sw-95 activate dynamic provider, accounts

### Notes
- activate the dynamic billing provider and accounts for
   - OpenShift Metrics and Dedicated Metrics
   - ROSA
   - Ansible
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. confirm new dynamic fields display and function per the corresponding product list above

### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. confirm new dynamic fields display and function per the corresponding product list above

### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. confirm tests come back clean

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screenshot 2025-04-28 at 9 59 45 AM](https://github.com/user-attachments/assets/344d496e-a557-47f1-bb64-e70a501227b6)
![Screenshot 2025-04-28 at 9 59 26 AM](https://github.com/user-attachments/assets/0a38aa2c-8e9a-4255-a88c-5fdd8e09c0d9)
![Screenshot 2025-04-28 at 9 59 13 AM](https://github.com/user-attachments/assets/2e031d80-a4e2-4923-b3c6-d690a7343ace)
![Screenshot 2025-04-28 at 9 58 56 AM](https://github.com/user-attachments/assets/2238201f-9eba-45d4-99a3-9fc68744c59c)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
