### PR TITLE
fix(locale): sw-3519 unique provider names context

### DIFF
--- a/public/locales/en-US.json
+++ b/public/locales/en-US.json
@@ -8,8 +8,8 @@
   "curiosity-banner": {
     "usage_title": "Usage that has no matching subscription was found for $t(curiosity-view.title_{{product}})",
     "usage_description": "Usage that has no matching subscription is being reported. <1>Learn more about resolving this issue</1>",
-    "usage_description_one": "Usage that has no matching subscription is being reported for <0>$t(curiosity-toolbar.label_billing_provider_{{provider}})</0> billing account <0>{{account}}</0>. <1>Learn more about resolving this issue</1>",
-    "usage_description_other": "Usage that has no matching subscription is being reported for <0>$t(curiosity-toolbar.label_billing_provider_{{provider}})</0> billing account <0>{{account}}</0>, and <0>{{remaining}}</0>. <1>Learn more about resolving this issue</1>",
+    "usage_description_one": "Usage that has no matching subscription is being reported for <0>{{provider}}</0> billing account <0>{{account}}</0>. <1>Learn more about resolving this issue</1>",
+    "usage_description_other": "Usage that has no matching subscription is being reported for <0>{{provider}}</0> billing account <0>{{account}}</0>, and <0>{{remaining}}</0>. <1>Learn more about resolving this issue</1>",
     "usage_description_remaining": "{{count}} more",
     "usage_description_remaining_one": "{{count}} more account",
     "usage_description_remaining_other": "{{count}} more accounts",

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -338,6 +338,10 @@ exports[`I18n Component should generate a predictable locale key output snapshot
         "key": "curiosity-banner.usage",
         "match": "t('curiosity-banner.usage', { context: ['description', 'remaining', numberProviders >= 2 && 'provider'], count: (numberProviders === 2 && 1)",
       },
+      {
+        "key": "curiosity-toolbar.label",
+        "match": "t('curiosity-toolbar.label', { context: ['billing_provider', (firstProvider === '' && 'none')",
+      },
     ],
   },
   {
@@ -1173,6 +1177,10 @@ exports[`I18n Component should have locale keys that exist in the default langua
   {
     "file": "src/components/productView/productViewOnloadContext.js",
     "key": "curiosity-banner.usage",
+  },
+  {
+    "file": "src/components/productView/productViewOnloadContext.js",
+    "key": "curiosity-toolbar.label",
   },
   {
     "file": "src/components/toolbar/toolbar.js",

--- a/src/components/productView/productViewOnloadContext.js
+++ b/src/components/productView/productViewOnloadContext.js
@@ -102,7 +102,10 @@ const useUsageBanner = ({
                 (firstProviderNumberAccounts > 2 && firstProviderNumberAccounts - 1) ||
                 0
             }),
-            provider: firstProvider,
+            provider: t('curiosity-toolbar.label', {
+              context: ['billing_provider', (firstProvider === '' && 'none') || firstProvider],
+              value: firstProvider
+            }),
             account: firstProviderAccount
           },
           [


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(locale): sw-3519 unique provider names context

### Notes
- minor locale context issue, adjustment
- similar to issue resolved in #1583 for sw-3513 where unique "provider names" display in "unique ways"
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. confirm the staging provider name `_ANY` displays as intended within the banner message
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-3519 
related sw-3513