### PR TITLE
ci: Fix bonfire deploy images

### DIFF
--- a/.tekton/bonfire-integration-tests-pipelinerun.yaml
+++ b/.tekton/bonfire-integration-tests-pipelinerun.yaml
@@ -45,19 +45,13 @@ spec:
 
     # Deployment configuration
     - name: REF_ENV
-      value: "insights-stage"
+      value: "insights-production"
     - name: EXTRA_DEPLOY_ARGS
       # TEMPORARY: pin chrome-service, insights-chrome, storage-broker to prod (app-interface).
       # Remove when Konflux publishes images for those components on main again.
       value: >-
         --no-remove-resources app:rhsm
         --exclude-components unleash-proxy
-        --set-template-ref chrome-service=06bb9b76cc845de7d8d3278d1be4bc8c514f5edc
-        --set-template-ref insights-chrome=a351281389bb8d860974db82d0c16311fefd1c5b
-        --set-template-ref storage-broker=3e02a457370c867c63f45bb847f2dd52b6362c41
-        --set-image-tag quay.io/redhat-services-prod/hcc-platex-services/chrome-service=06bb9b7
-        --set-image-tag quay.io/redhat-services-prod/hcc-platex-services-tenant/insights-chrome=a351281
-        --set-image-tag quay.io/redhat-services-prod/hcc-integrations-tenant/storage-broker=3e02a45
     - name: DEPLOY_FRONTENDS
       value: "true"
     - name: DEPLOY_TIMEOUT

--- a/.tekton/bonfire-integration-tests-pipelinerun.yaml
+++ b/.tekton/bonfire-integration-tests-pipelinerun.yaml
@@ -47,8 +47,6 @@ spec:
     - name: REF_ENV
       value: "insights-production"
     - name: EXTRA_DEPLOY_ARGS
-      # TEMPORARY: pin chrome-service, insights-chrome, storage-broker to prod (app-interface).
-      # Remove when Konflux publishes images for those components on main again.
       value: >-
         --no-remove-resources app:rhsm
         --exclude-components unleash-proxy


### PR DESCRIPTION
## What's included

Using `-ref-env insights-production` fixes several image pull errors:
- ImagePullBackOff error for pod/rbac-frontend-6d84d8c77b-rglzc (container 'fe-image')
- quay.io/redhat-services-prod/rh-platform-experien-tenant/insights-rbac-ui:37533ce

Removed the temporary pinned image versions.

### Local run check
`bonfire deploy --source=appsre --ref-env insights-production  --timeout 1800 --optional-deps-method hybrid --frontends true --no-remove-resources app:rhsm --exclude-components unleash-proxy  rhsm`


## How to test
Verify the `curiosity-frontend-bonfire-tekton` pipeline can deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the integration test pipeline deployment settings by switching the environment to production and simplifying deployment parameters, removing temporary component pinning while keeping the existing resource-management flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->