### PR TITLE
fix(config): sw-3519 instances tooltip for billing accounts

### DIFF
--- a/public/locales/en-US.json
+++ b/public/locales/en-US.json
@@ -347,7 +347,10 @@
     "table_ariaLabel_skeleton": "Loading",
     "table_summary": "A generated table with one level of column headers.",
     "table_emptyState_description": "To show more results, clear some or all filters.",
-    "table_emptyState_title": "No results found"
+    "table_emptyState_title": "No results found",
+    "tooltip_header_billing_provider": "Hover over a billing provider name to display the related billing account.",
+    "tooltip_cell_billing_provider": "{{provider}} billing account {{account}}",
+    "tooltip_cell_billing_provider_none": "Billing account {{account}}"
   },
   "curiosity-toolbar": {
     "button_displayName": "Search button for name",

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -691,8 +691,16 @@ exports[`I18n Component should generate a predictable locale key output snapshot
         "match": "translate('curiosity-inventory.guestsHeader', { context: [INVENTORY_TYPES.DISPLAY_NAME] })",
       },
       {
-        "key": "",
-        "match": "translate(\`curiosity-inventory.label_\${INVENTORY_TYPES.BILLING_PROVIDER}\`, { context: provider || 'none' })",
+        "key": "curiosity-inventory.tooltip",
+        "match": "translate(\`curiosity-inventory.tooltip\`, { context: ['header', INVENTORY_TYPES.BILLING_PROVIDER] })",
+      },
+      {
+        "key": "curiosity-inventory.tooltip",
+        "match": "translate(\`curiosity-inventory.tooltip\`, { context: ['cell', INVENTORY_TYPES.BILLING_PROVIDER, !provider && 'none'], provider: translate('curiosity-inventory.label', { context: [INVENTORY_TYPES.BILLING_PROVIDER, provider] })",
+      },
+      {
+        "key": "curiosity-inventory.label",
+        "match": "translate('curiosity-inventory.label', { context: [INVENTORY_TYPES.BILLING_PROVIDER, provider || 'none'] })",
       },
       {
         "key": "curiosity-inventory.measurement",
@@ -801,8 +809,16 @@ exports[`I18n Component should generate a predictable locale key output snapshot
         "match": "translate('curiosity-inventory.label', { context: 'numberOfGuests', count: numberOfGuests }, [ <PfLabel color="blue" /> ])",
       },
       {
-        "key": "",
-        "match": "translate(\`curiosity-inventory.label_\${INVENTORY_TYPES.BILLING_PROVIDER}\`, { context: provider || 'none' })",
+        "key": "curiosity-inventory.tooltip",
+        "match": "translate(\`curiosity-inventory.tooltip\`, { context: ['header', INVENTORY_TYPES.BILLING_PROVIDER] })",
+      },
+      {
+        "key": "curiosity-inventory.tooltip",
+        "match": "translate(\`curiosity-inventory.tooltip\`, { context: ['cell', INVENTORY_TYPES.BILLING_PROVIDER, !provider && 'none'], provider: translate('curiosity-inventory.label', { context: [INVENTORY_TYPES.BILLING_PROVIDER, provider] })",
+      },
+      {
+        "key": "curiosity-inventory.label",
+        "match": "translate('curiosity-inventory.label', { context: [INVENTORY_TYPES.BILLING_PROVIDER, provider || 'none'] })",
       },
       {
         "key": "curiosity-inventory.measurement",
@@ -858,8 +874,16 @@ exports[`I18n Component should generate a predictable locale key output snapshot
         "match": "translate('curiosity-inventory.label', { context: 'numberOfGuests', count: numberOfGuests }, [ <PfLabel color="blue" /> ])",
       },
       {
-        "key": "",
-        "match": "translate(\`curiosity-inventory.label_\${INVENTORY_TYPES.BILLING_PROVIDER}\`, { context: provider || 'none' })",
+        "key": "curiosity-inventory.tooltip",
+        "match": "translate(\`curiosity-inventory.tooltip\`, { context: ['header', INVENTORY_TYPES.BILLING_PROVIDER] })",
+      },
+      {
+        "key": "curiosity-inventory.tooltip",
+        "match": "translate(\`curiosity-inventory.tooltip\`, { context: ['cell', INVENTORY_TYPES.BILLING_PROVIDER, !provider && 'none'], provider: translate('curiosity-inventory.label', { context: [INVENTORY_TYPES.BILLING_PROVIDER, provider] })",
+      },
+      {
+        "key": "curiosity-inventory.label",
+        "match": "translate('curiosity-inventory.label', { context: [INVENTORY_TYPES.BILLING_PROVIDER, provider || 'none'] })",
       },
       {
         "key": "curiosity-inventory.measurement",
@@ -891,8 +915,16 @@ exports[`I18n Component should generate a predictable locale key output snapshot
         "match": "translate('curiosity-inventory.guestsHeader', { context: [INVENTORY_TYPES.DISPLAY_NAME] })",
       },
       {
-        "key": "",
-        "match": "translate(\`curiosity-inventory.label_\${INVENTORY_TYPES.BILLING_PROVIDER}\`, { context: provider || 'none' })",
+        "key": "curiosity-inventory.tooltip",
+        "match": "translate(\`curiosity-inventory.tooltip\`, { context: ['header', INVENTORY_TYPES.BILLING_PROVIDER] })",
+      },
+      {
+        "key": "curiosity-inventory.tooltip",
+        "match": "translate(\`curiosity-inventory.tooltip\`, { context: ['cell', INVENTORY_TYPES.BILLING_PROVIDER, !provider && 'none'], provider: translate('curiosity-inventory.label', { context: [INVENTORY_TYPES.BILLING_PROVIDER, provider] })",
+      },
+      {
+        "key": "curiosity-inventory.label",
+        "match": "translate('curiosity-inventory.label', { context: [INVENTORY_TYPES.BILLING_PROVIDER, provider || 'none'] })",
       },
       {
         "key": "curiosity-inventory.measurement",
@@ -944,8 +976,16 @@ exports[`I18n Component should generate a predictable locale key output snapshot
         "match": "translate('curiosity-graph.label_axisX', { context: GRANULARITY_TYPES.DAILY })",
       },
       {
-        "key": "",
-        "match": "translate(\`curiosity-inventory.label_\${INVENTORY_TYPES.BILLING_PROVIDER}\`, { context: provider || 'none' })",
+        "key": "curiosity-inventory.tooltip",
+        "match": "translate(\`curiosity-inventory.tooltip\`, { context: ['header', INVENTORY_TYPES.BILLING_PROVIDER] })",
+      },
+      {
+        "key": "curiosity-inventory.tooltip",
+        "match": "translate(\`curiosity-inventory.tooltip\`, { context: ['cell', INVENTORY_TYPES.BILLING_PROVIDER, !provider && 'none'], provider: translate('curiosity-inventory.label', { context: [INVENTORY_TYPES.BILLING_PROVIDER, provider] })",
+      },
+      {
+        "key": "curiosity-inventory.label",
+        "match": "translate('curiosity-inventory.label', { context: [INVENTORY_TYPES.BILLING_PROVIDER, provider || 'none'] })",
       },
       {
         "key": "curiosity-inventory.measurement",
@@ -1034,6 +1074,14 @@ exports[`I18n Component should generate a predictable locale key output snapshot
         "match": "translate('curiosity-graph.label_axisX', { context: GRANULARITY_TYPES.DAILY })",
       },
       {
+        "key": "curiosity-inventory.tooltip",
+        "match": "translate(\`curiosity-inventory.tooltip\`, { context: ['header', INVENTORY_TYPES.BILLING_PROVIDER] })",
+      },
+      {
+        "key": "curiosity-inventory.tooltip",
+        "match": "translate(\`curiosity-inventory.tooltip\`, { context: ['cell', INVENTORY_TYPES.BILLING_PROVIDER, !provider && 'none'], provider: translate('curiosity-inventory.label', { context: [INVENTORY_TYPES.BILLING_PROVIDER, provider] })",
+      },
+      {
         "key": "curiosity-inventory.label",
         "match": "translate('curiosity-inventory.label', { context: [INVENTORY_TYPES.BILLING_PROVIDER, provider || 'none'] })",
       },
@@ -1091,8 +1139,16 @@ exports[`I18n Component should generate a predictable locale key output snapshot
         "match": "translate('curiosity-graph.label_axisX', { context: GRANULARITY_TYPES.DAILY })",
       },
       {
-        "key": "",
-        "match": "translate(\`curiosity-inventory.label_\${INVENTORY_TYPES.BILLING_PROVIDER}\`, { context: provider || 'none' })",
+        "key": "curiosity-inventory.tooltip",
+        "match": "translate(\`curiosity-inventory.tooltip\`, { context: ['header', INVENTORY_TYPES.BILLING_PROVIDER] })",
+      },
+      {
+        "key": "curiosity-inventory.tooltip",
+        "match": "translate(\`curiosity-inventory.tooltip\`, { context: ['cell', INVENTORY_TYPES.BILLING_PROVIDER, !provider && 'none'], provider: translate('curiosity-inventory.label', { context: [INVENTORY_TYPES.BILLING_PROVIDER, provider] })",
+      },
+      {
+        "key": "curiosity-inventory.label",
+        "match": "translate('curiosity-inventory.label', { context: [INVENTORY_TYPES.BILLING_PROVIDER, provider || 'none'] })",
       },
       {
         "key": "curiosity-inventory.measurement",
@@ -1136,8 +1192,16 @@ exports[`I18n Component should generate a predictable locale key output snapshot
         "match": "translate('curiosity-inventory.guestsHeader', { context: [INVENTORY_TYPES.DISPLAY_NAME] })",
       },
       {
-        "key": "",
-        "match": "translate(\`curiosity-inventory.label_\${INVENTORY_TYPES.BILLING_PROVIDER}\`, { context: provider || 'none' })",
+        "key": "curiosity-inventory.tooltip",
+        "match": "translate(\`curiosity-inventory.tooltip\`, { context: ['header', INVENTORY_TYPES.BILLING_PROVIDER] })",
+      },
+      {
+        "key": "curiosity-inventory.tooltip",
+        "match": "translate(\`curiosity-inventory.tooltip\`, { context: ['cell', INVENTORY_TYPES.BILLING_PROVIDER, !provider && 'none'], provider: translate('curiosity-inventory.label', { context: [INVENTORY_TYPES.BILLING_PROVIDER, provider] })",
+      },
+      {
+        "key": "curiosity-inventory.label",
+        "match": "translate('curiosity-inventory.label', { context: [INVENTORY_TYPES.BILLING_PROVIDER, provider || 'none'] })",
       },
       {
         "key": "curiosity-inventory.measurement",
@@ -1406,6 +1470,18 @@ exports[`I18n Component should have locale keys that exist in the default langua
   },
   {
     "file": "src/config/product.ansible.js",
+    "key": "curiosity-inventory.tooltip",
+  },
+  {
+    "file": "src/config/product.ansible.js",
+    "key": "curiosity-inventory.tooltip",
+  },
+  {
+    "file": "src/config/product.ansible.js",
+    "key": "curiosity-inventory.label",
+  },
+  {
+    "file": "src/config/product.ansible.js",
     "key": "curiosity-inventory.label",
   },
   {
@@ -1445,6 +1521,18 @@ exports[`I18n Component should have locale keys that exist in the default langua
     "key": "curiosity-inventory.label",
   },
   {
+    "file": "src/config/product.openshiftDedicated.js",
+    "key": "curiosity-inventory.tooltip",
+  },
+  {
+    "file": "src/config/product.openshiftDedicated.js",
+    "key": "curiosity-inventory.tooltip",
+  },
+  {
+    "file": "src/config/product.openshiftDedicated.js",
+    "key": "curiosity-inventory.label",
+  },
+  {
     "file": "src/config/product.openshiftMetrics.js",
     "key": "curiosity-graph.label_axisY",
   },
@@ -1455,6 +1543,18 @@ exports[`I18n Component should have locale keys that exist in the default langua
   {
     "file": "src/config/product.openshiftMetrics.js",
     "key": "curiosity-inventory.guestsHeader",
+  },
+  {
+    "file": "src/config/product.openshiftMetrics.js",
+    "key": "curiosity-inventory.label",
+  },
+  {
+    "file": "src/config/product.openshiftMetrics.js",
+    "key": "curiosity-inventory.tooltip",
+  },
+  {
+    "file": "src/config/product.openshiftMetrics.js",
+    "key": "curiosity-inventory.tooltip",
   },
   {
     "file": "src/config/product.openshiftMetrics.js",
@@ -1467,6 +1567,18 @@ exports[`I18n Component should have locale keys that exist in the default langua
   {
     "file": "src/config/product.rhacm.js",
     "key": "curiosity-inventory.guestsHeader",
+  },
+  {
+    "file": "src/config/product.rhacm.js",
+    "key": "curiosity-inventory.tooltip",
+  },
+  {
+    "file": "src/config/product.rhacm.js",
+    "key": "curiosity-inventory.tooltip",
+  },
+  {
+    "file": "src/config/product.rhacm.js",
+    "key": "curiosity-inventory.label",
   },
   {
     "file": "src/config/product.rhacm.js",
@@ -1479,6 +1591,18 @@ exports[`I18n Component should have locale keys that exist in the default langua
   {
     "file": "src/config/product.rhacs.js",
     "key": "curiosity-graph.label_axisX",
+  },
+  {
+    "file": "src/config/product.rhacs.js",
+    "key": "curiosity-inventory.tooltip",
+  },
+  {
+    "file": "src/config/product.rhacs.js",
+    "key": "curiosity-inventory.tooltip",
+  },
+  {
+    "file": "src/config/product.rhacs.js",
+    "key": "curiosity-inventory.label",
   },
   {
     "file": "src/config/product.rhacs.js",
@@ -1507,6 +1631,14 @@ exports[`I18n Component should have locale keys that exist in the default langua
   {
     "file": "src/config/product.rhelElsPayg.js",
     "key": "curiosity-graph.label_axisX",
+  },
+  {
+    "file": "src/config/product.rhelElsPayg.js",
+    "key": "curiosity-inventory.tooltip",
+  },
+  {
+    "file": "src/config/product.rhelElsPayg.js",
+    "key": "curiosity-inventory.tooltip",
   },
   {
     "file": "src/config/product.rhelElsPayg.js",
@@ -1527,6 +1659,18 @@ exports[`I18n Component should have locale keys that exist in the default langua
   {
     "file": "src/config/product.rhods.js",
     "key": "curiosity-graph.label_axisX",
+  },
+  {
+    "file": "src/config/product.rhods.js",
+    "key": "curiosity-inventory.tooltip",
+  },
+  {
+    "file": "src/config/product.rhods.js",
+    "key": "curiosity-inventory.tooltip",
+  },
+  {
+    "file": "src/config/product.rhods.js",
+    "key": "curiosity-inventory.label",
   },
   {
     "file": "src/config/product.rhods.js",
@@ -1539,6 +1683,18 @@ exports[`I18n Component should have locale keys that exist in the default langua
   {
     "file": "src/config/product.rosa.js",
     "key": "curiosity-inventory.guestsHeader",
+  },
+  {
+    "file": "src/config/product.rosa.js",
+    "key": "curiosity-inventory.tooltip",
+  },
+  {
+    "file": "src/config/product.rosa.js",
+    "key": "curiosity-inventory.tooltip",
+  },
+  {
+    "file": "src/config/product.rosa.js",
+    "key": "curiosity-inventory.label",
   },
   {
     "file": "src/config/product.rosa.js",

--- a/src/components/tooltip/__tests__/__snapshots__/tooltip.test.js.snap
+++ b/src/components/tooltip/__tests__/__snapshots__/tooltip.test.js.snap
@@ -14,8 +14,12 @@ exports[`Tooltip Component should allow custom properties: custom, content 1`] =
   exitDelay={0}
   position="top"
 >
-  <div>
-    content
+  <div
+    className="curiosity-tooltip-content"
+  >
+    <div>
+      content
+    </div>
   </div>
 </Tooltip>
 `;
@@ -31,11 +35,15 @@ exports[`Tooltip Component should render a basic component: basic 1`] = `
   <div
     style="display: contents;"
   >
-    <span
-      class="curiosity-tooltip-children"
+    <div
+      class="curiosity-tooltip-content"
     >
-      hello world
-    </span>
+      <span
+        class="curiosity-tooltip-children"
+      >
+        hello world
+      </span>
+    </div>
   </div>
 </tooltip>
 `;

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -43,7 +43,9 @@ const Tooltip = ({
     position={position}
     {...props}
   >
-    {(React.isValidElement(children) && children) || <span className="curiosity-tooltip-children">{children}</span>}
+    <div className="curiosity-tooltip-content">
+      {(React.isValidElement(children) && children) || <span className="curiosity-tooltip-children">{children}</span>}
+    </div>
   </PfTooltip>
 );
 

--- a/src/config/__tests__/__snapshots__/product.config.test.js.snap
+++ b/src/config/__tests__/__snapshots__/product.config.test.js.snap
@@ -4545,7 +4545,9 @@ exports[`Product specific configurations should apply variations in inventory fi
         {
           "cell": [Function],
           "content": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"ansible-aap-managed"})",
-          "info": undefined,
+          "info": {
+            "tooltip": "t(curiosity-inventory.tooltip_header_billing, {"context":"provider"})",
+          },
           "isSort": true,
           "isWrap": true,
           "label": [Function],
@@ -4599,9 +4601,16 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.label_billing_provider, {"context":"none"})",
+              "content": <Tooltip
+                content="t(curiosity-inventory.tooltip_cell_billing_provider, {"context":"none","provider":"t(curiosity-inventory.label_billing, {\\"context\\":\\"provider\\"})"})"
+              >
+                t(curiosity-inventory.label_billing_provider, {"context":"none"})
+              </Tooltip>,
               "dataLabel": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"ansible-aap-managed"})",
               "header": [Function],
+              "info": {
+                "tooltip": [Function],
+              },
               "isSort": true,
               "isWrap": true,
               "metric": "billing_provider",
@@ -4782,7 +4791,9 @@ exports[`Product specific configurations should apply variations in inventory fi
         {
           "cell": [Function],
           "content": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"OpenShift-dedicated-metrics"})",
-          "info": undefined,
+          "info": {
+            "tooltip": "t(curiosity-inventory.tooltip_header_billing, {"context":"provider"})",
+          },
           "isSort": true,
           "isWrap": true,
           "label": [Function],
@@ -4847,9 +4858,16 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.label_billing_provider, {"context":"none"})",
+              "content": <Tooltip
+                content="t(curiosity-inventory.tooltip_cell_billing_provider, {"context":"none","provider":"t(curiosity-inventory.label_billing, {\\"context\\":\\"provider\\"})"})"
+              >
+                t(curiosity-inventory.label_billing_provider, {"context":"none"})
+              </Tooltip>,
               "dataLabel": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"OpenShift-dedicated-metrics"})",
               "header": [Function],
+              "info": {
+                "tooltip": [Function],
+              },
               "isSort": true,
               "isWrap": true,
               "metric": "billing_provider",
@@ -4916,7 +4934,9 @@ exports[`Product specific configurations should apply variations in inventory fi
         {
           "cell": [Function],
           "content": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"OpenShift-metrics"})",
-          "info": undefined,
+          "info": {
+            "tooltip": "t(curiosity-inventory.tooltip_header_billing, {"context":"provider"})",
+          },
           "isSort": true,
           "isWrap": true,
           "label": [Function],
@@ -4970,9 +4990,16 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.label_billing_provider, {"context":"none"})",
+              "content": <Tooltip
+                content="t(curiosity-inventory.tooltip_cell_billing_provider, {"context":"none","provider":"t(curiosity-inventory.label_billing, {\\"context\\":\\"provider\\"})"})"
+              >
+                t(curiosity-inventory.label_billing_provider, {"context":"none"})
+              </Tooltip>,
               "dataLabel": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"OpenShift-metrics"})",
               "header": [Function],
+              "info": {
+                "tooltip": [Function],
+              },
               "isSort": true,
               "isWrap": true,
               "metric": "billing_provider",
@@ -5030,7 +5057,9 @@ exports[`Product specific configurations should apply variations in inventory fi
         {
           "cell": [Function],
           "content": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"rhacm"})",
-          "info": undefined,
+          "info": {
+            "tooltip": "t(curiosity-inventory.tooltip_header_billing, {"context":"provider"})",
+          },
           "isSort": true,
           "isWrap": true,
           "label": [Function],
@@ -5080,9 +5109,16 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.label_billing_provider, {"context":"none"})",
+              "content": <Tooltip
+                content="t(curiosity-inventory.tooltip_cell_billing_provider, {"context":"none","provider":"t(curiosity-inventory.label_billing, {\\"context\\":\\"provider\\"})"})"
+              >
+                t(curiosity-inventory.label_billing_provider, {"context":"none"})
+              </Tooltip>,
               "dataLabel": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"rhacm"})",
               "header": [Function],
+              "info": {
+                "tooltip": [Function],
+              },
               "isSort": true,
               "isWrap": true,
               "metric": "billing_provider",
@@ -5140,7 +5176,9 @@ exports[`Product specific configurations should apply variations in inventory fi
         {
           "cell": [Function],
           "content": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"rhacs"})",
-          "info": undefined,
+          "info": {
+            "tooltip": "t(curiosity-inventory.tooltip_header_billing, {"context":"provider"})",
+          },
           "isSort": true,
           "isWrap": true,
           "label": [Function],
@@ -5190,9 +5228,16 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.label_billing_provider, {"context":"none"})",
+              "content": <Tooltip
+                content="t(curiosity-inventory.tooltip_cell_billing_provider, {"context":"none","provider":"t(curiosity-inventory.label_billing, {\\"context\\":\\"provider\\"})"})"
+              >
+                t(curiosity-inventory.label_billing_provider, {"context":"none"})
+              </Tooltip>,
               "dataLabel": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"rhacs"})",
               "header": [Function],
