### PR TITLE
fix(rhsmHelpers): sw-3519 expose unique accounts, providers

### DIFF
--- a/src/services/rhsm/__tests__/__snapshots__/rhsmHelpers.test.js.snap
+++ b/src/services/rhsm/__tests__/__snapshots__/rhsmHelpers.test.js.snap
@@ -13,6 +13,7 @@ exports[`RhsmHelpers billingMetrics should return parsed API responses in a cons
     "hasUniqueProviders": false,
     "numberProviders": 0,
     "providers": [],
+    "uniqueAccountsProvidersList": [],
   },
   "loremApi": {
     "accounts": [
@@ -50,6 +51,20 @@ exports[`RhsmHelpers billingMetrics should return parsed API responses in a cons
         "type": "loremApi",
       },
     ],
+    "uniqueAccountsProvidersList": [
+      [
+        "ipsum",
+        "123",
+      ],
+      [
+        "lorem",
+        "456",
+      ],
+      [
+        "dolor",
+        "012",
+      ],
+    ],
   },
 }
 `;
@@ -65,6 +80,7 @@ exports[`RhsmHelpers billingMetrics should return parsed API responses in a cons
     "hasUniqueProviders": false,
     "numberProviders": 0,
     "providers": [],
+    "uniqueAccountsProvidersList": [],
   },
   "loremApi": {
     "accounts": [
@@ -91,6 +107,20 @@ exports[`RhsmHelpers billingMetrics should return parsed API responses in a cons
     "hasUniqueProviders": false,
     "numberProviders": 1,
     "providers": [],
+    "uniqueAccountsProvidersList": [
+      [
+        "lorem",
+        "123",
+      ],
+      [
+        "lorem",
+        "456",
+      ],
+      [
+        "lorem",
+        "012",
+      ],
+    ],
   },
 }
 `;
@@ -106,6 +136,7 @@ exports[`RhsmHelpers billingMetrics should return parsed API responses in a cons
     "hasUniqueProviders": false,
     "numberProviders": 0,
     "providers": [],
+    "uniqueAccountsProvidersList": [],
   },
   "loremApi": {
     "accounts": [
@@ -122,6 +153,12 @@ exports[`RhsmHelpers billingMetrics should return parsed API responses in a cons
     "hasUniqueProviders": false,
     "numberProviders": 1,
     "providers": [],
+    "uniqueAccountsProvidersList": [
+      [
+        "lorem",
+        "123",
+      ],
+    ],
   },
 }
 `;
@@ -137,6 +174,7 @@ exports[`RhsmHelpers billingMetrics should return parsed API responses in a cons
     "hasUniqueProviders": false,
     "numberProviders": 0,
     "providers": [],
+    "uniqueAccountsProvidersList": [],
   },
   "loremApi": {
     "accounts": [
@@ -178,6 +216,20 @@ exports[`RhsmHelpers billingMetrics should return parsed API responses in a cons
         "provider": "lorem",
         "type": "loremApi",
       },
+    ],
+    "uniqueAccountsProvidersList": [
+      [
+        "lorem",
+        "123",
+      ],
+      [
+        "lorem",
+        "456",
+      ],
+      [
+        "lorem",
+        "012",
+      ],
     ],
   },
 }
@@ -194,6 +246,7 @@ exports[`RhsmHelpers billingMetrics should return parsed API responses in a cons
     "hasUniqueProviders": false,
     "numberProviders": 0,
     "providers": [],
+    "uniqueAccountsProvidersList": [],
   },
   "loremApi": {
     "accounts": [
@@ -215,6 +268,12 @@ exports[`RhsmHelpers billingMetrics should return parsed API responses in a cons
         "provider": "lorem",
         "type": "loremApi",
       },
+    ],
+    "uniqueAccountsProvidersList": [
+      [
+        "lorem",
+        "123",
+      ],
     ],
   },
 }

--- a/src/services/rhsm/__tests__/__snapshots__/rhsmTransformers.test.js.snap
+++ b/src/services/rhsm/__tests__/__snapshots__/rhsmTransformers.test.js.snap
@@ -986,6 +986,24 @@ exports[`RHSM Transformers should attempt to parse multiple billing account id r
           "type": "unknown",
         },
       ],
+      "uniqueAccountsProvidersList": [
+        [
+          "mockProvider",
+          "678910",
+        ],
+        [
+          "mockProvider",
+          "12345",
+        ],
+        [
+          "otherMockProvider",
+          "78910",
+        ],
+        [
+          "otherMockProvider",
+          "12345",
+        ],
+      ],
     },
   },
   "usageMetrics": {},

--- a/src/services/rhsm/rhsmHelpers.js
+++ b/src/services/rhsm/rhsmHelpers.js
@@ -34,10 +34,15 @@ const billingMetrics = (baseMetrics = {}) => {
     const aggregatedAccountsProviders = [...uniqueAccounts, ...uniqueProviders];
 
     const filterAggregatedAccountsProviders = {};
+    const uniqueAccountsProvidersList = [];
 
     aggregatedAccountsProviders.forEach(({ id, provider }) => {
       filterAggregatedAccountsProviders[provider] ??= new Set();
       filterAggregatedAccountsProviders[provider].add(id);
+    });
+
+    Object.entries(filterAggregatedAccountsProviders).forEach(([key, value]) => {
+      Array.from(value).forEach(valueId => uniqueAccountsProvidersList.push([key, valueId]));
     });
 
     const numberProviders = Object.keys(filterAggregatedAccountsProviders).length;
@@ -54,7 +59,8 @@ const billingMetrics = (baseMetrics = {}) => {
       firstProvider,
       firstProviderAccount,
       firstProviderNumberAccounts,
-      numberProviders
+      numberProviders,
+      uniqueAccountsProvidersList
     };
   });
 


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(rhsmHelpers): sw-3519 expose unique accounts, providers

### Notes
- minor helper adjustment to expose a unique listing of account, providers for potential consumption
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. next...
-->

### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. confirm tests come back clean

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-3519
