### PR TITLE
fix(toolbarFieldExportContext): sw-3639 notification confirmation

### DIFF
--- a/src/components/toolbar/__tests__/__snapshots__/toolbarFieldExportContext.test.js.snap
+++ b/src/components/toolbar/__tests__/__snapshots__/toolbarFieldExportContext.test.js.snap
@@ -529,7 +529,11 @@ exports[`ToolbarFieldExport Component should allow service calls on user confirm
     },
   ],
   "getService": [],
-  "notification": [],
+  "notification": [
+    [
+      "swatch-exports-status",
+    ],
+  ],
 }
 `;
 

--- a/src/components/toolbar/toolbarFieldExportContext.js
+++ b/src/components/toolbar/toolbarFieldExportContext.js
@@ -159,7 +159,7 @@ const useExistingExportsConfirmation = ({
 } = {}) => {
   const dispatch = useAliasDispatch();
   const confirmAppLoaded = useAliasAppLoad();
-  const { addNotification } = useAliasNotifications();
+  const { addNotification, removeNotification } = useAliasNotifications();
 
   return useCallback(
     async (confirmation, allResults) => {
@@ -170,6 +170,7 @@ const useExistingExportsConfirmation = ({
       // clean up unused exports
       if (confirmation === 'no') {
         dispatch(deleteAliasExistingExports(allResults));
+        removeNotification('swatch-exports-status');
         return;
       }
 
@@ -217,7 +218,15 @@ const useExistingExportsConfirmation = ({
         dispatch([{ type: reduxTypes.platform.SET_PLATFORM_EXPORT_RESET }]);
       }
     },
-    [addNotification, confirmAppLoaded, dispatch, deleteAliasExistingExports, getAliasExistingExports, t]
+    [
+      addNotification,
+      confirmAppLoaded,
+      dispatch,
+      deleteAliasExistingExports,
+      getAliasExistingExports,
+      removeNotification,
+      t
+    ]
   );
 };
 


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(toolbarFieldExportContext): sw-3639 notification confirmation

### Notes
- bug in the bug fix for #1660 
- reapply the remove notification when the existing exports confirmation is "no"
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
<!--
When moving between environments notify a specific party
1. local > CI, Dev, Design should be assigned when relative
1. CI > QA, QE, CCS/docs should be notified
1. QA > Stage, QE and CCS/docs should be notified, AND applied as PR reviewers
1. Stage > Prod, QE and CCS/docs should be notified, AND applied as PR reviewers
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm start`
1. next...
-->
<!--
### Proxy run check
1. update the NPM packages with `$ npm install`
1. make sure you're on network, then
1. `$ npm run start:proxy`
1. confirm the "no" on existing exports now closes correctly
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
sw-3639 relates #1660 