+              "info": {
+                "tooltip": [Function],
+              },
               "isSort": true,
               "isWrap": true,
               "metric": "billing_provider",
@@ -5377,10 +5422,14 @@ exports[`Product specific configurations should apply variations in inventory fi
         {
           "cell": [Function],
           "content": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"rhel-for-x86-els-payg"})",
-          "info": undefined,
+          "info": {
+            "tooltip": "t(curiosity-inventory.tooltip_header_billing, {"context":"provider"})",
+          },
           "isSort": true,
+          "isWrap": true,
           "label": [Function],
           "metric": "billing_provider",
+          "modifier": "wrap",
           "width": 20,
         },
         {
@@ -5418,10 +5467,18 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.label_billing_provider, {"context":"none"})",
+              "content": <Tooltip
+                content="t(curiosity-inventory.tooltip_cell_billing_provider, {"context":"none","provider":"t(curiosity-inventory.label_billing, {\\"context\\":\\"provider\\"})"})"
+              >
+                t(curiosity-inventory.label_billing_provider, {"context":"none"})
+              </Tooltip>,
               "dataLabel": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"rhel-for-x86-els-payg"})",
               "header": [Function],
+              "info": {
+                "tooltip": [Function],
+              },
               "isSort": true,
+              "isWrap": true,
               "metric": "billing_provider",
               "width": 20,
             },
@@ -5477,7 +5534,9 @@ exports[`Product specific configurations should apply variations in inventory fi
         {
           "cell": [Function],
           "content": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"rhods"})",
