### PR TITLE
fix(ci): pin kessel-kafka-connect to latest in ephemeral deployments

### DIFF
--- a/.tekton/bonfire-integration-tests-pipelinerun.yaml
+++ b/.tekton/bonfire-integration-tests-pipelinerun.yaml
@@ -89,6 +89,7 @@ spec:
         --set-image-tag quay.io/redhat-services-prod/rh-subs-watch-tenant/prometheus=latest
         --set-template-ref prometheus=main
         --set-parameter landing-page-frontend/IMAGE=quay.io/redhat-services-prod/rh-platform-experien-tenant/landing-page-frontend
+        --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-kafka-connect=latest
     - name: DEPLOY_FRONTENDS
       value: "true"
     - name: DEPLOY_TIMEOUT


### PR DESCRIPTION
Same changes as for https://github.com/RedHatInsights/rhsm-subscriptions/pull/6629.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated integration test deployments to use the latest available Kafka connector image, helping ensure validation runs against the current connector build.
  - No changes were made to exported functionality or end-user application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->