### PR TITLE
fix(ci): use identity auth for Bonfire ephemeral IQE

### DIFF
--- a/.tekton/bonfire-integration-tests-pipeline.yaml
+++ b/.tekton/bonfire-integration-tests-pipeline.yaml
@@ -118,6 +118,13 @@ spec:
       type: string
       description: Value to set for ENV_FOR_DYNACONF
       default: "ephemeral"
+    - name: IQE_ENV_VARS
+      type: string
+      description: >-
+        Comma-separated extra env vars for the IQE pod (see bonfire-tekton run-iqe-cji).
+        Ephemeral Bonfire runs outside the cluster; use identity auth for rhsm_subscriptions
+        API setup (clowder_smoke sets this in YAML; ephemeral does not).
+      default: "DYNACONF_HTTP__DEFAULT_AUTH_TYPE=identity"
     - name: IQE_IMAGE_REPOSITORY
       type: string
       description: IQE image repository without tag (must match Bonfire deploy); shown with tag in PR test comments
@@ -576,6 +583,8 @@ spec:
           value: "$(params.IQE_CJI_TIMEOUT)"
         - name: IQE_ENV
           value: "$(params.IQE_ENV)"
+        - name: IQE_ENV_VARS
+          value: "$(params.IQE_ENV_VARS)"
         - name: IQE_IMAGE_TAG
           value: "$(tasks.extract-metadata.results.IQE_IMAGE_TAG)"
         - name: IQE_PARALLEL_ENABLED

--- a/.tekton/bonfire-integration-tests-pipelinerun.yaml
+++ b/.tekton/bonfire-integration-tests-pipelinerun.yaml
@@ -74,6 +74,8 @@ spec:
       value: ""
     - name: IQE_ENV
       value: "ephemeral"
+    - name: IQE_ENV_VARS
+      value: "DYNACONF_HTTP__DEFAULT_AUTH_TYPE=identity"
     - name: IQE_IMAGE_TAG
       value: "curiosity"
     - name: IQE_PLAYWRIGHT


### PR DESCRIPTION
## Summary

- Pass `IQE_ENV_VARS=DYNACONF_HTTP__DEFAULT_AUTH_TYPE=identity` into the Bonfire `run-iqe-cji` task for `curiosity-frontend-bonfire-tekton`.
- Fixes `KeyError: 'refresh_token'` in ephemeral UI tests: `curiosity_user_app` calls `rhsm_subscriptions` REST APIs during fixture setup, but `ENV_FOR_DYNACONF=ephemeral` inherits `jwt-auth` from iqe-core while clowder users only have username/password (no refresh token).
- rhsm-subscriptions GitLab CI avoids this by running marker `ephemeral` with `IQE_ENV=clowder_smoke` (identity auth in YAML). Bonfire Curiosity must use `ephemeral` for Playwright outside the cluster; this override aligns API auth without changing `iqe-rhsm-subscriptions-plugin`.

## Test plan

- [ ] Konflux `curiosity-frontend-bonfire-tekton` IntegrationTestScenario passes on this PR
- [ ] IQE pod log shows `Setting auth_type to identity` (not `jwt-auth` / `refresh_token`) before `put_opt_in_config`
- [ ] Ephemeral UI tests (`@pytest.mark.ephemeral`) complete past fixture setup


Made with [Cursor](https://cursor.com)