### PR TITLE
ci: use github api token for bonfire deployment task

### DIFF
--- a/.tekton/bonfire-integration-tests-pipeline.yaml
+++ b/.tekton/bonfire-integration-tests-pipeline.yaml
@@ -160,7 +160,7 @@ spec:
     # Project configuration
     - name: GITHUB_TOKEN_SECRET
       type: string
-      description: Secret name containing the GitHub API token for posting PR comments
+      description: Secret name containing the GitHub API token (bonfire deploy template fetch and PR comments)
       default: "swatch-ci-github-token"
     - name: PROJECT_REPO
       type: string
@@ -390,6 +390,10 @@ spec:
           value: "$(params.DEPLOY_TIMEOUT)"
         - name: REF_ENV
           value: "$(params.REF_ENV)"
+        - name: EPHEMERAL_ENV_PROVIDER_SECRET
+          value: "$(params.EPHEMERAL_ENV_PROVIDER_SECRET)"
+        - name: GITHUB_TOKEN_SECRET
+          value: "$(params.GITHUB_TOKEN_SECRET)"
       taskSpec:
         params:
           - name: BONFIRE_IMAGE
@@ -415,6 +419,10 @@ spec:
           - name: DEPLOY_TIMEOUT
             type: string
           - name: REF_ENV
+            type: string
+          - name: EPHEMERAL_ENV_PROVIDER_SECRET
+            type: string
+          - name: GITHUB_TOKEN_SECRET
             type: string
         workspaces:
           - name: artifacts
@@ -450,6 +458,11 @@ spec:
                   secretKeyRef:
                     name: $(params.EPHEMERAL_ENV_PROVIDER_SECRET)
                     key: url
+              - name: GITHUB_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: $(params.GITHUB_TOKEN_SECRET)
+                    key: github_token
               - name: APP_NAME
                 value: $(params.APP_NAME)
               - name: COMPONENTS
@@ -471,6 +484,10 @@ spec:
             script: |
               #!/bin/bash
               set +e
+
+              if [ -n "${GITHUB_TOKEN:-}" ]; then
+                export GITHUB_TOKEN="$(echo -n "$GITHUB_TOKEN" | tr -d '[:space:]')"
+              fi
 
               DEPLOY_LOG="$(workspaces.artifacts.path)/deploy.log"
               EXIT_CODE_FILE="$(workspaces.artifacts.path)/deploy-exit-code"


### PR DESCRIPTION
## What's included
Use the same github token that post comments that already has the repo:read permissions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployment-related workflows now support using the GitHub API token for both PR comments and fetching deployment templates.
  * The deploy task can now receive the GitHub token and provide it to the deploy step during execution.
* **Bug Fixes**
  * Improved token handling by sanitizing/normalizing the GitHub token (whitespace is stripped) before it is used, when set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->