### PR TITLE
SWATCH-4975: Create Konflux Pipeline for hermetic frontend build

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -45,4 +45,4 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.COV_TOKEN }}
       - name: Confirm integration
         if: ${{ success() }}
-        run: npm run build
+        run: npm run build && npm run test:integration

--- a/.tekton/curiosity-frontend-pull-request.yaml
+++ b/.tekton/curiosity-frontend-pull-request.yaml
@@ -27,9 +27,13 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: dockerfile
-    value: build-tools/Dockerfile
+    value: build-tools/Dockerfile.hermetic
   - name: path-context
     value: .
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "npm", "path": "."}'
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/curiosity-frontend-push.yaml
+++ b/.tekton/curiosity-frontend-push.yaml
@@ -24,9 +24,13 @@ spec:
   - name: output-image
     value: quay.io/redhat-user-workloads/rh-subs-watch-tenant/curiosity-frontend/curiosity-frontend:{{revision}}
   - name: dockerfile
-    value: build-tools/Dockerfile
+    value: build-tools/Dockerfile.hermetic
   - name: path-context
     value: .
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "npm", "path": "."}'
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "api:proxy-hosts": "bash ./scripts/proxy.api.sh",
     "api:spec": "SPEC=https://petstore.swagger.io/?url=https://raw.githubusercontent.com/RedHatInsights/rhsm-subscriptions/main/api/rhsm-subscriptions-api-v1-spec.yaml; xdg-open $SPEC || open $SPEC",
     "api:spec2": "SPEC=https://petstore.swagger.io/?url=https://raw.githubusercontent.com/RedHatInsights/rhsm-subscriptions/main/api/rhsm-subscriptions-api-v2-spec.yaml; xdg-open $SPEC || open $SPEC",
-    "build": "run-s -l build:pre build:js build:post test:integration",
+    "build": "run-s -l build:pre build:js build:post",
     "build:docs": "run-s -l test:docs docs:md",
     "build:ephemeral": "run-s -l build:pre build:js build:post test:integration-ephemeral",
     "build:pr_checks": "run-s -l build:pre build:js build:post",


### PR DESCRIPTION
## What's included
Starting May 13, the frontend will need to be build with the Nexus registry in order to be released.  Or a prodsec-approvaed policy exception will be required.

There is already a [Dockerfile.hermetic](https://github.com/RedHatInsights/insights-frontend-builder-common/blob/c1204294e120df77acf22edc24828598da4a1702/Dockerfile.hermetic) in the build-tools submodule.  And a [README-hermetic-build.md](https://github.com/RedHatInsights/insights-frontend-builder-common/blob/master/README-hermetic-build.md).  We need to create a pipeline that uses the Dockerfile.hermetic instead of the Dockerfile.
