### PR TITLE
build(eslint): bump eslint-plugin-react-hooks to 7.1.1

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,7 +30,7 @@ export default [
   importPlugin.flatConfigs.recommended,
   eslintPluginJs.configs.recommended,
   reactPlugin.configs.flat.recommended,
-  reactHooksPlugin.configs['recommended-latest'],
+  reactHooksPlugin.configs.flat['recommended-latest'],
   ...airbnbConfig,
   prettierPlugin,
   jsonPlugin.configs.recommended,

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "eslint-plugin-n": "^17.24.0",
         "eslint-plugin-prettier": "^5.5.6",
         "eslint-plugin-react": "^7.37.5",
-        "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "glob": "^13.0.6",
         "globals": "^17.8.0",
         "jest": "30.4.2",
@@ -13832,16 +13832,23 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
-      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
@@ -15580,6 +15587,23 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -27711,6 +27735,29 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "eslint-plugin-n": "^17.24.0",
     "eslint-plugin-prettier": "^5.5.6",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "glob": "^13.0.6",
     "globals": "^17.8.0",
     "jest": "30.4.2",

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -777,8 +777,10 @@ Graph layer status.
 * [ChartElements](#Chart.module_ChartElements)
     * [~InterpolationTypes](#Chart.module_ChartElements..InterpolationTypes) : <code>Object</code>
     * [~chartElementsDefaults](#Chart.module_ChartElements..chartElementsDefaults) : <code>Object</code>
+    * [~VictoryVoronoiCursorContainer](#Chart.module_ChartElements..VictoryVoronoiCursorContainer) : <code>function</code>
+    * [~TooltipLabelWrapper(props)](#Chart.module_ChartElements..TooltipLabelWrapper) ⇒ <code>JSX.Element</code>
+    * [~AxisLabelWrapper(props)](#Chart.module_ChartElements..AxisLabelWrapper) ⇒ <code>JSX.Element</code>
     * [~ChartElements(props)](#Chart.module_ChartElements..ChartElements) ⇒ <code>JSX.Element</code>
-        * [~VictoryVoronoiCursorContainer](#Chart.module_ChartElements..ChartElements..VictoryVoronoiCursorContainer)
     * [~ChartTypeDefault](#Chart.module_ChartElements..ChartTypeDefault) : <code>object</code>
 
 <a name="Chart.module_ChartElements..InterpolationTypes"></a>
@@ -793,6 +795,60 @@ Available chart interpolation types
 Chart elements default prop settings
 
 **Kind**: inner constant of [<code>ChartElements</code>](#Chart.module_ChartElements)  
+<a name="Chart.module_ChartElements..VictoryVoronoiCursorContainer"></a>
+
+### ChartElements~VictoryVoronoiCursorContainer : <code>function</code>
+Combined Victory voronoi and cursor container for chart tooltip interaction.
+
+**Kind**: inner constant of [<code>ChartElements</code>](#Chart.module_ChartElements)  
+<a name="Chart.module_ChartElements..TooltipLabelWrapper"></a>
+
+### ChartElements~TooltipLabelWrapper(props) ⇒ <code>JSX.Element</code>
+Stable wrapper for the chart tooltip label component. Defined outside render to prevent
+component identity changes per render.
+
+**Kind**: inner method of [<code>ChartElements</code>](#Chart.module_ChartElements)  
+<table>
+  <thead>
+    <tr>
+      <th>Param</th><th>Type</th>
+    </tr>
+  </thead>
+  <tbody>
+<tr>
+    <td>props</td><td><code>object</code></td>
+    </tr><tr>
+    <td>props.chartSettings</td><td><code>object</code></td>
+    </tr><tr>
+    <td>props.chartContainerRef</td><td><code>function</code></td>
+    </tr><tr>
+    <td>props.chartTooltipRef</td><td><code>function</code></td>
+    </tr>  </tbody>
+</table>
+
+<a name="Chart.module_ChartElements..AxisLabelWrapper"></a>
+
+### ChartElements~AxisLabelWrapper(props) ⇒ <code>JSX.Element</code>
+Stable wrapper for the chart axis label component. Defined outside render to prevent
+component identity changes per render.
+
+**Kind**: inner method of [<code>ChartElements</code>](#Chart.module_ChartElements)  
+<table>
+  <thead>
+    <tr>
+      <th>Param</th><th>Type</th><th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+<tr>
+    <td>props</td><td><code>object</code></td><td></td>
+    </tr><tr>
+    <td>props.axis</td><td><code>string</code></td><td></td>
+    </tr><tr>
+    <td>[props.index]</td><td><code>number</code></td><td><code>0</code></td>
+    </tr>  </tbody>
+</table>
+
 <a name="Chart.module_ChartElements..ChartElements"></a>
 
 ### ChartElements~ChartElements(props) ⇒ <code>JSX.Element</code>
@@ -813,13 +869,6 @@ Aggregate, generate, a compatible Victory chart element/facet component.
     </tr>  </tbody>
 </table>
 
-<a name="Chart.module_ChartElements..ChartElements..VictoryVoronoiCursorContainer"></a>
-
-#### ChartElements~VictoryVoronoiCursorContainer
-Note: both cursor and voronoiDimension attrs required if the need is to have...
-the tooltip populate consistently without being "near" a chart element y axis point
-
-**Kind**: inner constant of [<code>ChartElements</code>](#Chart.module_ChartElements..ChartElements)  
 <a name="Chart.module_ChartElements..ChartTypeDefault"></a>
 
 ### ChartElements~ChartTypeDefault : <code>object</code>

--- a/src/components/chart/__tests__/__snapshots__/chartElements.test.js.snap
+++ b/src/components/chart/__tests__/__snapshots__/chartElements.test.js.snap
@@ -29,7 +29,229 @@ exports[`ChartElements Component should handle basic element settings from conte
             }
           }
           groupComponent={<g />}
-          labelComponent={<Unknown />}
+          labelComponent={
+            <TooltipLabelWrapper
+              chartSettings={
+                {
+                  "chartDomain": {
+                    "domain": {
+                      "y": [
+                        0,
+                        3,
+                      ],
+                    },
+                  },
+                  "chartElementsProps": {
+                    "elements": [
+                      {
+                        "chartType": undefined,
+                        "props": {
+                          "data": [
+                            {
+                              "x": 1,
+                              "xAxisLabel": "1 x axis label",
+                              "y": 1,
+                            },
+                            {
+                              "x": 2,
+                              "xAxisLabel": "2 x axis label",
+                              "y": 2,
+                            },
+                          ],
+                          "key": "chart-ipsumGraph-",
+                          "name": "chart-ipsumGraph-",
+                          "style": {
+                            "data": {
+                              "fill": "#ipsum",
+                              "stroke": "#lorem",
+                              "strokeDasharray": "4,3",
+                              "strokeWidth": 3,
+                            },
+                          },
+                          "themeColor": undefined,
+                          "themeVariant": undefined,
+                          "x": undefined,
+                          "y": [Function],
+                        },
+                      },
+                    ],
+                    "elementsById": {
+                      "ipsumGraph": {
+                        "chartType": undefined,
+                        "props": {
+                          "data": [
+                            {
+                              "x": 1,
+                              "xAxisLabel": "1 x axis label",
+                              "y": 1,
+                            },
+                            {
+                              "x": 2,
+                              "xAxisLabel": "2 x axis label",
+                              "y": 2,
+                            },
+                          ],
+                          "key": "chart-ipsumGraph-",
+                          "name": "chart-ipsumGraph-",
+                          "style": {
+                            "data": {
+                              "fill": "#ipsum",
+                              "stroke": "#lorem",
+                              "strokeDasharray": "4,3",
+                              "strokeWidth": 3,
+                            },
+                          },
+                          "themeColor": undefined,
+                          "themeVariant": undefined,
+                          "x": undefined,
+                          "y": [Function],
+                        },
+                      },
+                    },
+                    "stackedElements": [
+                      {
+                        "chartType": undefined,
+                        "props": {
+                          "data": [
+                            {
+                              "x": 1,
+                              "xAxisLabel": "1 x axis label",
+                              "y": 1,
+                            },
+                            {
+                              "x": 2,
+                              "xAxisLabel": "2 x axis label",
+                              "y": 2,
+                            },
+                          ],
+                          "key": "chart-loremGraph-",
+                          "name": "chart-loremGraph-",
+                          "style": {
+                            "data": {
+                              "fill": "#ipsum",
+                              "stroke": "#lorem",
+                              "strokeWidth": 2,
+                            },
+                          },
+                          "themeColor": undefined,
+                          "themeVariant": undefined,
+                          "x": undefined,
+                          "y": [Function],
+                        },
+                      },
+                    ],
+                    "stackedElementsById": {
+                      "loremGraph": {
+                        "chartType": undefined,
+                        "props": {
+                          "data": [
+                            {
+                              "x": 1,
+                              "xAxisLabel": "1 x axis label",
+                              "y": 1,
+                            },
+                            {
+                              "x": 2,
+                              "xAxisLabel": "2 x axis label",
+                              "y": 2,
+                            },
+                          ],
+                          "key": "chart-loremGraph-",
+                          "name": "chart-loremGraph-",
+                          "style": {
+                            "data": {
+                              "fill": "#ipsum",
+                              "stroke": "#lorem",
+                              "strokeWidth": 2,
+                            },
+                          },
+                          "themeColor": undefined,
+                          "themeVariant": undefined,
+                          "x": undefined,
+                          "y": [Function],
+                        },
+                      },
+                    },
+                  },
+                  "chartLegend": null,
+                  "chartWidth": 0,
+                  "dataSets": [
+                    {
+                      "data": [
+                        {
+                          "x": 1,
+                          "xAxisLabel": "1 x axis label",
+                          "y": 1,
+                        },
+                        {
+                          "x": 2,
+                          "xAxisLabel": "2 x axis label",
+                          "y": 2,
+                        },
+                      ],
+                      "fill": "#ipsum",
+                      "id": "loremGraph",
+                      "isStacked": true,
+                      "stroke": "#lorem",
+                      "strokeWidth": 2,
+                    },
+                    {
+                      "data": [
+                        {
+                          "x": 1,
+                          "xAxisLabel": "1 x axis label",
+                          "y": 1,
+                        },
+                        {
+                          "x": 2,
+                          "xAxisLabel": "2 x axis label",
+                          "y": 2,
+                        },
+                      ],
+                      "fill": "#ipsum",
+                      "id": "ipsumGraph",
+                      "isThreshold": true,
+                      "stroke": "#lorem",
+                      "strokeDasharray": "4,3",
+                      "strokeWidth": 3,
+                    },
+                  ],
+                  "hasData": true,
+                  "isMultiYAxis": false,
+                  "maxX": 2,
+                  "maxY": 2,
+                  "padding": {
+                    "bottom": 75,
+                    "left": 55,
+                    "right": 55,
+                    "top": 50,
+                  },
+                  "themeColor": "blue",
+                  "tooltipDataSetLookUp": {},
+                  "xAxisProps": {
+                    "fixLabelOverlap": true,
+                    "tickFormat": [Function],
+                    "tickValues": [
+                      1,
+                      2,
+                    ],
+                  },
+                  "yAxisProps": [
+                    {
+                      "dependentAxis": true,
+                      "orientation": "left",
+                      "showGrid": true,
+                      "style": {
+                        "axis": {},
+                        "tickLabels": {},
+                      },
+                      "tickFormat": [Function],
+                    },
+                  ],
+                }
+              }
+            />
+          }
           renderInPortal={true}
           y={0}
         />

--- a/src/components/chart/chartElements.js
+++ b/src/components/chart/chartElements.js
@@ -69,6 +69,37 @@ const chartElementsDefaults = {
 };
 
 /**
+ * Combined Victory voronoi and cursor container for chart tooltip interaction.
+ *
+ * @type {Function}
+ */
+const VictoryVoronoiCursorContainer = createContainer('voronoi', 'cursor');
+
+/**
+ * Stable wrapper for the chart tooltip label component. Defined outside render to prevent
+ * component identity changes per render.
+ *
+ * @param {object} props
+ * @param {object} props.chartSettings
+ * @param {Function} props.chartContainerRef
+ * @param {Function} props.chartTooltipRef
+ * @returns {JSX.Element}
+ */
+const TooltipLabelWrapper = ({ chartSettings, chartContainerRef, chartTooltipRef, ...victoryProps }) =>
+  chartTooltip({ chartSettings, chartContainerRef, chartTooltipRef })(victoryProps);
+
+/**
+ * Stable wrapper for the chart axis label component. Defined outside render to prevent
+ * component identity changes per render.
+ *
+ * @param {object} props
+ * @param {string} props.axis
+ * @param {number} [props.index=0]
+ * @returns {JSX.Element}
+ */
+const AxisLabelWrapper = ({ axis, index = 0, ...victoryProps }) => chartAxisLabel({ axis, index })(victoryProps);
+
+/**
  * FixMe: Victory Charts v3.8.3+ conversion to TS alters props applied around VictoryTooltip
  * Recent conversions to TS for Victory Charts has altered the behavior around props
  * applied to custom label components, specifically for VictoryTooltip and the associated
@@ -103,13 +134,10 @@ const ChartElements = ({ chartTypeDefaults = chartElementsDefaults }) => {
   let stackedChartElements = [];
 
   if (hasData) {
-    /**
+    /*
      * Note: both cursor and voronoiDimension attrs required if the need is to have...
      * the tooltip populate consistently without being "near" a chart element y axis point
      */
-    const VictoryVoronoiCursorContainer = createContainer('voronoi', 'cursor');
-    const TooltipLabelComponent = chartTooltip({ chartSettings, chartContainerRef, chartTooltipRef });
-
     containerComponent = (
       <VictoryVoronoiCursorContainer
         cursorDimension="x"
@@ -122,7 +150,13 @@ const ChartElements = ({ chartTypeDefaults = chartElementsDefaults }) => {
             y={0}
             centerOffset={{ x: 0, y: 0 }}
             flyoutStyle={{ fill: 'transparent', stroke: 'transparent' }}
-            labelComponent={<TooltipLabelComponent />}
+            labelComponent={
+              <TooltipLabelWrapper
+                chartSettings={chartSettings}
+                chartContainerRef={chartContainerRef}
+                chartTooltipRef={chartTooltipRef}
+              />
+            }
           />
         }
         voronoiPadding={(padding && Object.values(padding).sort()?.[0]) || 0}
@@ -140,8 +174,7 @@ const ChartElements = ({ chartTypeDefaults = chartElementsDefaults }) => {
     };
 
     if (updatedXAxisProps.label) {
-      const AxisLabelComponent = chartAxisLabel({ axis: 'x' });
-      updatedXAxisProps.axisLabelComponent = <AxisLabelComponent />;
+      updatedXAxisProps.axisLabelComponent = <AxisLabelWrapper axis="x" />;
     }
 
     xAxis = <ChartAxis name="curiosity-chartarea__x-axis" {...updatedXAxisProps} animate={false} />;
@@ -157,8 +190,7 @@ const ChartElements = ({ chartTypeDefaults = chartElementsDefaults }) => {
       };
 
       if (updatedAxisProps.label) {
-        const AxisLabelComponent = chartAxisLabel({ axis: 'y', index });
-        updatedAxisProps.axisLabelComponent = <AxisLabelComponent />;
+        updatedAxisProps.axisLabelComponent = <AxisLabelWrapper axis="y" index={index} />;
       }
 
       return (

--- a/src/components/inventoryGuests/inventoryGuestsContext.js
+++ b/src/components/inventoryGuests/inventoryGuestsContext.js
@@ -70,7 +70,7 @@ const useSelectorGuests = (
 
   useEffect(() => {
     if (response?.fulfilled) {
-      setDataSetRows([...(parsedData?.dataSetRows || [])]);
+      setDataSetRows([...(parsedData?.dataSetRows || [])]); // eslint-disable-line react-hooks/set-state-in-effect
     }
   }, [response?.fulfilled, parsedData?.dataSetRows]);
 

--- a/src/components/minHeight/minHeight.js
+++ b/src/components/minHeight/minHeight.js
@@ -24,35 +24,30 @@ const MinHeight = ({
   minHeight = 0,
   useResizeObserver: useAliasResizeObserver = useResizeObserver
 }) => {
-  const [tracking, setTracking] = useState({ containerWidth: undefined, isLoaded: false });
+  const [tracking, setTracking] = useState({ containerWidth: undefined, isLoaded: false, updatedHeight: 0 });
   const containerRef = useRef(null);
   const innerContainerRef = useRef(null);
   const { height: containerHeight, width: containerWidth } = useAliasResizeObserver(containerRef);
 
   useEffect(() => {
     if (!isOnLoad || (isOnLoad && !tracking.isLoaded)) {
-      const { current: domElement = {} } = containerRef;
       const { current: innerDomElement = {} } = innerContainerRef;
+      let updatedHeight = innerDomElement?.clientHeight || 0;
 
-      if (domElement?.style) {
-        let updatedHeight = innerDomElement?.clientHeight || 0;
-
-        if (minHeight > containerHeight) {
-          updatedHeight = minHeight;
-        }
-
-        domElement.style.minHeight = `${updatedHeight}px`;
-        setTracking(() => ({
-          containerWidth,
-          isLoaded: isOnLoad,
-          updatedHeight
-        }));
+      if (minHeight > containerHeight) {
+        updatedHeight = minHeight;
       }
+
+      setTracking(() => ({
+        containerWidth,
+        isLoaded: isOnLoad,
+        updatedHeight
+      }));
     }
-  }, [containerHeight, containerWidth, containerRef, innerContainerRef, isOnLoad, minHeight, tracking.isLoaded]);
+  }, [containerHeight, containerWidth, innerContainerRef, isOnLoad, minHeight, tracking.isLoaded]);
 
   return (
-    <div className="curiosity-minheight" ref={containerRef}>
+    <div className="curiosity-minheight" style={{ minHeight: `${tracking.updatedHeight}px` }} ref={containerRef}>
       <div className="curiosity-minheight__inner" ref={innerContainerRef}>
         {children}
       </div>

--- a/src/components/toolbar/toolbarFieldSelectCategory.js
+++ b/src/components/toolbar/toolbarFieldSelectCategory.js
@@ -156,22 +156,27 @@ const useSelectCategoryOptions = ({
   const { currentFilter: updatedValue } = useAliasSelector(({ toolbar }) => toolbar.filters?.[productId], {});
   const { filters = [] } = useAliasProductToolbarConfig();
 
-  let initialValue;
+  const relevantFilters = filters.filter(({ isItem, isSecondary }) => !isItem && !isSecondary);
 
-  const updatedOptions = filters
-    .filter(({ isItem, isSecondary }) => !isItem && !isSecondary)
-    .map(({ id, isSelected }) => {
-      const option = categoryOptions.find(({ value }) => id === value);
+  const initialValue =
+    updatedValue !== undefined
+      ? undefined
+      : relevantFilters.reduce((acc, { id, isSelected }) => {
+          if (!isSelected) {
+            return acc;
+          }
 
-      if (updatedValue === undefined && isSelected) {
-        initialValue = option.value;
-      }
+          return categoryOptions.find(({ value }) => id === value)?.value ?? acc;
+        }, undefined);
 
-      return {
-        ...option,
-        isSelected: (updatedValue === undefined && isSelected) || updatedValue === option.value
-      };
-    });
+  const updatedOptions = relevantFilters.map(({ id, isSelected }) => {
+    const option = categoryOptions.find(({ value }) => id === value);
+
+    return {
+      ...option,
+      isSelected: (updatedValue === undefined && isSelected) || updatedValue === option.value
+    };
+  });
 
   return {
     currentCategory: updatedValue,


### PR DESCRIPTION
## What's included
Bumps eslint-plugin-react-hooks to 7.1.1. The new version ships stricter React compiler rules that flagged several existing patterns which have all been addressed as part of this PR.

Closes [SWATCH-5189](https://redhat.atlassian.net/browse/SWATCH-5189)



[SWATCH-5189]: https://redhat.atlassian.net/browse/SWATCH-5189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart tooltip and axis label rendering for more consistent display.
  * Improved responsive height handling for components with dynamic content.
  * Refined category selection options to provide more reliable initial selections and filtering.

* **Documentation**
  * Expanded chart component documentation, including tooltip, axis label, and cursor functionality.

* **Chores**
  * Updated code quality checks and React Hooks linting rules to use the latest recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->