-          "info": undefined,
+          "info": {
+            "tooltip": "t(curiosity-inventory.tooltip_header_billing, {"context":"provider"})",
+          },
           "isSort": true,
           "isWrap": true,
           "label": [Function],
@@ -5520,9 +5579,16 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.label_billing_provider, {"context":"none"})",
+              "content": <Tooltip
+                content="t(curiosity-inventory.tooltip_cell_billing_provider, {"context":"none","provider":"t(curiosity-inventory.label_billing, {\\"context\\":\\"provider\\"})"})"
+              >
+                t(curiosity-inventory.label_billing_provider, {"context":"none"})
+              </Tooltip>,
               "dataLabel": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"rhods"})",
               "header": [Function],
+              "info": {
+                "tooltip": [Function],
+              },
               "isSort": true,
               "isWrap": true,
               "metric": "billing_provider",
@@ -5580,7 +5646,9 @@ exports[`Product specific configurations should apply variations in inventory fi
         {
           "cell": [Function],
           "content": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"rosa"})",
-          "info": undefined,
+          "info": {
+            "tooltip": "t(curiosity-inventory.tooltip_header_billing, {"context":"provider"})",
+          },
           "isSort": true,
           "isWrap": true,
           "label": [Function],
@@ -5641,9 +5709,16 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.label_billing_provider, {"context":"none"})",
+              "content": <Tooltip
+                content="t(curiosity-inventory.tooltip_cell_billing_provider, {"context":"none","provider":"t(curiosity-inventory.label_billing, {\\"context\\":\\"provider\\"})"})"
+              >
+                t(curiosity-inventory.label_billing_provider, {"context":"none"})
+              </Tooltip>,
               "dataLabel": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"rosa"})",
               "header": [Function],
+              "info": {
+                "tooltip": [Function],
+              },
               "isSort": true,
               "isWrap": true,
               "metric": "billing_provider",
@@ -5858,7 +5933,9 @@ exports[`Product specific configurations should apply variations in inventory fi
         {
           "cell": [Function],
           "content": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"ansible-aap-managed"})",
