### PR TITLE
build(deps): sw-5002 konflux-bot commit message rules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "commitMessagePrefix": "build",
+  "commitMessagePrefix": "build(deps):",
+  "commitMessageMaxLength": 65,
   "commitMessageLowerCase": "auto",
   "labels": ["build"],
   "rebaseWhen": "auto",
   "prConcurrentLimit": 3,
   "timezone": "America/New_York",
-  "minimumReleaseAge": "14 days",
   "rangeStrategy": "bump",
   "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "minimumReleaseAge": "14 days"
+    },
     {
       "matchPackageNames": [
         "@patternfly/*",

--- a/.tekton/curiosity-frontend-pull-request.yaml
+++ b/.tekton/curiosity-frontend-pull-request.yaml
@@ -46,7 +46,7 @@ spec:
         - name: name
           value: show-sbom
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.2@sha256:5fe387642611a8193395adb083df203534c30fef88a032ba0c074b8280c4b135
+          value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.3@sha256:1302cc71501829ae4ae8947619a4daf97294e40c8f4c46a54ce15f3ce78b3b1b
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/curiosity-frontend-push.yaml
+++ b/.tekton/curiosity-frontend-push.yaml
@@ -43,7 +43,7 @@ spec:
         - name: name
           value: show-sbom
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.2@sha256:5fe387642611a8193395adb083df203534c30fef88a032ba0c074b8280c4b135
+          value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.3@sha256:1302cc71501829ae4ae8947619a4daf97294e40c8f4c46a54ce15f3ce78b3b1b
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
Jira issue: [SWATCH-5002](https://redhat.atlassian.net/browse/SWATCH-5002)

## What's included
Updated the konflux dependency commit message format to match the lint rules:
- Added the required `:`
- Set the max length.
The 14 day cooldown period, only applies to npm dependencies now.  This allows the konflux workflow updates to apply immediately.

[SWATCH-5002]: https://redhat.atlassian.net/browse/SWATCH-5002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores

- Updated automated dependency update commit messages to use the `build(deps):` prefix.
- Limited these commit messages to 65 characters for improved consistency.
- Updated software bill of materials (SBOM) reporting tasks to the latest supported version in pull request and push workflows.
- Applied the minimum release-age policy specifically to npm packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->