### PR TITLE
ci: use insights-production template and overwrite SWATCH with stage images/templates

### DIFF
--- a/.tekton/bonfire-integration-tests-pipeline.yaml
+++ b/.tekton/bonfire-integration-tests-pipeline.yaml
@@ -77,7 +77,7 @@ spec:
     - name: REF_ENV
       type: string
       description: Reference environment for app-interface templates
-      default: "insights-stage"
+      default: "insights-production"
     - name: EXTRA_DEPLOY_ARGS
       type: string
       description: Extra arguments for the deployment

--- a/.tekton/bonfire-integration-tests-pipelinerun.yaml
+++ b/.tekton/bonfire-integration-tests-pipelinerun.yaml
@@ -43,21 +43,51 @@ spec:
     - name: COMPONENTS_W_RESOURCES
       value: "app:rhsm"
 
-    # Deployment configuration
     - name: REF_ENV
-      value: "insights-stage"
+      value: "insights-production"
     - name: EXTRA_DEPLOY_ARGS
-      # TEMPORARY: pin chrome-service, insights-chrome, storage-broker to prod (app-interface).
-      # Remove when Konflux publishes images for those components on main again.
       value: >-
         --no-remove-resources app:rhsm
         --exclude-components unleash-proxy
-        --set-template-ref chrome-service=06bb9b76cc845de7d8d3278d1be4bc8c514f5edc
-        --set-template-ref insights-chrome=a351281389bb8d860974db82d0c16311fefd1c5b
-        --set-template-ref storage-broker=3e02a457370c867c63f45bb847f2dd52b6362c41
-        --set-image-tag quay.io/redhat-services-prod/hcc-platex-services/chrome-service=06bb9b7
-        --set-image-tag quay.io/redhat-services-prod/hcc-platex-services-tenant/insights-chrome=a351281
-        --set-image-tag quay.io/redhat-services-prod/hcc-integrations-tenant/storage-broker=3e02a45
+        -p swatch-api/IMAGE=quay.io/redhat-services-prod/rh-subs-watch-tenant/swatch-api
+        -p swatch-billable-usage/IMAGE=quay.io/redhat-services-prod/rh-subs-watch-tenant/swatch-billable-usage
+        -p swatch-contracts/IMAGE=quay.io/redhat-services-prod/rh-subs-watch-tenant/swatch-contracts
+        -p swatch-metrics/IMAGE=quay.io/redhat-services-prod/rh-subs-watch-tenant/swatch-metrics
+        -p swatch-metrics-hbi/IMAGE=quay.io/redhat-services-prod/rh-subs-watch-tenant/swatch-metrics-hbi
+        -p swatch-producer-aws/IMAGE=quay.io/redhat-services-prod/rh-subs-watch-tenant/swatch-producer-aws
+        -p swatch-producer-azure/IMAGE=quay.io/redhat-services-prod/rh-subs-watch-tenant/swatch-producer-azure
+        -p swatch-system-conduit/IMAGE=quay.io/redhat-services-prod/rh-subs-watch-tenant/swatch-system-conduit
+        -p swatch-tally/IMAGE=quay.io/redhat-services-prod/rh-subs-watch-tenant/swatch-tally
+        -p swatch-utilization/IMAGE=quay.io/redhat-services-prod/rh-subs-watch-tenant/swatch-utilization
+        --set-image-tag quay.io/redhat-services-prod/rh-subs-watch-tenant/swatch-api=latest
+        --set-template-ref swatch-api=stable
+        --set-image-tag quay.io/redhat-services-prod/rh-subs-watch-tenant/swatch-contracts=latest
+        --set-template-ref swatch-contracts=stable
+        --set-image-tag quay.io/redhat-services-prod/rh-subs-watch-tenant/swatch-billable-usage=latest
+        --set-template-ref swatch-billable-usage=stable
+        --set-image-tag quay.io/redhat-services-prod/rh-subs-watch-tenant/swatch-producer-aws=latest
+        --set-template-ref swatch-producer-aws=stable
+        --set-image-tag quay.io/redhat-services-prod/rh-subs-watch-tenant/swatch-producer-azure=latest
+        --set-template-ref swatch-producer-azure=stable
+        --set-image-tag quay.io/redhat-services-prod/rh-subs-watch-tenant/swatch-system-conduit=latest
+        --set-template-ref swatch-system-conduit=stable
+        --set-image-tag quay.io/redhat-services-prod/rh-subs-watch-tenant/swatch-metrics=latest
+        --set-template-ref swatch-metrics=stable
+        --set-image-tag quay.io/redhat-services-prod/rh-subs-watch-tenant/swatch-metrics-hbi=latest
+        --set-template-ref swatch-metrics-hbi=stable
+        --set-image-tag quay.io/redhat-services-prod/rh-subs-watch-tenant/swatch-tally=latest
+        --set-template-ref swatch-tally=stable
+        --set-image-tag quay.io/redhat-services-prod/rh-subs-watch-tenant/swatch-utilization=latest
+        --set-template-ref swatch-utilization=stable
+        --set-template-ref swatch-database=stable
+        --set-template-ref rhsm=stable
+        --set-image-tag quay.io/redhat-services-prod/rh-subs-watch-tenant/nginx-otel=latest
+        --set-image-tag quay.io/redhat-services-prod/rh-subs-watch-tenant/wiremock-consoledot=latest
+        --set-template-ref wiremock=main
+        --set-image-tag quay.io/redhat-services-prod/rh-subs-watch-tenant/artemis=latest
+        --set-template-ref artemis=main
+        --set-image-tag quay.io/redhat-services-prod/rh-subs-watch-tenant/prometheus=latest
+        --set-template-ref prometheus=main
     - name: DEPLOY_FRONTENDS
       value: "true"
     - name: DEPLOY_TIMEOUT


### PR DESCRIPTION
JIRA Ticket: SWATCH-5125

## Description
Currently, running the frontend PR iqe tests against the stage environment for ConsoleDot images introduces instability.  Pulling images with bonfire fails frequently with that ref-env.  Moving ConsoleDot dependencies to pull from production will stabilize the pipeline.  The backend rhsm-subscriptions ephemeral PR checks also deploy the images from ref-env=production.

These changes are aligned to the changes in IQE: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1545

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default deployment environment to use production instead of stage when no environment is provided.
  * Aligned the integration test deployment setup with the production environment.
* **Chores**
  * Refreshed deployment overrides for the test run to match the latest component and image configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->