-          "info": undefined,
+          "info": {
+            "tooltip": "t(curiosity-inventory.tooltip_header_billing, {"context":"provider"})",
+          },
           "isSort": true,
           "isWrap": true,
           "label": [Function],
@@ -5912,9 +5989,16 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.label_billing_provider, {"context":"none"})",
+              "content": <Tooltip
+                content="t(curiosity-inventory.tooltip_cell_billing_provider, {"context":"none","provider":"t(curiosity-inventory.label_billing, {\\"context\\":\\"provider\\"})"})"
+              >
+                t(curiosity-inventory.label_billing_provider, {"context":"none"})
+              </Tooltip>,
               "dataLabel": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"ansible-aap-managed"})",
               "header": [Function],
+              "info": {
+                "tooltip": [Function],
+              },
               "isSort": true,
               "isWrap": true,
               "metric": "billing_provider",
@@ -6088,7 +6172,9 @@ exports[`Product specific configurations should apply variations in inventory fi
         {
           "cell": [Function],
           "content": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"OpenShift-dedicated-metrics"})",
-          "info": undefined,
+          "info": {
+            "tooltip": "t(curiosity-inventory.tooltip_header_billing, {"context":"provider"})",
+          },
           "isSort": true,
           "isWrap": true,
           "label": [Function],
@@ -6146,9 +6232,16 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.label_billing_provider, {"context":"none"})",
+              "content": <Tooltip
+                content="t(curiosity-inventory.tooltip_cell_billing_provider, {"context":"none","provider":"t(curiosity-inventory.label_billing, {\\"context\\":\\"provider\\"})"})"
+              >
+                t(curiosity-inventory.label_billing_provider, {"context":"none"})
+              </Tooltip>,
               "dataLabel": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"OpenShift-dedicated-metrics"})",
               "header": [Function],
+              "info": {
+                "tooltip": [Function],
+              },
               "isSort": true,
               "isWrap": true,
               "metric": "billing_provider",
@@ -6215,7 +6308,9 @@ exports[`Product specific configurations should apply variations in inventory fi
         {
           "cell": [Function],
           "content": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"OpenShift-metrics"})",
