### PR TITLE
SWATCH-5091:fix export notification logic

### DIFF
--- a/src/components/README.md
+++ b/src/components/README.md
@@ -6635,6 +6635,8 @@ Apply an existing exports hook for user abandoned reports. Allow bulk polling st
     </tr><tr>
     <td>options.useNotifications</td><td><code>NotificationsContext.useNotifications</code></td>
     </tr><tr>
+    <td>options.useProduct</td><td><code>useProduct</code></td>
+    </tr><tr>
     <td>options.useSelectorsResponse</td><td><code>storeHooks.reactRedux.useSelectorsResponse</code></td>
     </tr>  </tbody>
 </table>

--- a/src/components/toolbar/__tests__/toolbarFieldExportContext.test.js
+++ b/src/components/toolbar/__tests__/toolbarFieldExportContext.test.js
@@ -267,6 +267,7 @@ describe('ToolbarFieldExport Component', () => {
         getExistingExports: mockService,
         getExistingExportsStatus: mockService,
         deleteExistingExports: mockService,
+        useProduct: () => ({ productId: 'loremIpsum' }),
         useNotifications: () => ({
           addNotification: mockNotification,
           hasNotification: () => false,
@@ -276,10 +277,12 @@ describe('ToolbarFieldExport Component', () => {
           data: [
             {
               data: {
-                isAnythingPending: false,
-                isAnythingCompleted: true,
-                pending: [],
-                completed: [{ dolor: 'sit' }]
+                products: {
+                  loremIpsum: {
+                    pending: [],
+                    completed: [{ dolor: 'sit', productId: 'loremIpsum' }]
+                  }
+                }
               }
             }
           ],
@@ -292,6 +295,116 @@ describe('ToolbarFieldExport Component', () => {
     await unmount();
     expect(mockNotification.mock.calls).toMatchSnapshot('existingExports');
   });
+
+  it.each([
+    {
+      description: 'export matches current product in completed',
+      currentProductId: 'loremIpsum',
+      completed: [{ productId: 'loremIpsum' }],
+      pending: []
+    },
+    {
+      description: 'export matches current product in pending',
+      currentProductId: 'loremIpsum',
+      completed: [],
+      pending: [{ productId: 'loremIpsum' }]
+    },
+    {
+      description: 'exports for multiple products, current product included',
+      currentProductId: 'loremIpsum',
+      completed: [{ productId: 'loremIpsum' }, { productId: 'dolorSit' }],
+      pending: []
+    }
+  ])(
+    'should show notification when existing export matches current product, $description',
+    async ({ currentProductId, completed, pending }) => {
+      const mockNotification = jest.fn();
+
+      const { unmount } = await renderHook(() => {
+        useExistingExports({
+          cache: { get: () => false, set: jest.fn() },
+          getExistingExportsStatus: mockService,
+          useProduct: () => ({ productId: currentProductId }),
+          useNotifications: () => ({
+            addNotification: mockNotification,
+            hasNotification: () => false,
+            removeNotification: () => mockNotification
+          }),
+          useSelectorsResponse: () => ({
+            data: [
+              {
+                data: {
+                  products: {
+                    [currentProductId]: { completed, pending }
+                  }
+                }
+              }
+            ],
+            fulfilled: true
+          })
+        });
+      });
+
+      await unmount();
+
+      expect(mockNotification).toHaveBeenCalled();
+    }
+  );
+
+  it.each([
+    {
+      description: 'export belongs to a different product variant',
+      currentProductId: 'loremIpsum',
+      completed: [{ productId: 'dolorSit' }],
+      pending: []
+    },
+    {
+      description: 'export has no productId',
+      currentProductId: 'loremIpsum',
+      completed: [{ dolor: 'sit' }],
+      pending: []
+    },
+    {
+      description: 'no exports exist',
+      currentProductId: 'loremIpsum',
+      completed: [],
+      pending: []
+    }
+  ])(
+    'should not show notification when no existing exports match current product, $description',
+    async ({ currentProductId, completed, pending }) => {
+      const mockNotification = jest.fn();
+
+      const { unmount } = await renderHook(() => {
+        useExistingExports({
+          cache: { get: () => false, set: jest.fn() },
+          getExistingExportsStatus: mockService,
+          useProduct: () => ({ productId: currentProductId }),
+          useNotifications: () => ({
+            addNotification: mockNotification,
+            hasNotification: () => false,
+            removeNotification: () => mockNotification
+          }),
+          useSelectorsResponse: () => ({
+            data: [
+              {
+                data: {
+                  products: {
+                    dolorSit: { completed, pending }
+                  }
+                }
+              }
+            ],
+            fulfilled: true
+          })
+        });
+      });
+
+      await unmount();
+
+      expect(mockNotification).not.toHaveBeenCalled();
+    }
+  );
 
   it.each([
     {

--- a/src/components/toolbar/toolbarFieldExportContext.js
+++ b/src/components/toolbar/toolbarFieldExportContext.js
@@ -240,6 +240,7 @@ const useExistingExportsConfirmation = ({
  * @param {storeHooks.reactRedux.useDispatch} options.useDispatch
  * @param {useExistingExportsConfirmation} options.useExistingExportsConfirmation
  * @param {NotificationsContext.useNotifications} options.useNotifications
+ * @param {useProduct} options.useProduct
  * @param {storeHooks.reactRedux.useSelectorsResponse} options.useSelectorsResponse
  */
 const useExistingExports = ({
@@ -249,13 +250,15 @@ const useExistingExports = ({
   useDispatch: useAliasDispatch = storeHooks.reactRedux.useDispatch,
   useExistingExportsConfirmation: useAliasExistingExportsConfirmation = useExistingExportsConfirmation,
   useNotifications: useAliasNotifications = NotificationsContext.useNotifications,
+  useProduct: useAliasProduct = useProduct,
   useSelectorsResponse: useAliasSelectorsResponse = storeHooks.reactRedux.useSelectorsResponse
 } = {}) => {
   const dispatch = useAliasDispatch();
   const { addNotification, removeNotification, hasNotification } = useAliasNotifications();
   const onConfirmation = useAliasExistingExportsConfirmation();
+  const { productId: currentProductId } = useAliasProduct();
   const { data } = useAliasSelectorsResponse(({ app }) => app?.exportsExisting);
-  const { completed = [], isAnythingPending, isAnythingCompleted, pending = [] } = data?.[0]?.data || {};
+  const { completed = [], pending = [] } = data?.[0]?.data?.products?.[currentProductId] || {};
   const hasCache = cache.get('isExistingExports');
 
   useMount(() => {
@@ -269,12 +272,12 @@ const useExistingExports = ({
   });
 
   useEffect(() => {
-    const isAnythingAvailable = isAnythingCompleted || isAnythingPending || false;
+    const isAnythingAvailable = completed.length > 0 || pending.length > 0;
     const totalResults = completed.length + pending.length;
     const isExistingNotifications =
       hasNotification('swatch-exports-individual-status') || hasNotification('swatch-exports-status');
 
-    if (!hasCache && !isExistingNotifications && isAnythingAvailable && totalResults) {
+    if (!hasCache && !isExistingNotifications && isAnythingAvailable) {
       cache.set('isExistingExports', true);
 
       addNotification({
@@ -323,17 +326,7 @@ const useExistingExports = ({
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    addNotification,
-    completed,
-    hasCache,
-    hasNotification,
-    isAnythingCompleted,
-    isAnythingPending,
-    onConfirmation,
-    pending,
-    t
-  ]);
+  }, [addNotification, completed, hasCache, hasNotification, onConfirmation, pending, t]);
 };
 
 /**


### PR DESCRIPTION
## What's included
This PR fixes export notification scoping to current product page only.
Part of the acceptance criteria is to SWATCH-4427 IQE test `test_export_subscription_data_json_manual_download` passes after the fix (or is updated if behavior intentionally changes). however due to the issues in ephemeral this will be verified in stage after merging. Also worth noting is that a video of the issue is attached to the [ticket](https://redhat.atlassian.net/browse/SWATCH-5091).
...

<!-- ### Notes -->
<!--
- Any issues that aren't resolved by this merge request, or things of note? 
- Did you use an AI Agent to help with this work? By contributing AI-assisted or AI-generated work, you accept liability for work that infringes or uses copyrighted material outside the scope of the related license. Please follow ./CONTRIBUTING.md guidelines (see bottom of the file). 
-->
<!--
- This is bot-created work, I am but a passenger on this wild-ride. AI agent tooling and model leveraged are:
   - tooling: [IDE/Chat]
   - model: [Specific/IDE specific/Auto-selection]
-->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Prompt an agent to
1. `> [test prompt]`
-->
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
### Local run check
1. update the NPM packages with `$ npm install`
2. `$ npm start`
3. Temporarily edit `src/services/platform/platformServices.js`:
     - Remove `@apiMock {RandomSuccess}` from the `GET /api/export/v1/exports` JSDoc
     - In the first `@apiSuccessExample`, remove the `swatch-RHEL for x86` object,
       leaving only `swatch-rhel-for-x86-els-payg` with `"status": "complete"`
4. Navigate to the **RHEL for x86** product page (parent)
5. Verify notification doesn't appear
6.  Navigate to the ELS On-Demand for Third Party Linux Migration variant page (rhel-for-x86-els-payg)
7. Verify: notification appears
### Proxy run check
1. update the NPM packages with `$ npm install`
2. make sure you're on network, then
3. `$ npm run start:proxy`
4. Navigate to a product page, trigger an export on a different product and confirm notification only appears on the product page where export was created

<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
updates SWATCH-5091
