### PR TITLE
SWATCH-5457: fix(authentication): swatch-5457 overlay inventory for v2 orgs

### DIFF
--- a/src/components/authentication/__tests__/__snapshots__/authentication.test.js.snap
+++ b/src/components/authentication/__tests__/__snapshots__/authentication.test.js.snap
@@ -5,6 +5,7 @@ exports[`Authentication Component should allow being disabled: disabled 1`] = `
   value={
     {
       "authorized": {
+        "inventory": true,
         "subscriptions": true,
       },
       "errorCodes": [],
@@ -43,6 +44,7 @@ exports[`Authentication Component should render a component authorized: authoriz
   value={
     {
       "authorized": {
+        "inventory": true,
         "subscriptions": true,
       },
       "errorCodes": [],
@@ -98,7 +100,10 @@ exports[`Authentication Component should render authorized via kessel when flag 
 <Context.Provider
   value={
     {
-      "authorized": {},
+      "authorized": {
+        "inventory": true,
+        "subscriptions": true,
+      },
       "errorCodes": [],
       "errorStatus": undefined,
     }
@@ -218,7 +223,10 @@ exports[`Authentication Component should show optin when kessel authorized and 4
 <Context.Provider
   value={
     {
-      "authorized": {},
+      "authorized": {
+        "inventory": true,
+        "subscriptions": true,
+      },
       "errorCodes": [],
       "errorStatus": 418,
     }
@@ -232,7 +240,10 @@ exports[`Authentication Component should show optin when kessel authorized but o
 <Context.Provider
   value={
     {
-      "authorized": {},
+      "authorized": {
+        "inventory": true,
+        "subscriptions": true,
+      },
       "errorCodes": [
         "SUBSCRIPTIONS1004",
       ],
@@ -249,7 +260,8 @@ exports[`Authentication Component should use kessel over legacy rbac when flag i
   value={
     {
       "authorized": {
-        "subscriptions": false,
+        "inventory": true,
+        "subscriptions": true,
       },
       "errorCodes": [],
       "errorStatus": undefined,

--- a/src/components/authentication/__tests__/authentication.test.js
+++ b/src/components/authentication/__tests__/authentication.test.js
@@ -210,6 +210,10 @@ describe('Authentication Component', () => {
     );
 
     expect(component).toMatchSnapshot('authorized');
+    expect(component.props.value.authorized).toEqual({
+      [helpers.UI_NAME]: true,
+      inventory: true
+    });
   });
 
   const mockUseChromeKesselOn = () => ({ visibilityFunctions: { featureFlag: () => true } });
@@ -235,6 +239,10 @@ describe('Authentication Component', () => {
     );
 
     expect(component).toMatchSnapshot('kessel authorized');
+    expect(component.props.value.authorized).toEqual({
+      [helpers.UI_NAME]: true,
+      inventory: true
+    });
   });
 
   it('should render not authorized via kessel when flag is on', async () => {

--- a/src/components/authentication/__tests__/useHasRelation.test.js
+++ b/src/components/authentication/__tests__/useHasRelation.test.js
@@ -96,4 +96,18 @@ describe('useHasRelation', () => {
       })
     );
   });
+
+  it('should call checkSelf when enabled transitions from false to true', async () => {
+    mockCheckSelf.mockResolvedValue({ allowed: 'ALLOWED_TRUE' });
+
+    const { rerender, act: hookAct } = await renderHook((enabled = false) =>
+      useHasRelation(Relation.INVENTORY_VIEW, { enabled })
+    );
+
+    expect(mockCheckSelf).not.toHaveBeenCalled();
+
+    await hookAct(async () => rerender(true));
+
+    expect(mockCheckSelf).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/components/authentication/authentication.js
+++ b/src/components/authentication/authentication.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { BinocularsIcon } from '@patternfly/react-icons';
 import { Maintenance } from '@redhat-cloud-services/frontend-components/Maintenance';
 import { NotAuthorized } from '@redhat-cloud-services/frontend-components/NotAuthorized';
@@ -55,6 +55,34 @@ const Authentication = ({
 
   const isAuthorized = kesselEnabled ? kesselAuthorized : authorized[appName];
 
+  /*
+   * Instance table links read session.authorized.inventory. RBAC v1 inventory is empty in v2 orgs
+   * (Kessel on or off), so overlay it whenever the user is allowed to see the app.
+   */
+  const sessionData = useMemo(
+    () => ({
+      ...data,
+      authorized: {
+        ...authorized,
+        ...(isAuthorized && {
+          [appName]: true,
+          inventory: true
+        })
+      }
+    }),
+    [data, authorized, isAuthorized, appName]
+  );
+
+  helpers.browserExpose({
+    authDebug: {
+      kesselEnabled,
+      kesselAuthorized,
+      kesselPending,
+      isAuthorized,
+      authorized: sessionData.authorized
+    }
+  });
+
   const renderContent = () => {
     if (isDisabled) {
       return (
@@ -92,7 +120,7 @@ const Authentication = ({
     );
   };
 
-  return <AuthenticationContext.Provider value={data}>{renderContent()}</AuthenticationContext.Provider>;
+  return <AuthenticationContext.Provider value={sessionData}>{renderContent()}</AuthenticationContext.Provider>;
 };
 
 export { Authentication as default, Authentication };

--- a/src/components/authentication/useHasRelation.js
+++ b/src/components/authentication/useHasRelation.js
@@ -63,9 +63,9 @@ const useHasRelation = (relation, { enabled = true } = {}) => {
     return () => {
       cancelled = true;
     };
-    // intentional: run once on mount, matches React Query one-shot behavior
+    // re-run if Chrome feature flags arrive after first paint
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [enabled]);
 
   return { has, isLoading };
 };


### PR DESCRIPTION
## What's included
 Two related authentication fixes for Kessel/v2 org environments.
     
  authentication.js — overlay inventory in session authorized

  Instance table instance links read session.authorized.inventory to decide whether to render. In v2
  orgs (Kessel enabled or not), the RBAC v1 inventory permission is always empty, so those links were
  silently hidden even for authorized users. When isAuthorized is true, inventory: true (and appName: 
  true) are now overlaid onto the context value. The constructed object is wrapped in useMemo to avoid
  recreating the context reference on every render. A helpers.browserExpose({ authDebug }) block is
  included for in-browser debugging.

  useHasRelation.js — add enabled to useEffect deps

  The Kessel feature flag (swatch.common-security.use-kessel-rbac) is read from Chrome after the first
  paint. With an empty [] dep array the check ran once on mount — before the flag had resolved — so
  enabled was always false and checkSelf was never called. Adding enabled to the dep array lets the
  effect re-run when the flag arrives.

## How to test
To make `$npm run start:proxy` work, you need the following fix https://github.com/RedHatInsights/curiosity-frontend/pull/1965

Coverage and basic unit test check

  1. $ npm install
  2. $ npm test

  Local run check (mock API, dev mode — Kessel path skipped, legacy RBAC exercised)

  1. $ npm install
  2. $ npm start
  3. Navigate to any product page and confirm instance table links are visible

  Proxy run check (exercises Kessel path end-to-end)

  1. $ npm install
  2. $ npm run start:proxy
  3. In a v2 org with Kessel flag on, navigate to a product page
  4. Open the browser console → window.__curiosity.authDebug should show isAuthorized: true and
  authorized.inventory: true
  5. Confirm instance table instance links render correctly

## Example
N/A — auth/session context fix; no visual diff on the component itself.

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication state handling to consistently include application and inventory access when authorized.
  - Authentication details are now available throughout the app and browser integrations.
  - Relation checks now re-run when authentication becomes enabled, including after feature flags load.

- **Tests**
  - Added coverage for authorized access across legacy and updated authentication paths.
  - Added coverage for relation checks triggered when authentication is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->