-          "info": undefined,
+          "info": {
+            "tooltip": "t(curiosity-inventory.tooltip_header_billing, {"context":"provider"})",
+          },
           "isSort": true,
           "isWrap": true,
           "label": [Function],
@@ -6262,9 +6357,16 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.label_billing_provider, {"context":"none"})",
+              "content": <Tooltip
+                content="t(curiosity-inventory.tooltip_cell_billing_provider, {"context":"none","provider":"t(curiosity-inventory.label_billing, {\\"context\\":\\"provider\\"})"})"
+              >
+                t(curiosity-inventory.label_billing_provider, {"context":"none"})
+              </Tooltip>,
               "dataLabel": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"OpenShift-metrics"})",
               "header": [Function],
+              "info": {
+                "tooltip": [Function],
+              },
               "isSort": true,
               "isWrap": true,
               "metric": "billing_provider",
@@ -6322,7 +6424,9 @@ exports[`Product specific configurations should apply variations in inventory fi
         {
           "cell": [Function],
           "content": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"rhacm"})",
-          "info": undefined,
+          "info": {
+            "tooltip": "t(curiosity-inventory.tooltip_header_billing, {"context":"provider"})",
+          },
           "isSort": true,
           "isWrap": true,
           "label": [Function],
@@ -6365,9 +6469,16 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.label_billing_provider, {"context":"none"})",
+              "content": <Tooltip
+                content="t(curiosity-inventory.tooltip_cell_billing_provider, {"context":"none","provider":"t(curiosity-inventory.label_billing, {\\"context\\":\\"provider\\"})"})"
+              >
+                t(curiosity-inventory.label_billing_provider, {"context":"none"})
+              </Tooltip>,
               "dataLabel": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"rhacm"})",
               "header": [Function],
+              "info": {
+                "tooltip": [Function],
+              },
               "isSort": true,
               "isWrap": true,
               "metric": "billing_provider",
@@ -6425,7 +6536,9 @@ exports[`Product specific configurations should apply variations in inventory fi
         {
           "cell": [Function],
           "content": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"rhacs"})",
-          "info": undefined,
+          "info": {
+            "tooltip": "t(curiosity-inventory.tooltip_header_billing, {"context":"provider"})",
+          },
           "isSort": true,
           "isWrap": true,
           "label": [Function],
@@ -6468,9 +6581,16 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.label_billing_provider, {"context":"none"})",
+              "content": <Tooltip
+                content="t(curiosity-inventory.tooltip_cell_billing_provider, {"context":"none","provider":"t(curiosity-inventory.label_billing, {\\"context\\":\\"provider\\"})"})"
+              >
+                t(curiosity-inventory.label_billing_provider, {"context":"none"})
+              </Tooltip>,
               "dataLabel": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"rhacs"})",
               "header": [Function],
+              "info": {
+                "tooltip": [Function],
+              },
               "isSort": true,
               "isWrap": true,
               "metric": "billing_provider",
@@ -6648,10 +6768,14 @@ exports[`Product specific configurations should apply variations in inventory fi
         {
           "cell": [Function],
           "content": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"rhel-for-x86-els-payg"})",
-          "info": undefined,
+          "info": {
+            "tooltip": "t(curiosity-inventory.tooltip_header_billing, {"context":"provider"})",
+          },
           "isSort": true,
+          "isWrap": true,
           "label": [Function],
           "metric": "billing_provider",
+          "modifier": "wrap",
           "width": 20,
         },
         {
@@ -6689,10 +6813,18 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.label_billing_provider, {"context":"none"})",
+              "content": <Tooltip
+                content="t(curiosity-inventory.tooltip_cell_billing_provider, {"context":"none","provider":"t(curiosity-inventory.label_billing, {\\"context\\":\\"provider\\"})"})"
+              >
+                t(curiosity-inventory.label_billing_provider, {"context":"none"})
+              </Tooltip>,
               "dataLabel": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"rhel-for-x86-els-payg"})",
               "header": [Function],
+              "info": {
+                "tooltip": [Function],
+              },
               "isSort": true,
+              "isWrap": true,
               "metric": "billing_provider",
               "width": 20,
             },
@@ -6748,7 +6880,9 @@ exports[`Product specific configurations should apply variations in inventory fi
         {
           "cell": [Function],
           "content": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"rhods"})",
-          "info": undefined,
+          "info": {
+            "tooltip": "t(curiosity-inventory.tooltip_header_billing, {"context":"provider"})",
+          },
           "isSort": true,
           "isWrap": true,
           "label": [Function],
@@ -6791,9 +6925,16 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.label_billing_provider, {"context":"none"})",
+              "content": <Tooltip
+                content="t(curiosity-inventory.tooltip_cell_billing_provider, {"context":"none","provider":"t(curiosity-inventory.label_billing, {\\"context\\":\\"provider\\"})"})"
+              >
+                t(curiosity-inventory.label_billing_provider, {"context":"none"})
+              </Tooltip>,
               "dataLabel": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"rhods"})",
               "header": [Function],
+              "info": {
+                "tooltip": [Function],
+              },
               "isSort": true,
               "isWrap": true,
               "metric": "billing_provider",
