### PR TITLE
ci: Konflux bot should also update build-tools

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,5 +8,5 @@
     "on Tuesday after 3am and before 10am"
   ],
   "timezone": "America/New_York",
-  "enabledManagers": ["tekton"]
+  "enabledManagers": ["tekton", "git-submodules"]
 }


### PR DESCRIPTION
Enabling konflux bot updates to git submodule for build-tools

When turning off the dependency updates in:  https://github.com/RedHatInsights/curiosity-frontend/pull/new/vbusch/konfluxbot the submodule updates were excluded as well.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated dependency management configuration to include additional dependency types, enabling more comprehensive automated updates across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->