@@ -6851,7 +6992,9 @@ exports[`Product specific configurations should apply variations in inventory fi
         {
           "cell": [Function],
           "content": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"rosa"})",
-          "info": undefined,
+          "info": {
+            "tooltip": "t(curiosity-inventory.tooltip_header_billing, {"context":"provider"})",
+          },
           "isSort": true,
           "isWrap": true,
           "label": [Function],
@@ -6905,9 +7048,16 @@ exports[`Product specific configurations should apply variations in inventory fi
               "width": undefined,
             },
             {
-              "content": "t(curiosity-inventory.label_billing_provider, {"context":"none"})",
+              "content": <Tooltip
+                content="t(curiosity-inventory.tooltip_cell_billing_provider, {"context":"none","provider":"t(curiosity-inventory.label_billing, {\\"context\\":\\"provider\\"})"})"
+              >
+                t(curiosity-inventory.label_billing_provider, {"context":"none"})
+              </Tooltip>,
               "dataLabel": "t([curiosity-inventory.header_billing_provider,curiosity-inventory.guestsHeader_billing_provider], {"context":"rosa"})",
               "header": [Function],
+              "info": {
+                "tooltip": [Function],
+              },
               "isSort": true,
               "isWrap": true,
               "metric": "billing_provider",

--- a/src/config/product.ansible.js
+++ b/src/config/product.ansible.js
@@ -24,6 +24,7 @@ import {
 import { dateHelpers, helpers } from '../common';
 import { ChartTypeVariant } from '../components/chart/chartHelpers';
 import { SelectPosition } from '../components/form/select';
+import { Tooltip } from '../components/tooltip/tooltip';
 import { translate } from '../components/i18n/i18n';
 
 /**
@@ -277,10 +278,27 @@ const config = {
     },
     {
       metric: INVENTORY_TYPES.BILLING_PROVIDER,
-      cell: ({ [INVENTORY_TYPES.BILLING_PROVIDER]: provider }) =>
-        translate(`curiosity-inventory.label_${INVENTORY_TYPES.BILLING_PROVIDER}`, {
-          context: provider || 'none'
-        }),
+      info: {
+        tooltip: () =>
+          translate(`curiosity-inventory.tooltip`, {
+            context: ['header', INVENTORY_TYPES.BILLING_PROVIDER]
+          })
+      },
+      cell: ({ [INVENTORY_TYPES.BILLING_PROVIDER]: provider, [INVENTORY_TYPES.BILLING_ACCOUNT_ID]: account }) => (
+        <Tooltip
+          content={translate(`curiosity-inventory.tooltip`, {
+            context: ['cell', INVENTORY_TYPES.BILLING_PROVIDER, !provider && 'none'],
+            provider: translate('curiosity-inventory.label', {
+              context: [INVENTORY_TYPES.BILLING_PROVIDER, provider]
+            }),
+            account
+          })}
+        >
+          {translate('curiosity-inventory.label', {
+            context: [INVENTORY_TYPES.BILLING_PROVIDER, provider || 'none']
+          })}
+        </Tooltip>
+      ),
       isSort: true,
       isWrap: true,
       width: 15

--- a/src/config/product.openshiftDedicated.js
+++ b/src/config/product.openshiftDedicated.js
@@ -21,6 +21,7 @@ import {
 import { ChartTypeVariant } from '../components/chart/chart';
 import { dateHelpers, helpers } from '../common';
 import { SelectPosition } from '../components/form/select';
+import { Tooltip } from '../components/tooltip/tooltip';
 import { translate } from '../components/i18n/i18n';
 
 /**
@@ -275,10 +276,27 @@ const config = {
     },
     {
       metric: INVENTORY_TYPES.BILLING_PROVIDER,
-      cell: ({ [INVENTORY_TYPES.BILLING_PROVIDER]: provider }) =>
-        translate(`curiosity-inventory.label_${INVENTORY_TYPES.BILLING_PROVIDER}`, {
-          context: provider || 'none'
-        }),
+      info: {
+        tooltip: () =>
+          translate(`curiosity-inventory.tooltip`, {
+            context: ['header', INVENTORY_TYPES.BILLING_PROVIDER]
+          })
+      },
+      cell: ({ [INVENTORY_TYPES.BILLING_PROVIDER]: provider, [INVENTORY_TYPES.BILLING_ACCOUNT_ID]: account }) => (
+        <Tooltip
+          content={translate(`curiosity-inventory.tooltip`, {
+            context: ['cell', INVENTORY_TYPES.BILLING_PROVIDER, !provider && 'none'],
+            provider: translate('curiosity-inventory.label', {
+              context: [INVENTORY_TYPES.BILLING_PROVIDER, provider]
+            }),
+            account
+          })}
+        >
+          {translate('curiosity-inventory.label', {
+            context: [INVENTORY_TYPES.BILLING_PROVIDER, provider || 'none']
+          })}
+        </Tooltip>
+      ),
       isSort: true,
       isWrap: true,
       width: 15

--- a/src/config/product.openshiftMetrics.js
+++ b/src/config/product.openshiftMetrics.js
@@ -19,6 +19,7 @@ import {
 import { ChartTypeVariant } from '../components/chart/chartHelpers';
 import { dateHelpers, helpers } from '../common';
 import { SelectPosition } from '../components/form/select';
+import { Tooltip } from '../components/tooltip/tooltip';
 import { translate } from '../components/i18n/i18n';
 
 /**
@@ -266,10 +267,27 @@ const config = {
     },
     {
       metric: INVENTORY_TYPES.BILLING_PROVIDER,
-      cell: ({ [INVENTORY_TYPES.BILLING_PROVIDER]: provider }) =>
-        translate(`curiosity-inventory.label_${INVENTORY_TYPES.BILLING_PROVIDER}`, {
-          context: provider || 'none'
-        }),
+      info: {
+        tooltip: () =>
+          translate(`curiosity-inventory.tooltip`, {
+            context: ['header', INVENTORY_TYPES.BILLING_PROVIDER]
+          })
+      },
+      cell: ({ [INVENTORY_TYPES.BILLING_PROVIDER]: provider, [INVENTORY_TYPES.BILLING_ACCOUNT_ID]: account }) => (
+        <Tooltip
+          content={translate(`curiosity-inventory.tooltip`, {
+            context: ['cell', INVENTORY_TYPES.BILLING_PROVIDER, !provider && 'none'],
+            provider: translate('curiosity-inventory.label', {
+              context: [INVENTORY_TYPES.BILLING_PROVIDER, provider]
+            }),
+            account
+          })}
+        >
+          {translate('curiosity-inventory.label', {
+            context: [INVENTORY_TYPES.BILLING_PROVIDER, provider || 'none']
+          })}
+        </Tooltip>
+      ),
       isSort: true,
       isWrap: true,
       width: 15

--- a/src/config/product.rhacm.js
+++ b/src/config/product.rhacm.js
@@ -24,6 +24,7 @@ import {
 import { dateHelpers, helpers } from '../common';
 import { ChartTypeVariant } from '../components/chart/chartHelpers';
 import { SelectPosition } from '../components/form/select';
+import { Tooltip } from '../components/tooltip/tooltip';
 import { translate } from '../components/i18n/i18n';
 
 /**
@@ -254,10 +255,27 @@ const config = {
     },
     {
       metric: INVENTORY_TYPES.BILLING_PROVIDER,
-      cell: ({ [INVENTORY_TYPES.BILLING_PROVIDER]: provider }) =>
-        translate(`curiosity-inventory.label_${INVENTORY_TYPES.BILLING_PROVIDER}`, {
-          context: provider || 'none'
-        }),
+      info: {
+        tooltip: () =>
+          translate(`curiosity-inventory.tooltip`, {
+            context: ['header', INVENTORY_TYPES.BILLING_PROVIDER]
+          })
+      },
+      cell: ({ [INVENTORY_TYPES.BILLING_PROVIDER]: provider, [INVENTORY_TYPES.BILLING_ACCOUNT_ID]: account }) => (
+        <Tooltip
+          content={translate(`curiosity-inventory.tooltip`, {
+            context: ['cell', INVENTORY_TYPES.BILLING_PROVIDER, !provider && 'none'],
+            provider: translate('curiosity-inventory.label', {
+              context: [INVENTORY_TYPES.BILLING_PROVIDER, provider]
+            }),
+            account
+          })}
+        >
+          {translate('curiosity-inventory.label', {
+            context: [INVENTORY_TYPES.BILLING_PROVIDER, provider || 'none']
+          })}
+        </Tooltip>
+      ),
       isSort: true,
       isWrap: true,
       width: 15

--- a/src/config/product.rhacs.js
+++ b/src/config/product.rhacs.js
@@ -22,6 +22,7 @@ import {
 import { ChartTypeVariant } from '../components/chart/chart';
 import { dateHelpers, helpers } from '../common';
 import { SelectPosition } from '../components/form/select';
+import { Tooltip } from '../components/tooltip/tooltip';
 import { translate, EMPTY_CONTEXT } from '../components/i18n/i18n';
 
 /**
@@ -217,10 +218,27 @@ const config = {
     },
     {
       metric: INVENTORY_TYPES.BILLING_PROVIDER,
-      cell: ({ [INVENTORY_TYPES.BILLING_PROVIDER]: provider }) =>
-        translate(`curiosity-inventory.label_${INVENTORY_TYPES.BILLING_PROVIDER}`, {
-          context: provider || 'none'
-        }),
+      info: {
+        tooltip: () =>
+          translate(`curiosity-inventory.tooltip`, {
+            context: ['header', INVENTORY_TYPES.BILLING_PROVIDER]
+          })
+      },
+      cell: ({ [INVENTORY_TYPES.BILLING_PROVIDER]: provider, [INVENTORY_TYPES.BILLING_ACCOUNT_ID]: account }) => (
+        <Tooltip
+          content={translate(`curiosity-inventory.tooltip`, {
+            context: ['cell', INVENTORY_TYPES.BILLING_PROVIDER, !provider && 'none'],
+            provider: translate('curiosity-inventory.label', {
+              context: [INVENTORY_TYPES.BILLING_PROVIDER, provider]
+            }),
+            account
+          })}
+        >
+          {translate('curiosity-inventory.label', {
+            context: [INVENTORY_TYPES.BILLING_PROVIDER, provider || 'none']
+          })}
+        </Tooltip>
+      ),
       isSort: true,
       isWrap: true,
       width: 15

--- a/src/config/product.rhelElsPayg.js
+++ b/src/config/product.rhelElsPayg.js
@@ -23,6 +23,7 @@ import {
 import { ChartTypeVariant } from '../components/chart/chart';
 import { dateHelpers, helpers } from '../common';
 import { SelectPosition } from '../components/form/select';
+import { Tooltip } from '../components/tooltip/tooltip';
 import { translate, EMPTY_CONTEXT } from '../components/i18n/i18n';
 
 /**
@@ -216,11 +217,29 @@ const config = {
     },
     {
       metric: INVENTORY_TYPES.BILLING_PROVIDER,
-      cell: ({ [INVENTORY_TYPES.BILLING_PROVIDER]: provider } = {}) =>
-        translate('curiosity-inventory.label', {
-          context: [INVENTORY_TYPES.BILLING_PROVIDER, provider || 'none']
-        }),
+      info: {
+        tooltip: () =>
+          translate(`curiosity-inventory.tooltip`, {
+            context: ['header', INVENTORY_TYPES.BILLING_PROVIDER]
+          })
+      },
+      cell: ({ [INVENTORY_TYPES.BILLING_PROVIDER]: provider, [INVENTORY_TYPES.BILLING_ACCOUNT_ID]: account }) => (
+        <Tooltip
+          content={translate(`curiosity-inventory.tooltip`, {
+            context: ['cell', INVENTORY_TYPES.BILLING_PROVIDER, !provider && 'none'],
+            provider: translate('curiosity-inventory.label', {
+              context: [INVENTORY_TYPES.BILLING_PROVIDER, provider]
+            }),
+            account
+          })}
+        >
+          {translate('curiosity-inventory.label', {
+            context: [INVENTORY_TYPES.BILLING_PROVIDER, provider || 'none']
+          })}
+        </Tooltip>
+      ),
       isSort: true,
+      isWrap: true,
       width: 20
     },
     {

--- a/src/config/product.rhods.js
+++ b/src/config/product.rhods.js
@@ -22,6 +22,7 @@ import {
 import { ChartTypeVariant } from '../components/chart/chart';
 import { dateHelpers, helpers } from '../common';
 import { SelectPosition } from '../components/form/select';
+import { Tooltip } from '../components/tooltip/tooltip';
 import { translate, EMPTY_CONTEXT } from '../components/i18n/i18n';
 
 /**
@@ -215,10 +216,27 @@ const config = {
     },
     {
       metric: INVENTORY_TYPES.BILLING_PROVIDER,
-      cell: ({ [INVENTORY_TYPES.BILLING_PROVIDER]: provider }) =>
-        translate(`curiosity-inventory.label_${INVENTORY_TYPES.BILLING_PROVIDER}`, {
-          context: provider || 'none'
-        }),
+      info: {
+        tooltip: () =>
+          translate(`curiosity-inventory.tooltip`, {
+            context: ['header', INVENTORY_TYPES.BILLING_PROVIDER]
+          })
+      },
+      cell: ({ [INVENTORY_TYPES.BILLING_PROVIDER]: provider, [INVENTORY_TYPES.BILLING_ACCOUNT_ID]: account }) => (
+        <Tooltip
+          content={translate(`curiosity-inventory.tooltip`, {
+            context: ['cell', INVENTORY_TYPES.BILLING_PROVIDER, !provider && 'none'],
+            provider: translate('curiosity-inventory.label', {
+              context: [INVENTORY_TYPES.BILLING_PROVIDER, provider]
+            }),
+            account
+          })}
+        >
+          {translate('curiosity-inventory.label', {
+            context: [INVENTORY_TYPES.BILLING_PROVIDER, provider || 'none']
+          })}
+        </Tooltip>
+      ),
       isSort: true,
       isWrap: true,
       width: 15

--- a/src/config/product.rosa.js
+++ b/src/config/product.rosa.js
@@ -24,6 +24,7 @@ import {
 import { dateHelpers, helpers } from '../common';
 import { ChartTypeVariant } from '../components/chart/chartHelpers';
 import { SelectPosition } from '../components/form/select';
+import { Tooltip } from '../components/tooltip/tooltip';
 import { translate } from '../components/i18n/i18n';
 
 /**
@@ -280,10 +281,27 @@ const config = {
     },
     {
       metric: INVENTORY_TYPES.BILLING_PROVIDER,
-      cell: ({ [INVENTORY_TYPES.BILLING_PROVIDER]: provider }) =>
-        translate(`curiosity-inventory.label_${INVENTORY_TYPES.BILLING_PROVIDER}`, {
-          context: provider || 'none'
-        }),
+      info: {
+        tooltip: () =>
+          translate(`curiosity-inventory.tooltip`, {
+            context: ['header', INVENTORY_TYPES.BILLING_PROVIDER]
+          })
+      },
+      cell: ({ [INVENTORY_TYPES.BILLING_PROVIDER]: provider, [INVENTORY_TYPES.BILLING_ACCOUNT_ID]: account }) => (
+        <Tooltip
+          content={translate(`curiosity-inventory.tooltip`, {
+            context: ['cell', INVENTORY_TYPES.BILLING_PROVIDER, !provider && 'none'],
+            provider: translate('curiosity-inventory.label', {
+              context: [INVENTORY_TYPES.BILLING_PROVIDER, provider]
+            }),
+            account
+          })}
+        >
+          {translate('curiosity-inventory.label', {
+            context: [INVENTORY_TYPES.BILLING_PROVIDER, provider || 'none']
+          })}
+        </Tooltip>
+      ),
       isSort: true,
       isWrap: true,
       width: 15

--- a/src/services/rhsm/rhsmServices.js
+++ b/src/services/rhsm/rhsmServices.js
@@ -73,7 +73,7 @@ const getApiVersion = (options = {}) => {
  *     {
  *       "ids": [
  *         {
- *           "billing_account_id": "2cfa4d67-cf37-47f4-bd76-2mock91242",
+ *           "billing_account_id": "XXXXXXXXXX",
  *           "billing_provider": "aws"
  *         },
  *         {
@@ -2055,7 +2055,7 @@ const getInstancesInventoryGuests = (id, params = {}, options = {}) => {
  *       "data" : [
  *         {
  *           "category": "physical",
- *           "billing_account_id": "xxxxx-xxxx-CCCCC-xxxx-xxxx10",
+ *           "billing_account_id": "XXXXXXXXXX",
  *           "inventory_id": "CCCCC-b344-4778-831c-CCCCCCC",
  *           "instance_id": "i-831cCCCCCCC",
  *           "subscription_manager_id": "CCCCC-5b00-42fa-CCCCC-75801d45cc6d",
@@ -2071,7 +2071,7 @@ const getInstancesInventoryGuests = (id, params = {}, options = {}) => {
  *         },
  *         {
  *           "category": "virtual",
- *           "billing_account_id": "xxxxx-xxxx-FFFFF-xxxx-xxxx40",
+ *           "billing_account_id": "XXXXXXXXXX",
  *           "inventory_id": "FFFFF-b344-4778-831c-FFFFF",
  *           "instance_id": "i-831cFFFFF",
  *           "subscription_manager_id": "FFFFF-5b00-42fa-FFFFF-75801d45cc6d",
@@ -2090,7 +2090,7 @@ const getInstancesInventoryGuests = (id, params = {}, options = {}) => {
  *           "category": "cloud",
  *           "billing_provider": "red hat",
  *           "cloud_provider": "aws",
- *           "billing_account_id": "xxxxx-xxxx-xxxx-xxxx-xxxx01",
+ *           "billing_account_id": "XXXXXXXXXX",
  *           "inventory_id": "d6214a0b-b344-4778-831c-d53dcacb2da3",
  *           "instance_id": "i-831cd53dcacb2da3",
  *           "subscription_manager_id": "adafd9d5-5b00-42fa-a6c9-75801d45cc6d",
@@ -2108,7 +2108,7 @@ const getInstancesInventoryGuests = (id, params = {}, options = {}) => {
  *           "category": "cloud",
  *           "billing_provider": "azure",
  *           "cloud_provider": "azure",
- *           "billing_account_id": "xxxxx-xxxx-xxxx-xxxx-xxxx02",
+ *           "billing_account_id": "XXXXXXXXXX",
  *           "inventory_id": "XXXXXX-b344-4778-831c-XXXXXXXX",
  *           "instance_id": "i-831cXXXXXXXX",
  *           "subscription_manager_id": "XXXXXX-5b00-42fa-XXXX-75801d45cc6d",
@@ -2124,7 +2124,7 @@ const getInstancesInventoryGuests = (id, params = {}, options = {}) => {
  *         },
  *         {
  *           "category": "physical",
- *           "billing_account_id": "xxxxx-xxxx-xxxx-xxxx-xxxx03",
+ *           "billing_account_id": "XXXXXXXXXX",
  *           "inventory_id": "BBBBB-b344-4778-831c-BBBBBBB",
  *           "instance_id": "i-831cBBBBBBB",
  *           "subscription_manager_id": "BBBBB-5b00-42fa-BBBBB-75801d45cc6d",

--- a/src/styles/_tooltip.scss
+++ b/src/styles/_tooltip.scss
@@ -1,5 +1,10 @@
 html > .curiosity-tooltip,
 .curiosity-tooltip {
+  &-content {
+    display: inline-block;
+    cursor: pointer;
+  }
+
   &__nowrap {
     white-space: nowrap;
   }


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(config): sw-3519 instances tooltip for billing accounts

### Notes
- adds a tooltip to highlight the billing account id associated with a billing provider in the instances inventory display.
   - useful for scenarios when usage vs subscriptions is mismatched
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->

### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. navigate towards variant that uses the billing provider/account filtering, we leveraged OpenShift AI
   - scroll down to the instances inventory display
   - a tooltip next to the "Purchased through" column header should provide an explanation
   - hovering over the provider column per each instance inventory row should display the associated billing account id
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![May-07-2025 16-12-02](https://github.com/user-attachments/assets/723de7a5-993a-41ea-a52c-babf702b3bc9)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-3519